### PR TITLE
introduced additional isRegisterAllowed() callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bin/
 *.war
 *.ear
 leshan-core/ddffiles
+.idea/
+*.iml

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegistrationCleaner.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegistrationCleaner.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *     Bosch Software Innovations GmbH - separated from client registry
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.impl;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.server.Startable;
+import org.eclipse.leshan.server.Stoppable;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The registry cleaner checks the client registry periodically for outdated registrations and cleans them, if
+ * necessary.
+ */
+public class RegistrationCleaner implements Startable, Stoppable {
+
+    private final ScheduledExecutorService schedExecutor = Executors.newScheduledThreadPool(1);
+    private final ClientRegistry clientRegistry;
+    private static final Logger LOG = LoggerFactory.getLogger(RegistrationCleaner.class);
+
+    /**
+     * Creates a new periodic registry cleaner.
+     * 
+     * @param clientRegistry client registry to check
+     */
+    public RegistrationCleaner(final ClientRegistry clientRegistry) {
+        this.clientRegistry = clientRegistry;
+    }
+
+    @Override
+    public void start() {
+        // every 2 seconds clean the registration list
+        // TODO re-consider clean-up interval: wouldn't 5 minutes do as well?
+        schedExecutor.scheduleAtFixedRate(new Cleaner(), 2, 2, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void stop() {
+        schedExecutor.shutdownNow();
+        try {
+            schedExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOG.warn("Registration cleaner was interrupted.", e);
+        }
+    }
+
+    private class Cleaner implements Runnable {
+        @Override
+        public void run() {
+            for (Client client : clientRegistry.allClients()) {
+                synchronized (client) {
+                    if (!client.isAlive()) {
+                        // force de-registration
+                        clientRegistry.deregisterClient(client.getRegistrationId());
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/LwM2mServer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/LwM2mServer.java
@@ -21,6 +21,7 @@ import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseConsumer;
 import org.eclipse.leshan.server.client.Client;
 import org.eclipse.leshan.server.client.ClientRegistry;
+import org.eclipse.leshan.server.client.ClientRegistryListenerManagement;
 import org.eclipse.leshan.server.model.LwM2mModelProvider;
 import org.eclipse.leshan.server.observation.ObservationRegistry;
 import org.eclipse.leshan.server.security.SecurityRegistry;
@@ -83,4 +84,6 @@ public interface LwM2mServer {
      * Get the provider in charge of retrieving the object definitions for each client.
      */
     LwM2mModelProvider getModelProvider();
+
+    ClientRegistryListenerManagement getClientRegistryListenerManagement();
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientRegistry.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientRegistry.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Bosch Software Innovations GmbH - externalize registry listeners
  *******************************************************************************/
 package org.eclipse.leshan.server.client;
 
@@ -25,7 +26,7 @@ public interface ClientRegistry {
     /**
      * Retrieves a registered client by end-point.
      * 
-     * @param endpoint
+     * @param endpoint endpoint name
      * @return the matching client or <code>null</code> if not found
      */
     Client get(String endpoint);
@@ -38,29 +39,13 @@ public interface ClientRegistry {
     Collection<Client> allClients();
 
     /**
-     * Adds a new listener to be notified with client registration events.
-     * 
-     * @param listener
-     */
-    void addListener(ClientRegistryListener listener);
-
-    /**
-     * Removes a client registration listener.
-     * 
-     * @param listener the listener to be removed
-     */
-    void removeListener(ClientRegistryListener listener);
-
-    /**
      * Registers a new client.
      * 
      * An implementation must notify all registered listeners as part of processing the registration request.
      * 
      * @param client the client to register, identified by its end-point.
-     * @return <code>true</code> if the client was properly registered and <code>false</code> if the registration is not
-     *         allowed.
      */
-    boolean registerClient(Client client);
+    void registerClient(Client client);
 
     /**
      * Updates registration properties for a given client.

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientRegistryListenerManagement.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientRegistryListenerManagement.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.client;
+
+/**
+ * A Client registry listener management provides a facility for adding/removing client registry listeners.
+ */
+public interface ClientRegistryListenerManagement {
+
+    /**
+     * Adds a listener which is notified on client registration changes.
+     *
+     * @param clientRegistryListener listener to add
+     */
+    void addClientRegistryListener(ClientRegistryListener clientRegistryListener);
+
+    /**
+     * Removes an already registered listener.
+     *
+     * @param clientRegistryListener listener to remove
+     */
+    void removeClientRegistryListener(ClientRegistryListener clientRegistryListener);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientRegistryNotification.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientRegistryNotification.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.client;
+
+/**
+ * A client registry notification provides a facility for notifying of client registry listeners.
+ */
+public interface ClientRegistryNotification {
+    /**
+     * Calls client registry listeners on registration event of a client.
+     *
+     * @param client new registered client
+     */
+    void notifyOnRegistration(Client client);
+
+    /**
+     * Calls client registry listeners on update event of a client.
+     *
+     * @param client updated client
+     */
+    void notifyOnUpdate(Client client);
+
+    /**
+     * Calls client registry listeners on unregistration of a client.
+     *
+     * @param client unregistered client
+     */
+    void notifyOnUnregistration(Client client);
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/ClientRegistryImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/ClientRegistryImpl.java
@@ -12,49 +12,30 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Bosch Software Innovations GmbH - externalize registry listeners
  *******************************************************************************/
 package org.eclipse.leshan.server.impl;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
-import org.eclipse.leshan.server.Startable;
-import org.eclipse.leshan.server.Stoppable;
 import org.eclipse.leshan.server.client.Client;
 import org.eclipse.leshan.server.client.ClientRegistry;
-import org.eclipse.leshan.server.client.ClientRegistryListener;
 import org.eclipse.leshan.server.client.ClientUpdate;
 import org.eclipse.leshan.util.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * In memory client registry
+ * In-memory client registry.
  */
-public class ClientRegistryImpl implements ClientRegistry, Startable, Stoppable {
+public class ClientRegistryImpl implements ClientRegistry {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientRegistryImpl.class);
 
     private final Map<String /* end-point */, Client> clientsByEp = new ConcurrentHashMap<>();
-
-    private final List<ClientRegistryListener> listeners = new CopyOnWriteArrayList<>();
-
-    @Override
-    public void addListener(ClientRegistryListener listener) {
-        listeners.add(listener);
-    }
-
-    @Override
-    public void removeListener(ClientRegistryListener listener) {
-        listeners.remove(listener);
-    }
 
     @Override
     public Collection<Client> allClients() {
@@ -67,28 +48,15 @@ public class ClientRegistryImpl implements ClientRegistry, Startable, Stoppable 
     }
 
     @Override
-    public boolean registerClient(Client client) {
+    public void registerClient(Client client) {
         Validate.notNull(client);
-
         LOG.debug("Registering new client: {}", client);
-
-        Client previous = clientsByEp.put(client.getEndpoint(), client);
-        if (previous != null) {
-            for (ClientRegistryListener l : listeners) {
-                l.unregistered(previous);
-            }
-        }
-        for (ClientRegistryListener l : listeners) {
-            l.registered(client);
-        }
-
-        return true;
+        clientsByEp.put(client.getEndpoint(), client);
     }
 
     @Override
     public Client updateClient(ClientUpdate update) {
         Validate.notNull(update);
-
         LOG.debug("Updating registration for client: {}", update);
         Client client = findByRegistrationId(update.getRegistrationId());
         if (client == null) {
@@ -97,10 +65,6 @@ public class ClientRegistryImpl implements ClientRegistry, Startable, Stoppable 
             Client clientUpdated = update.updateClient(client);
             clientsByEp.put(clientUpdated.getEndpoint(), clientUpdated);
 
-            // notify listener
-            for (ClientRegistryListener l : listeners) {
-                l.updated(clientUpdated);
-            }
             return clientUpdated;
         }
     }
@@ -108,20 +72,9 @@ public class ClientRegistryImpl implements ClientRegistry, Startable, Stoppable 
     @Override
     public Client deregisterClient(String registrationId) {
         Validate.notNull(registrationId);
-
         LOG.debug("Deregistering client with registrationId: {}", registrationId);
-
         Client toBeUnregistered = findByRegistrationId(registrationId);
-        if (toBeUnregistered == null) {
-            return null;
-        } else {
-            Client unregistered = clientsByEp.remove(toBeUnregistered.getEndpoint());
-            for (ClientRegistryListener l : listeners) {
-                l.unregistered(unregistered);
-            }
-            LOG.debug("Deregistered client: {}", unregistered);
-            return unregistered;
-        }
+        return toBeUnregistered == null ? null : clientsByEp.remove(toBeUnregistered.getEndpoint());
     }
 
     private Client findByRegistrationId(String id) {
@@ -135,45 +88,5 @@ public class ClientRegistryImpl implements ClientRegistry, Startable, Stoppable 
             }
         }
         return result;
-    }
-
-    /**
-     * start the registration manager, will start regular cleanup of dead registrations.
-     */
-    @Override
-    public void start() {
-        // every 2 seconds clean the registration list
-        // TODO re-consider clean-up interval: wouldn't 5 minutes do as well?
-        schedExecutor.scheduleAtFixedRate(new Cleaner(), 2, 2, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Stop the underlying cleanup of the registrations.
-     */
-    @Override
-    public void stop() {
-        schedExecutor.shutdownNow();
-        try {
-            schedExecutor.awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            LOG.warn("Clean up registration thread was interrupted.", e);
-        }
-    }
-
-    private final ScheduledExecutorService schedExecutor = Executors.newScheduledThreadPool(1);
-
-    private class Cleaner implements Runnable {
-
-        @Override
-        public void run() {
-            for (Client client : clientsByEp.values()) {
-                synchronized (client) {
-                    if (!client.isAlive()) {
-                        // force de-registration
-                        deregisterClient(client.getRegistrationId());
-                    }
-                }
-            }
-        }
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/ClientRegistryManagementImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/ClientRegistryManagementImpl.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.impl;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientRegistryListener;
+import org.eclipse.leshan.server.client.ClientRegistryListenerManagement;
+import org.eclipse.leshan.server.client.ClientRegistryNotification;
+
+/**
+ * Implementation for the client registry listener management and notification.
+ */
+public class ClientRegistryManagementImpl implements ClientRegistryListenerManagement, ClientRegistryNotification {
+
+    private final List<ClientRegistryListener> registryListeners = new CopyOnWriteArrayList<>();
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    @Override
+    public void addClientRegistryListener(ClientRegistryListener clientRegistryListener) {
+        if (!registryListeners.contains(clientRegistryListener)) {
+            registryListeners.add(clientRegistryListener);
+        }
+    }
+
+    @Override
+    public void removeClientRegistryListener(ClientRegistryListener clientRegistryListener) {
+        registryListeners.remove(clientRegistryListener);
+    }
+
+    @Override
+    public void notifyOnRegistration(final Client client) {
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                for (ClientRegistryListener clientRegistryListener : registryListeners) {
+                    clientRegistryListener.registered(client);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void notifyOnUpdate(final Client client) {
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                for (ClientRegistryListener clientRegistryListener : registryListeners) {
+                    clientRegistryListener.updated(client);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void notifyOnUnregistration(final Client client) {
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                for (ClientRegistryListener clientRegistryListener : registryListeners) {
+                    clientRegistryListener.unregistered(client);
+                }
+            }
+        });
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ClientAware.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ClientAware.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+import org.eclipse.leshan.server.client.Client;
+
+/**
+ * Implementators of this interface are aware of used Client object.
+ */
+public interface ClientAware {
+    /**
+     * @return client object associated with the interface impl
+     */
+    Client getClient();
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ClientAwareResponseHolder.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ClientAwareResponseHolder.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.server.client.Client;
+
+/**
+ * A response holder object, which is also ClientAware.
+ */
+public class ClientAwareResponseHolder implements ClientAware {
+
+    private final LwM2mResponse response;
+    private final Client client;
+
+    /**
+     * Creates a new client-aware LwM2M response holder.
+     * 
+     * @param response response to hold
+     * @param client client
+     */
+    public ClientAwareResponseHolder(final LwM2mResponse response, final Client client) {
+        this.response = response;
+        this.client = client;
+    }
+
+    /**
+     * Creates a new client-aware LwM2M response holder (without client, i.e. null).
+     * 
+     * @param response response to hold
+     */
+    public ClientAwareResponseHolder(final LwM2mResponse response) {
+        this.response = response;
+        this.client = null;
+    }
+
+    @Override
+    public Client getClient() {
+        return client;
+    }
+
+    /**
+     * @return lwm2m response contained in this holder
+     */
+    public LwM2mResponse getResponse() {
+        return response;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationAcceptor.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationAcceptor.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+import org.eclipse.leshan.server.client.Client;
+
+/**
+ * A registration acceptor decides if a client is allowed to be registered.
+ */
+public interface RegistrationAcceptor {
+
+    /**
+     * Should return true, if the client is allowed to be registered.
+     *
+     * @param client client with registration pending
+     * @return true, if the client is allowed to be registered, otherwise false.
+     */
+    boolean acceptRegistration(Client client);
+}

--- a/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/servlet/EventServlet.java
+++ b/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/servlet/EventServlet.java
@@ -126,7 +126,7 @@ public class EventServlet extends HttpServlet {
     };
 
     public EventServlet(LeshanServer server) {
-        server.getClientRegistry().addListener(this.clientRegistryListener);
+        server.getClientRegistryListenerManagement().addClientRegistryListener(this.clientRegistryListener);
         server.getObservationRegistry().addListener(this.observationRegistryListener);
 
         // add an interceptor to each endpoint to trace all CoAP messages


### PR DESCRIPTION
With the current implementation of ``RegistrationHandler`` there is an issue that ``ClientRegistry#registerClient()`` is called **before** the actual registration acknowledge (201 CREATED or an error) is being sent by back the server. So if you are, for instance, implementing a LwM2M read request directly in ``ClientRegistry#registerClient()`` or in the same thread there after, then the LwM2M client will process the particular read request before sending the actual registration response. Some LwM2M clients we have seen, do even refuse to process a read request *before* the registration response, other will go happily without it.

With the proposed PR the semantic of the ``ClientRegistry`` is changed a little bit:
the previously used ``ClientRegistry#registerClient()`` has been renamed to ``ClientRegistry#isRegisterAllowed()`` (as the old register() also used to return a boolean), and is called in the same place (before responding) to signal if the client will be registered. After the response has been sent successfully to the client, the ``ClientRegistry#registerClient()`` - the new one - is called.

Signed-off-by: Alexander Ellwein <alexander.ellwein@bosch-si.com>