### PR TITLE
Client registry used by Leshan standalone server should be configurable.

### DIFF
--- a/leshan-standalone/pom.xml
+++ b/leshan-standalone/pom.xml
@@ -71,6 +71,16 @@ Contributors:
             <artifactId>log4j-slf4j-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/LeshanStandalone.java
+++ b/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/LeshanStandalone.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.client.ClientRegistry;
 import org.eclipse.leshan.server.impl.SecurityRegistryImpl;
 import org.eclipse.leshan.standalone.servlet.ClientServlet;
 import org.eclipse.leshan.standalone.servlet.EventServlet;
@@ -51,6 +52,8 @@ public class LeshanStandalone {
 
     private Server server;
     private LeshanServer lwServer;
+
+    private ClientRegistry clientRegistry;
 
     public void start() {
         // Use those ENV variables for specifying the interface to be bound for coap and coaps
@@ -99,7 +102,7 @@ public class LeshanStandalone {
             LOG.warn("Unable to load RPK.", e);
         }
 
-        lwServer = builder.build();
+        lwServer = builder.setClientRegistry(clientRegistry).build();
         lwServer.start();
 
         // Now prepare and start jetty
@@ -146,6 +149,15 @@ public class LeshanStandalone {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public LeshanServer leshanServer() {
+        return lwServer;
+    }
+
+    public LeshanStandalone clientRegistry(ClientRegistry clientRegistry) {
+        this.clientRegistry = clientRegistry;
+        return this;
     }
 
     public static void main(String[] args) {

--- a/leshan-standalone/src/test/java/org/eclipse/leshan/standalone/LeshanStandaloneTest.java
+++ b/leshan-standalone/src/test/java/org/eclipse/leshan/standalone/LeshanStandaloneTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.html.
+ *******************************************************************************/
+package org.eclipse.leshan.standalone;
+
+import org.eclipse.leshan.server.client.ClientRegistry;
+import org.eclipse.leshan.server.impl.ClientRegistryImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.mock;
+
+public class LeshanStandaloneTest extends Assert {
+
+    LeshanStandalone server = new LeshanStandalone();
+
+    @Test
+    public void shouldUseInMemoryClientRegistry() throws InterruptedException {
+        // When
+        server.start();
+        SECONDS.sleep(1);
+        server.stop();
+
+        // Then
+        assertTrue(server.leshanServer().getClientRegistry() instanceof ClientRegistryImpl);
+    }
+
+    @Test
+    public void shouldUseGivenClientRegistry() throws InterruptedException {
+        // Given
+        ClientRegistry mockClientRegistry = mock(ClientRegistry.class);
+        server.clientRegistry(mockClientRegistry);
+
+        // When
+        server.start();
+        SECONDS.sleep(1);
+        server.stop();
+
+        // Then
+        assertSame(mockClientRegistry, server.leshanServer().getClientRegistry());
+    }
+
+}


### PR DESCRIPTION
Hi,

I'd like to run embedded `LehanStandalone` in my device management microservice. In order to achieve that, `LehanStandalone` should be able to take reference to my custom `ClientRegistry`.

My pull request adds an option to include custom `ClientRegistry` in the standalone Lehan server build process.

Cheers!