### PR TITLE
avoid maven warnings by providing plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,11 @@ Contributors:
                         </additionalConfig>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Signed-off-by: Alexander Ellwein <alexander.ellwein@bosch-si.com>

A minor fix in the pom.xml to avoid the maven warnings while building Leshan.