### PR TITLE
fixes a minor bug in the jar generation

### DIFF
--- a/leshan-client-example/pom.xml
+++ b/leshan-client-example/pom.xml
@@ -42,7 +42,7 @@ Contributors:
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>leshan.client.example.LeshanClientExample</mainClass>
+                            <mainClass>org.eclipse.leshan.client.example.LeshanClientExample</mainClass>
                         </manifest>
                     </archive>
                     <descriptorRefs>


### PR DESCRIPTION
This bug generate a error following:
java -jar NetBeansProjects/leshan/leshan-client-example/target/leshan-client-example-0.1.10-SNAPSHOT-jar-with-dependencies.jar localhost 9000 localhost 5386
Error: Could not find or load main class leshan.client.example.LeshanClientExample