### PR TITLE
Spec change : Use POST for registration Update instead of PUT

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/CoapClientRequestBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/CoapClientRequestBuilder.java
@@ -82,7 +82,7 @@ public class CoapClientRequestBuilder implements UplinkRequestVisitor {
 
     @Override
     public void visit(final UpdateRequest request) {
-        coapRequest = Request.newPut();
+        coapRequest = Request.newPost();
         buildRequestSettings();
         coapRequest.getOptions().setUriPath(request.getRegistrationId());
 


### PR DESCRIPTION
The spec has changed since V1_0-20150615-D version, the registration update must be a CoAP POST instead of CoAP PUT.

We now accept PUT and POST to be compatible with older version of the spec.