### PR TITLE
Fix TLV encoding for negative integer

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
@@ -186,10 +186,10 @@ public class TlvDecoder {
      * Decodes a byte array into an integer value (signed magnitude representation)
      */
     public static Number decodeInteger(byte[] value) throws TlvException {
-        boolean positive = (value[0] & (1 << 7)) == 0; // last bit to 0?
+        boolean positive = (value[0] & 0b1000_0000) == 0; // last bit to 0?
         if (!positive) {
             // convert to positive value by setting the most significant bit to 0
-            value[0] &= ~(1 << 7);
+            value[0] &= 0b0111_1111;
         }
 
         BigInteger buf = new BigInteger(value);

--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.tlv;
 
+import java.math.BigInteger;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -191,15 +192,15 @@ public class TlvDecoder {
             value[0] &= ~(1 << 7);
         }
 
-        ByteBuffer buf = ByteBuffer.wrap(value);
+        BigInteger buf = new BigInteger(value);
         if (value.length == 1) {
-            return positive ? buf.get() : -buf.get();
+            return positive ? buf.byteValue() : -buf.byteValue();
         } else if (value.length <= 2) {
-            return positive ? buf.getShort() : -buf.getShort();
+            return positive ? buf.shortValue() : -buf.shortValue();
         } else if (value.length <= 4) {
-            return positive ? buf.getInt() : -buf.getInt();
+            return positive ? buf.intValue() : -buf.intValue();
         } else if (value.length <= 8) {
-            return positive ? buf.getLong() : -buf.getLong();
+            return positive ? buf.longValue() : -buf.longValue();
         } else {
             throw new TlvException("Invalid length for an integer value: " + value.length);
         }

--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvEncoder.java
@@ -56,7 +56,13 @@ public class TlvEncoder {
     public static byte[] encodeInteger(Number number) {
 
         ByteBuffer iBuf = null;
-        long positiveValue = number.longValue() < 0 ? -number.longValue() : number.longValue();
+        long longValue = number.longValue();
+        if (longValue == Long.MIN_VALUE) {
+            throw new IllegalArgumentException(
+                    "Could not encode Long.MIN_VALUE, because of signed magnitude representation.");
+        }
+
+        long positiveValue = longValue < 0 ? -longValue : longValue;
         if (positiveValue <= Byte.MAX_VALUE) {
             iBuf = ByteBuffer.allocate(1);
             iBuf.put((byte) positiveValue);
@@ -66,7 +72,7 @@ public class TlvEncoder {
         } else if (positiveValue <= Integer.MAX_VALUE) {
             iBuf = ByteBuffer.allocate(4);
             iBuf.putInt((int) positiveValue);
-        } else {
+        } else if (positiveValue <= Long.MAX_VALUE) {
             iBuf = ByteBuffer.allocate(8);
             iBuf.putLong(positiveValue);
         }
@@ -85,7 +91,7 @@ public class TlvEncoder {
     public static byte[] encodeFloat(Number number) {
         ByteBuffer fBuf = null;
         double dValue = number.doubleValue();
-        if (dValue >= Float.MIN_VALUE && dValue <= Float.MAX_VALUE) {
+        if (Float.MIN_VALUE <= dValue && dValue <= Float.MAX_VALUE) {
             fBuf = ByteBuffer.allocate(4);
             fBuf.putFloat((float) dValue);
         } else {

--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvEncoder.java
@@ -51,25 +51,32 @@ public class TlvEncoder {
     }
 
     /**
-     * Encodes an integer value.
+     * Encodes an integer value (signed magnitude representation)
      */
     public static byte[] encodeInteger(Number number) {
+
         ByteBuffer iBuf = null;
-        long lValue = number.longValue();
-        if (lValue >= Byte.MIN_VALUE && lValue <= Byte.MAX_VALUE) {
+        long positiveValue = number.longValue() < 0 ? -number.longValue() : number.longValue();
+        if (positiveValue <= Byte.MAX_VALUE) {
             iBuf = ByteBuffer.allocate(1);
-            iBuf.put((byte) lValue);
-        } else if (lValue >= Short.MIN_VALUE && lValue <= Short.MAX_VALUE) {
+            iBuf.put((byte) positiveValue);
+        } else if (positiveValue <= Short.MAX_VALUE) {
             iBuf = ByteBuffer.allocate(2);
-            iBuf.putShort((short) lValue);
-        } else if (lValue >= Integer.MIN_VALUE && lValue <= Integer.MAX_VALUE) {
+            iBuf.putShort((short) positiveValue);
+        } else if (positiveValue <= Integer.MAX_VALUE) {
             iBuf = ByteBuffer.allocate(4);
-            iBuf.putInt((int) lValue);
+            iBuf.putInt((int) positiveValue);
         } else {
             iBuf = ByteBuffer.allocate(8);
-            iBuf.putLong(lValue);
+            iBuf.putLong(positiveValue);
         }
-        return iBuf.array();
+
+        byte[] bytes = iBuf.array();
+        // set the most significant bit to 1 if negative value
+        if (number.longValue() < 0) {
+            bytes[0] |= (1 << 7);
+        }
+        return bytes;
     }
 
     /**

--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvEncoder.java
@@ -80,7 +80,7 @@ public class TlvEncoder {
         byte[] bytes = iBuf.array();
         // set the most significant bit to 1 if negative value
         if (number.longValue() < 0) {
-            bytes[0] |= (1 << 7);
+            bytes[0] |= 0b1000_0000;
         }
         return bytes;
     }

--- a/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvDecoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvDecoderTest.java
@@ -15,7 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.tlv;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -60,6 +61,20 @@ public class TlvDecoderTest {
         } catch (TlvException ex) {
             assertEquals("Impossible to parse TLV: \n0011223344556677889900", ex.getMessage());
         }
+    }
+
+    @Test
+    public void decode_uncomplete_integer() throws TlvException {
+
+        // byte representation of 4194304 (2^22) integer on only 3 bytes instead of 4.
+        ByteBuffer bb = ByteBuffer.allocate(3);
+        bb.put((byte) 0b01000000);
+        bb.put((byte) 0b00000000);
+        bb.put((byte) 0b00000000);
+        byte[] val = bb.array();
+
+        Integer intVal = (Integer) TlvDecoder.decodeInteger(val);
+        assertEquals(4194304, intVal.intValue());
     }
 
     @Test

--- a/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvDecoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvDecoderTest.java
@@ -15,8 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.tlv;
 
+import static org.junit.Assert.*;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Date;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -42,7 +45,7 @@ public class TlvDecoderTest {
         LOG.debug(Arrays.toString(tlv));
 
         ByteBuffer buff = TlvEncoder.encode(tlv);
-        Assert.assertTrue(Arrays.equals(bytes, buff.array()));
+        assertTrue(Arrays.equals(bytes, buff.array()));
     }
 
     @Test
@@ -52,11 +55,35 @@ public class TlvDecoderTest {
         ByteBuffer b = ByteBuffer.wrap(bytes);
 
         try {
-            Tlv[] tlv = TlvDecoder.decode(b);
+            TlvDecoder.decode(b);
             Assert.fail();
         } catch (TlvException ex) {
-
-            Assert.assertEquals("Impossible to parse TLV: \n0011223344556677889900", ex.getMessage());
+            assertEquals("Impossible to parse TLV: \n0011223344556677889900", ex.getMessage());
         }
+    }
+
+    @Test
+    public void decode_negative_integer() throws TlvException {
+
+        // signed magnitude representation for value -123456
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.putInt(123456);
+        byte[] val = bb.array();
+
+        // last bit to 1 for negative number
+        val[0] |= (1 << 7);
+
+        Integer intVal = (Integer) TlvDecoder.decodeInteger(val);
+        assertEquals(-123456, intVal.intValue());
+    }
+
+    @Test
+    public void decode_date() throws TlvException {
+
+        long tsInSecond = 100000;
+        ByteBuffer bb = ByteBuffer.allocate(8);
+        bb.putLong(tsInSecond);
+
+        assertEquals(new Date(tsInSecond * 1000L), TlvDecoder.decodeDate(bb.array()));
     }
 }

--- a/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvEncoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvEncoderTest.java
@@ -15,12 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.tlv;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
 import java.util.Date;
 
-import org.eclipse.leshan.tlv.TlvEncoder;
 import org.junit.Test;
 
 public class TlvEncoderTest {
@@ -40,6 +39,20 @@ public class TlvEncoderTest {
         byte[] encoded = TlvEncoder.encodeInteger(1245823);
 
         // check value
+        ByteBuffer bb = ByteBuffer.wrap(encoded);
+        assertEquals(1245823, bb.getInt());
+        assertEquals(0, bb.remaining());
+    }
+
+    @Test
+    public void encode_negative_integer() {
+        byte[] encoded = TlvEncoder.encodeInteger(-1245823);
+
+        // check sign
+        assertFalse((encoded[0] & (1 << 7)) == 0);
+
+        // convert to positive and check the value
+        encoded[0] &= ~(1 << 7);
         ByteBuffer bb = ByteBuffer.wrap(encoded);
         assertEquals(1245823, bb.getInt());
         assertEquals(0, bb.remaining());

--- a/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvEncoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvEncoderTest.java
@@ -15,7 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.tlv;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.nio.ByteBuffer;
 import java.util.Date;
@@ -67,6 +68,12 @@ public class TlvEncoderTest {
         ByteBuffer bb = ByteBuffer.wrap(encoded);
         assertEquals(value, bb.getLong());
         assertEquals(0, bb.remaining());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void can_not_encode_min_long() {
+        long value = Long.MIN_VALUE;
+        TlvEncoder.encodeInteger(value);
     }
 
     @Test


### PR DESCRIPTION
Use signed magnitude representation instead of two's complement