### PR TITLE
adjustments in import / export packages in pom.xml for osgi support

### DIFF
--- a/leshan-core/pom.xml
+++ b/leshan-core/pom.xml
@@ -67,11 +67,13 @@ Contributors:
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            org.eclipse.leshan,        
+                            org.eclipse.leshan,
+                            org.eclipse.leshan.core.model,
+                            org.eclipse.leshan.core.model.json,
                             org.eclipse.leshan.core.node,  
                             org.eclipse.leshan.core.node.codec,
-                            org.eclipse.leshan.core.objectspec,
-                            org.eclipse.leshan.core.request,                            
+                            org.eclipse.leshan.core.request,
+                            org.eclipse.leshan.core.request.exception,
                             org.eclipse.leshan.core.response,
 							org.eclipse.leshan.tlv,
                             org.eclipse.leshan.util                                      

--- a/leshan-server-cf/pom.xml
+++ b/leshan-server-cf/pom.xml
@@ -81,6 +81,7 @@ Contributors:
                         <Import-Package>
                         	org.eclipse.leshan.core.node.codec.*;version="${project.version}",
                         	org.eclipse.leshan.core.objectspec.*;version="${project.version}",
+                        	org.eclipse.leshan.core.request.exception;version="${project.version}",
                         	org.eclipse.leshan.server.registration.*;version="${project.version}",
                             org.eclipse.californium.*;version="[1.0.0, 1.1)",
                             org.apache.commons.lang.*;version="[2.6, 3)",

--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -68,6 +68,7 @@ Contributors:
                             org.eclipse.leshan.server.bootstrap,
                             org.eclipse.leshan.server.client,
                             org.eclipse.leshan.server.impl,
+                            org.eclipse.leshan.server.model,
                             org.eclipse.leshan.server.observation,
                             org.eclipse.leshan.server.registration,
                             org.eclipse.leshan.server.request,
@@ -75,6 +76,7 @@ Contributors:
                         </Export-Package>
                         <Import-Package>
                         	org.eclipse.leshan.core.request.*;version="${project.version}",
+                        	org.eclipse.leshan.core.model.*;version="${project.version}",
                             org.eclipse.californium.*;version="[1.0.0, 1.1)",
                             org.apache.commons.lang.*;version="[2.6, 3)",
                             *


### PR DESCRIPTION
Signed-off-by: ingo schaal <ingo.schaal@bosch-si.com>
I fixed a few import / export packages instructions in the pom.xml of
leshan-core
leshan-server-cf
leshan-server-core
in order to use this artefacts as OSGi-bundles in a OSGi container.