### PR TITLE
adjustments in pom.xml for osgi support

### DIFF
--- a/leshan-core/pom.xml
+++ b/leshan-core/pom.xml
@@ -14,6 +14,7 @@ and the Eclipse Distribution License is available at
 Contributors:
     Sierra Wireless - initial API and implementation
     Eurotech - initial API and implementation
+    Bosch Software Innovations GmbH - OSGi support
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -68,7 +69,12 @@ Contributors:
                         <Export-Package>
                             org.eclipse.leshan,
                             org.eclipse.leshan.tlv,
-                            org.eclipse.leshan.util
+                            org.eclipse.leshan.util,
+                            org.eclipse.leshan.core.node
+                            org.eclipse.leshan.core.node.codec,
+                            org.eclipse.leshan.core.objectspec,
+                            org.eclipse.leshan.core.request,
+                            org.eclipse.leshan.core.response
                         </Export-Package>
                         <Import-Package>
                             org.slf4j;version="1.6",

--- a/leshan-core/pom.xml
+++ b/leshan-core/pom.xml
@@ -70,11 +70,11 @@ Contributors:
                             org.eclipse.leshan,
                             org.eclipse.leshan.tlv,
                             org.eclipse.leshan.util,
-                            org.eclipse.leshan.core.node
+                            org.eclipse.leshan.core.node,  
                             org.eclipse.leshan.core.node.codec,
                             org.eclipse.leshan.core.objectspec,
-                            org.eclipse.leshan.core.request,
-                            org.eclipse.leshan.core.response
+                            org.eclipse.leshan.core.request,                            
+                            org.eclipse.leshan.core.response                                               
                         </Export-Package>
                         <Import-Package>
                             org.slf4j;version="1.6",

--- a/leshan-server-cf/pom.xml
+++ b/leshan-server-cf/pom.xml
@@ -13,6 +13,7 @@ and the Eclipse Distribution License is available at
 
 Contributors:
     Sierra Wireless - initial API and implementation
+    Bosch Software Innovations GmbH - OSGi support
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,6 +24,7 @@ Contributors:
         <version>0.1.10-SNAPSHOT</version>
     </parent>
     <artifactId>leshan-server-cf</artifactId>
+    <packaging>bundle</packaging>
     <name>leshan - server californium</name>
     <description>A transport implementation for leshan server based on CoAP Californium</description>
 
@@ -77,6 +79,9 @@ Contributors:
                             org.eclipse.leshan.server.californium.impl,
                         </Export-Package>
                         <Import-Package>
+                        	org.eclipse.leshan.core.node.codec.*;version="${project.version}",
+                        	org.eclipse.leshan.core.objectspec.*;version="${project.version}",
+                        	org.eclipse.leshan.server.registration.*;version="${project.version}",
                             org.eclipse.californium.*;version="[1.0.0, 1.1)",
                             org.apache.commons.lang.*;version="[2.6, 3)",
                             *

--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -78,7 +78,7 @@ Contributors:
                             org.eclipse.leshan.server.node,
                             org.eclipse.leshan.server.observation,
                             org.eclipse.leshan.server.request,
-                            org.eclipse.leshan.server.security,
+                            org.eclipse.leshan.server.security,   
                             org.eclipse.leshan.server.registration
                         </Export-Package>
                         <Import-Package>

--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -13,6 +13,7 @@ and the Eclipse Distribution License is available at
 
 Contributors:
     Sierra Wireless - initial API and implementation
+    Bosch Software Innovations GmbH - OSGi support
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -23,6 +24,7 @@ Contributors:
         <version>0.1.10-SNAPSHOT</version>
     </parent>
     <artifactId>leshan-server-core</artifactId>
+    <packaging>bundle</packaging>
     <name>leshan - server core</name>
     <description>A LWM2M server implementation which abstracts transport layer. A transport implementation like "leshan.server.californium" is needed.</description>
 
@@ -77,8 +79,10 @@ Contributors:
                             org.eclipse.leshan.server.observation,
                             org.eclipse.leshan.server.request,
                             org.eclipse.leshan.server.security,
+                            org.eclipse.leshan.server.registration
                         </Export-Package>
                         <Import-Package>
+                        	org.eclipse.leshan.core.request.*;version="${project.version}",
                             org.eclipse.californium.*;version="[1.0.0, 1.1)",
                             org.apache.commons.lang.*;version="[2.6, 3)",
                             *


### PR DESCRIPTION
Hello

I added a few import / export packages instructions in the pom.xml of 
leshan-core
leshan-server-cf
leshan-server-core
in order to use this artefacts as OSGi-bundles in a OSGi container.