### PR TITLE
Implement Queue Mode feature

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/BindingMode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/BindingMode.java
@@ -12,8 +12,12 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Alexander Ellwein (Bosch Software Innovations GmbH) 
+ *                     - extended for using with queue mode
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
+
+import java.util.EnumSet;
 
 /**
  * Transport binding and Queue Mode
@@ -36,5 +40,14 @@ public enum BindingMode {
     US,
 
     /** UDP with Queue Mode and SMS */
-    UQS
+    UQS;
+
+    private static final EnumSet<BindingMode> QUEUE_MODES = EnumSet.of(UQ, SQ, UQS);
+
+    /**
+     * @return true, if a binding mode is a queue mode, otherwise false.
+     */
+    public boolean isQueueMode() {
+        return QUEUE_MODES.contains(this);
+    }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.network.CoAPEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.client.resource.ObjectsInitializer;
+import org.eclipse.leshan.integration.tests.util.QueuedModeLeshanClient;
+import org.eclipse.leshan.server.californium.LeshanServerBuilder;
+import org.eclipse.leshan.server.californium.impl.CaliforniumLwM2mRequestSender;
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.californium.impl.RegisterResource;
+import org.eclipse.leshan.server.californium.impl.SecureEndpoint;
+import org.eclipse.leshan.server.client.ClientRegistry;
+import org.eclipse.leshan.server.impl.ClientRegistryImpl;
+import org.eclipse.leshan.server.impl.ObservationRegistryImpl;
+import org.eclipse.leshan.server.impl.SecurityRegistryImpl;
+import org.eclipse.leshan.server.model.LwM2mModelProvider;
+import org.eclipse.leshan.server.model.StandardModelProvider;
+import org.eclipse.leshan.server.observation.ObservationRegistry;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.eclipse.leshan.server.queue.QueueRequestFactory;
+import org.eclipse.leshan.server.queue.QueueRequestSender;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.eclipse.leshan.server.queue.impl.QueueRequestFactoryImpl;
+import org.eclipse.leshan.server.queue.impl.QueueRequestSenderImpl;
+import org.eclipse.leshan.server.queue.impl.RequestQueueImpl;
+import org.eclipse.leshan.server.queue.reactor.QueueReactorImpl;
+import org.eclipse.leshan.server.registration.RegistrationHandler;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
+import org.eclipse.leshan.server.security.SecurityRegistry;
+import org.eclipse.leshan.server.security.SecurityStore;
+
+/**
+ * IntegrationTestHelper, which is intended to create a client/server environment for testing the Queue Mode feature.
+ */
+public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
+
+    private RequestQueue requestQueue;
+    private QueueReactor queueReactor;
+    private QueueRequestSenderImpl requestSender;
+
+    private CoapServer createCoapServer(final InetSocketAddress localAddress, final ClientRegistry clientRegistry,
+            final SecurityStore securityStore) {
+
+        CoapServer coapServer = new CoapServer();
+        final Endpoint endpoint = new CoAPEndpoint(localAddress);
+        coapServer.addEndpoint(endpoint);
+
+        final RegisterResource rdResource = new RegisterResource(new RegistrationHandler(clientRegistry, securityStore));
+        coapServer.add(rdResource);
+
+        return coapServer;
+    }
+
+    @Override
+    public void createServer() {
+        LeshanServerBuilder serverBuilder = new LeshanServerBuilder();
+
+        // create and wire the dependencies
+
+        InetSocketAddress localAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        QueueRequestFactory requestFactory = new QueueRequestFactoryImpl();
+        queueReactor = new QueueReactorImpl(0);
+        requestQueue = new RequestQueueImpl(requestFactory, queueReactor);
+        ClientRegistry clientRegistry = new ClientRegistryImpl();
+        SecurityRegistry securityRegistry = new SecurityRegistryImpl();
+        CoapServer coapServer = createCoapServer(localAddress, clientRegistry, securityRegistry);
+        ObservationRegistry observationRegistry = new ObservationRegistryImpl();
+        LwM2mModelProvider modelProvider = new StandardModelProvider();
+
+        LwM2mRequestSender delegateSender = new CaliforniumLwM2mRequestSender(new HashSet<>(coapServer.getEndpoints()),
+                observationRegistry, modelProvider);
+
+        requestSender = new QueueRequestSenderImpl(queueReactor, requestQueue, delegateSender, requestFactory,
+                clientRegistry, observationRegistry, 10, TimeUnit.MINUTES, 700L);
+
+        requestSender.setSendExpirationInterval(24, TimeUnit.HOURS); // send within 24 hours
+        requestSender.setKeepExpirationInterval(5, TimeUnit.DAYS); // keep at most 5 days
+
+        serverBuilder.setClientRegistry(clientRegistry);
+        serverBuilder.setCoapServer(coapServer);
+        serverBuilder.setObjectModelProvider(modelProvider);
+        serverBuilder.setObservationRegistry(observationRegistry);
+        serverBuilder.setSecurityRegistry(securityRegistry);
+        serverBuilder.setLocalAddress(localAddress);
+        serverBuilder.setRequestSender(requestSender);
+
+        server = serverBuilder.build();
+    }
+
+    @Override
+    public void createClient() {
+        ObjectsInitializer initializer = new ObjectsInitializer();
+        ArrayList<LwM2mObjectEnabler> enablers = new ArrayList<>();
+        enablers.add(initializer.create(3));
+
+        client = new QueuedModeLeshanClient(new InetSocketAddress("0", 0), getServerAddress(), enablers);
+    }
+
+    protected InetSocketAddress getServerAddress() {
+        for (Endpoint endpoint : ((LeshanServer) server).getCoapServer().getEndpoints()) {
+            if (!(endpoint instanceof SecureEndpoint))
+                return endpoint.getAddress();
+        }
+        return null;
+    }
+
+    protected QueueRequestSender getQueueRequestSender() {
+        return requestSender;
+    }
+
+    protected RequestQueue getRequestQueue() {
+        return requestQueue;
+    }
+
+    protected QueueReactor getQueueReactor() {
+        return queueReactor;
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests;
+
+import static org.eclipse.leshan.integration.tests.IntegrationTestHelper.ENDPOINT_IDENTIFIER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.leshan.ResponseCode;
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.request.ReadRequest;
+import org.eclipse.leshan.core.request.RegisterRequest;
+import org.eclipse.leshan.core.request.UpdateRequest;
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.RegisterResponse;
+import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.core.response.ValueResponse;
+import org.eclipse.leshan.integration.tests.util.QueuedModeLeshanClient;
+import org.eclipse.leshan.integration.tests.util.QueuedModeLeshanClient.OnGetCallback;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for Queue Mode feature.
+ */
+public class QueueModeTest {
+
+    private QueueModeIntegrationTestHelper helper = new QueueModeIntegrationTestHelper();
+    private CountDownLatch countDownLatch;
+    private final OnGetCallback doNothingOnGet = new OnGetCallback() {
+        @Override
+        public boolean handleGet(final CoapExchange coapExchange) {
+            return false;
+        }
+    };
+
+    @Before
+    public void start() {
+        countDownLatch = new CountDownLatch(1);
+        helper.createServer();
+        helper.server.start();
+        helper.createClient();
+        helper.getQueueReactor().start();
+        helper.client.start();
+    }
+
+    @After
+    public void stop() {
+        helper.client.stop();
+        helper.server.stop();
+        helper.getQueueReactor().stop(200, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void verifyRequestIsSentImmediatelyIfPossible() throws Exception {
+        // client registration
+        RegisterResponse registerResponse = helper.client.send(new RegisterRequest(ENDPOINT_IDENTIFIER, 10000L, null,
+                BindingMode.UQ, null, null));
+
+        assertEquals("client was not registered", ResponseCode.CREATED, registerResponse.getCode());
+
+        helper.server.send(helper.getClient(), new ReadRequest(3, 0), new ResponseCallback<ValueResponse>() {
+            @Override
+            public void onResponse(final ValueResponse response) {
+                countDownLatch.countDown();
+            }
+        }, new ErrorCallback() {
+            @Override
+            public void onError(final Exception e) {
+                throw new IllegalStateException("unexpected exception occurred: ", e);
+            }
+        });
+        if (!countDownLatch.await(2, TimeUnit.SECONDS)) {
+            fail("response from client was not received within timeout");
+        }
+    }
+
+    @Test
+    public void verifyRequestIsDeferredIfClientDoesNotRespond() throws Exception {
+        // client registration
+        RegisterResponse registerResponse = helper.client.send(new RegisterRequest(ENDPOINT_IDENTIFIER, 10000L, null,
+                BindingMode.UQ, null, null));
+
+        assertEquals("client was not registered", ResponseCode.CREATED, registerResponse.getCode());
+
+        // client is set up to "sleep", i.e. not to respond
+        QueuedModeLeshanClient client = (QueuedModeLeshanClient) helper.client;
+
+        client.setOnGetCallback(doNothingOnGet);
+
+        helper.server.send(helper.getClient(), new ReadRequest(3, 0), new ResponseCallback<ValueResponse>() {
+            @Override
+            public void onResponse(final ValueResponse response) {
+                countDownLatch.countDown();
+            }
+        }, new ErrorCallback() {
+            @Override
+            public void onError(final Exception e) {
+                throw new IllegalStateException("unexpected exception occurred: ", e);
+            }
+        });
+        if (countDownLatch.await(3, TimeUnit.SECONDS)) {
+            fail("response from client is expected to time out");
+        }
+        // assert that queue has one deferred request
+        assertEquals(1, helper.getRequestQueue().getRequests(helper.getClient().getEndpoint()).size());
+        assertEquals(RequestState.DEFERRED, helper.getRequestQueue().getRequests(helper.getClient().getEndpoint())
+                .iterator().next().getRequestState());
+    }
+
+    @Test
+    public void verifyPendingRequestIsSentAfterClientsUpdate() throws Exception {
+        // client registration
+        RegisterResponse registerResponse = helper.client.send(new RegisterRequest(ENDPOINT_IDENTIFIER, 10000L, null,
+                BindingMode.UQ, null, null));
+
+        assertEquals("client was not registered", ResponseCode.CREATED, registerResponse.getCode());
+
+        // client is set up to not respond the next request, but to respond afterwards
+        final QueuedModeLeshanClient client = (QueuedModeLeshanClient) helper.client;
+        final CountDownLatch acceptCountDownLatch = new CountDownLatch(1);
+
+        client.setOnGetCallback(new OnGetCallback() {
+            @Override
+            public boolean handleGet(final CoapExchange coapExchange) {
+                client.setOnGetCallback(new OnGetCallback() {
+                    @Override
+                    public boolean handleGet(final CoapExchange coapExchange) {
+                        return true;
+                    }
+                });
+                countDownLatch.countDown();
+                return false;
+            }
+        });
+
+        helper.server.send(helper.getClient(), new ReadRequest(3, 0), new ResponseCallback<ValueResponse>() {
+            @Override
+            public void onResponse(final ValueResponse response) {
+                acceptCountDownLatch.countDown();
+            }
+        }, new ErrorCallback() {
+            @Override
+            public void onError(final Exception e) {
+                throw new IllegalStateException("unexpected exception occurred: ", e);
+            }
+        });
+
+        // after first (unresponded) request
+        if (!countDownLatch.await(1, TimeUnit.SECONDS)) {
+            fail("request was not properly processed");
+        }
+
+        // Needed to ensure that the request has been DEFERRED, otherwise
+        // update would not have the expected effect here.
+        Thread.sleep(700);
+        helper.client.send(new UpdateRequest(registerResponse.getRegistrationID(), null, null, null, null));
+
+        if (!acceptCountDownLatch.await(2, TimeUnit.SECONDS)) {
+            fail("server never received the response");
+        }
+
+        // assert that queue has one executed request
+        assertEquals(1, helper.getRequestQueue().getRequests(helper.getClient().getEndpoint()).size());
+        assertEquals(RequestState.EXECUTED, helper.getRequestQueue().getRequests(helper.getClient().getEndpoint())
+                .iterator().next().getRequestState());
+    }
+
+    @Test
+    public void verifyRequestIsElapsedAfterSendExpiration() throws Exception {
+        // client registration
+        RegisterResponse registerResponse = helper.client.send(new RegisterRequest(ENDPOINT_IDENTIFIER, 10000L, null,
+                BindingMode.UQ, null, null));
+
+        assertEquals("client was not registered", ResponseCode.CREATED, registerResponse.getCode());
+
+        // client is set up to not respond the first request, then to respond
+        final QueuedModeLeshanClient client = (QueuedModeLeshanClient) helper.client;
+
+        helper.getQueueRequestSender().setSendExpirationInterval(10, TimeUnit.MILLISECONDS);
+        helper.getQueueRequestSender().setKeepExpirationInterval(10, TimeUnit.SECONDS);
+
+        client.setOnGetCallback(doNothingOnGet);
+
+        helper.server.send(helper.getClient(), new ReadRequest(3, 0), new ResponseCallback<ValueResponse>() {
+
+            @Override
+            public void onResponse(final ValueResponse response) {
+                countDownLatch.countDown();
+            }
+        }, new ErrorCallback() {
+            @Override
+            public void onError(final Exception e) {
+                throw new IllegalStateException("unexpected exception occurred: ", e);
+            }
+        });
+
+        if (countDownLatch.await(1, TimeUnit.SECONDS)) {
+            fail("unexpected response from client");
+        }
+
+        helper.client.send(new UpdateRequest(registerResponse.getRegistrationID(), null, null, null, null));
+
+        // assert that queue has one executed request
+        assertEquals(1, helper.getRequestQueue().getRequests(helper.getClient().getEndpoint()).size());
+        assertEquals(RequestState.TTL_ELAPSED, helper.getRequestQueue().getRequests(helper.getClient().getEndpoint())
+                .iterator().next().getRequestState());
+    }
+
+    @Test
+    public void verifyRequestIsUnqueuedAfterKeepExpiration() throws Exception {
+        // client registration
+        RegisterResponse registerResponse = helper.client.send(new RegisterRequest(ENDPOINT_IDENTIFIER, 10000L, null,
+                BindingMode.UQ, null, null));
+
+        assertEquals("client was not registered", ResponseCode.CREATED, registerResponse.getCode());
+
+        // client is set up to not respond the first request, then to respond
+        final QueuedModeLeshanClient client = (QueuedModeLeshanClient) helper.client;
+
+        helper.getQueueRequestSender().setSendExpirationInterval(10, TimeUnit.MILLISECONDS);
+        helper.getQueueRequestSender().setKeepExpirationInterval(11, TimeUnit.MILLISECONDS);
+
+        client.setOnGetCallback(doNothingOnGet);
+
+        helper.server.send(helper.getClient(), new ReadRequest(3, 0), new ResponseCallback<ValueResponse>() {
+            @Override
+            public void onResponse(final ValueResponse response) {
+                countDownLatch.countDown();
+            }
+        }, new ErrorCallback() {
+            @Override
+            public void onError(final Exception e) {
+                throw new IllegalStateException("unexpected exception occurred: ", e);
+            }
+        });
+
+        if (countDownLatch.await(1, TimeUnit.SECONDS)) {
+            fail("unexpected response from client");
+        }
+
+        helper.client.send(new UpdateRequest(registerResponse.getRegistrationID(), null, null, null, null));
+
+        // assert that queue has no requests
+        assertEquals(0, helper.getRequestQueue().getRequests(helper.getClient().getEndpoint()).size());
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/QueuedModeLeshanClient.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/QueuedModeLeshanClient.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH) 
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.network.CoAPEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.leshan.client.LwM2mClient;
+import org.eclipse.leshan.client.californium.impl.CaliforniumLwM2mClientRequestSender;
+import org.eclipse.leshan.client.californium.impl.ObjectResource;
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.core.request.UplinkRequest;
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.util.Validate;
+
+/**
+ * This client has a special ability to have its GET handler instrumented by a test. It is very useful especially if a
+ * client is not assumed to be always online, i.e. to sleep and wake up sometimes, so that different communications
+ * scenarios could be tested.
+ */
+public class QueuedModeLeshanClient implements LwM2mClient {
+
+    private boolean running;
+    private CoapServer clientSideServer;
+    private final Object startMonitor = new Object();
+    private final CaliforniumLwM2mClientRequestSender requestSender;
+    private final List<LwM2mObjectEnabler> objectEnablers;
+    private OnGetCallback onGetCallback = null;
+
+    private class CustomObjectResource extends ObjectResource {
+
+        private LwM2mObjectEnabler nodeEnabler;
+
+        public CustomObjectResource(final LwM2mObjectEnabler nodeEnabler) {
+            super(nodeEnabler);
+            this.nodeEnabler = nodeEnabler;
+            this.nodeEnabler.setNotifySender(this);
+            setObservable(true);
+        }
+
+        @Override
+        public void handleGET(final CoapExchange exchange) {
+            if (onGetCallback != null) {
+                if (onGetCallback.handleGet(exchange)) {
+                    super.handleGET(exchange);
+                }
+            } else {
+                super.handleGET(exchange);
+            }
+        }
+    }
+
+    public interface OnGetCallback {
+
+        /**
+         * @return true, if the super implementation should be called, otherwise false.
+         */
+        boolean handleGet(CoapExchange coapExchange);
+    }
+
+    public QueuedModeLeshanClient(final InetSocketAddress clientAddress, final InetSocketAddress serverAddress,
+            final List<LwM2mObjectEnabler> objectEnablers) {
+        Validate.notNull(clientAddress);
+        Validate.notNull(serverAddress);
+        Validate.notNull(objectEnablers);
+        Validate.notEmpty(objectEnablers);
+
+        final Endpoint endpoint = new CoAPEndpoint(clientAddress);
+
+        clientSideServer = new CoapServer();
+        clientSideServer.addEndpoint(endpoint);
+
+        this.objectEnablers = new ArrayList<>(objectEnablers);
+        for (LwM2mObjectEnabler enabler : objectEnablers) {
+            if (clientSideServer.getRoot().getChild(Integer.toString(enabler.getId())) != null) {
+                throw new IllegalArgumentException("Trying to load Client Object of name '" + enabler.getId()
+                        + "' when one was already added.");
+            }
+
+            final ObjectResource clientObject = new CustomObjectResource(enabler);
+            clientSideServer.add(clientObject);
+        }
+
+        requestSender = new CaliforniumLwM2mClientRequestSender(clientSideServer.getEndpoint(clientAddress),
+                serverAddress, this);
+    }
+
+    @Override
+    public void start() {
+        synchronized (startMonitor) {
+            if (!running) {
+                clientSideServer.start();
+                running = true;
+            }
+        }
+    }
+
+    @Override
+    public void stop() {
+        synchronized (startMonitor) {
+            if (running) {
+                clientSideServer.stop();
+                running = false;
+            }
+        }
+    }
+
+    @Override
+    public <T extends LwM2mResponse> T send(final UplinkRequest<T> request) {
+        return requestSender.send(request, null);
+    }
+
+    @Override
+    public <T extends LwM2mResponse> T send(final UplinkRequest<T> request, final long timeout) {
+        return requestSender.send(request, timeout);
+    }
+
+    @Override
+    public <T extends LwM2mResponse> void send(final UplinkRequest<T> request,
+            final ResponseCallback<T> responseCallback, final ErrorCallback errorCallback) {
+        requestSender.send(request, responseCallback, errorCallback);
+    }
+
+    @Override
+    public List<LwM2mObjectEnabler> getObjectEnablers() {
+        return objectEnablers;
+    }
+
+    public void setOnGetCallback(final OnGetCallback onGetCallback) {
+        this.onGetCallback = onGetCallback;
+    }
+}

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -12,14 +12,28 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Alexander Ellwein (Bosch Software Innovations GmbH) 
+ *                     - allow to provide own coap server and request sender
  *******************************************************************************/
 package org.eclipse.leshan.server.californium;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.HashSet;
 
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.network.CoAPEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.leshan.server.LwM2mServer;
+import org.eclipse.leshan.server.californium.impl.CaliforniumLwM2mRequestSender;
 import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.californium.impl.LwM2mPskStore;
+import org.eclipse.leshan.server.californium.impl.RegisterResource;
+import org.eclipse.leshan.server.californium.impl.SecureEndpoint;
 import org.eclipse.leshan.server.client.ClientRegistry;
 import org.eclipse.leshan.server.impl.ClientRegistryImpl;
 import org.eclipse.leshan.server.impl.ObservationRegistryImpl;
@@ -27,6 +41,8 @@ import org.eclipse.leshan.server.impl.SecurityRegistryImpl;
 import org.eclipse.leshan.server.model.LwM2mModelProvider;
 import org.eclipse.leshan.server.model.StandardModelProvider;
 import org.eclipse.leshan.server.observation.ObservationRegistry;
+import org.eclipse.leshan.server.registration.RegistrationHandler;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
 import org.eclipse.leshan.server.security.SecurityRegistry;
 
 /**
@@ -48,6 +64,8 @@ public class LeshanServerBuilder {
     private LwM2mModelProvider modelProvider;
     private InetSocketAddress localAddress;
     private InetSocketAddress localAddressSecure;
+    private CoapServer coapServer;
+    private LwM2mRequestSender requestSender;
 
     public LeshanServerBuilder setLocalAddress(String hostname, int port) {
         this.localAddress = new InetSocketAddress(hostname, port);
@@ -89,6 +107,48 @@ public class LeshanServerBuilder {
         return this;
     }
 
+    public LeshanServerBuilder setCoapServer(CoapServer coapServer) {
+        this.coapServer = coapServer;
+        return this;
+    }
+
+    public LeshanServerBuilder setRequestSender(LwM2mRequestSender requestSender) {
+        this.requestSender = requestSender;
+        return this;
+    }
+
+    CoapServer createCoapServer() {
+        // default endpoint
+        CoapServer coapServer = new CoapServer();
+        final Endpoint endpoint = new CoAPEndpoint(localAddress);
+        coapServer.addEndpoint(endpoint);
+
+        // secure endpoint
+        DTLSConnector connector = new DTLSConnector(localAddressSecure);
+        connector.getConfig().setPskStore(new LwM2mPskStore(securityRegistry, clientRegistry));
+        PrivateKey privateKey = securityRegistry.getServerPrivateKey();
+        PublicKey publicKey = securityRegistry.getServerPublicKey();
+
+        if (privateKey != null && publicKey != null) {
+            connector.getConfig().setPrivateKey(privateKey, publicKey);
+            // TODO this should be automatically done by scandium
+            connector.getConfig().setPreferredCipherSuite(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
+        } else {
+            // TODO this should be automatically done by scandium
+            connector.getConfig().setPreferredCipherSuite(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8);
+        }
+
+        final Endpoint secureEndpoint = new SecureEndpoint(connector);
+        coapServer.addEndpoint(secureEndpoint);
+
+        // define /rd resource
+        final RegisterResource rdResource = new RegisterResource(new RegistrationHandler(this.clientRegistry,
+                this.securityRegistry));
+        coapServer.add(rdResource);
+
+        return coapServer;
+    }
+
     public LeshanServer build() {
         if (localAddress == null)
             localAddress = new InetSocketAddress((InetAddress) null, PORT);
@@ -103,7 +163,14 @@ public class LeshanServerBuilder {
         if (modelProvider == null) {
             modelProvider = new StandardModelProvider();
         }
+        if (coapServer == null) {
+            coapServer = createCoapServer();
+        }
+        if (requestSender == null) {
+            requestSender = new CaliforniumLwM2mRequestSender(new HashSet<>(coapServer.getEndpoints()),
+                    observationRegistry, modelProvider);
+        }
         return new LeshanServer(localAddress, localAddressSecure, clientRegistry, securityRegistry,
-                observationRegistry, modelProvider);
+                observationRegistry, modelProvider, coapServer, requestSender);
     }
 }

--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -52,6 +52,11 @@ Contributors:
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+		    <groupId>org.mockito</groupId>
+		    <artifactId>mockito-all</artifactId>
+		    <scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>
@@ -59,7 +64,6 @@ Contributors:
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/SecurityRegistryImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/SecurityRegistryImpl.java
@@ -151,7 +151,7 @@ public class SecurityRegistryImpl implements SecurityRegistry {
 
             } else {
 
-                try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(file));) {
+                try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(file))) {
                     SecurityInfo[] infos = (SecurityInfo[]) in.readObject();
 
                     if (infos != null) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueManagement.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueManagement.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+/**
+ * Queue management interface allows simple ordering/prioritizing of single queue requests or request sequences.
+ */
+public interface QueueManagement {
+
+    /**
+     * Moves the given queue request to the top of the queue, so it will be processed first.
+     *
+     * @param queueRequest queue request to move
+     */
+    void moveTop(QueueRequest queueRequest);
+
+    /**
+     * Moves a sequence with the given sequence ID to the top of the queue, so it will processed first.
+     *
+     * @param endpoint endpoint ID of the client which has the sequence ID assigned
+     * @param sequenceId sequence ID of the sequence to move
+     */
+    void moveSequenceTop(String endpoint, SequenceId sequenceId);
+
+    /**
+     * Moves the given queue request to the bottom of the queue, so it will be processed last.
+     *
+     * @param queueRequest queue request to move
+     */
+    void moveBottom(QueueRequest queueRequest);
+
+    /**
+     * Moves a sequence with the given sequence ID to the bottom of the queue, so it will processed last.
+     *
+     * @param endpoint endpoint ID of the client which has the sequence ID assigned
+     * @param sequenceId sequence ID of the sequence to move
+     */
+    void moveSequenceBottom(String endpoint, SequenceId sequenceId);
+
+    /**
+     * Moves a given request one position up the queue, over a single request or sequence.
+     *
+     * @param queueRequest queue request to move
+     */
+    void moveUp(QueueRequest queueRequest);
+
+    /**
+     * Moves a sequence with the given ID one position up the queue, over a single request or sequence.
+     *
+     * @param endpoint endpoint ID of the client which has the sequence ID assigned
+     * @param sequenceId sequence ID of the sequence to move
+     */
+    void moveSequenceUp(String endpoint, SequenceId sequenceId);
+
+    /**
+     * Moves a given request one position down the queue, over a single request or sequence.
+     *
+     * @param queueRequest queue request to move
+     */
+    void moveDown(QueueRequest queueRequest);
+
+    /**
+     * Moves a sequence with the given ID one position down the queue, over a single request or sequence.
+     *
+     * @param endpoint endpoint ID of the client which has the sequence ID assigned
+     * @param sequenceId sequence ID of the sequence to move
+     */
+    void moveSequenceDown(String endpoint, SequenceId sequenceId);
+
+    /**
+     * Removes the given request from the queue.
+     *
+     * @param queueRequest request to remove.
+     */
+    void dropRequest(QueueRequest queueRequest);
+
+    /**
+     * Removes a sequence of requests for a given client from the queue.
+     *
+     * @param endpoint endpoint ID of the client which has the sequence ID assigned
+     * @param sequenceId sequence ID of the sequence to remove.
+     */
+    void dropSequence(String endpoint, SequenceId sequenceId);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueReactor.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueReactor.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This queue reactor allows concurrent processing of the requests without changing the order of execution. Because of a
+ * highly concurrent nature of the Queue Mode (responses from clients may arrive any time, changing the state of the
+ * pending requests, as well as the user can do via queue management interface), this reactor serves as a scheduler for
+ * queue tasks, which can run in the same thread of execution (non-blocking tasks) or in a separate worker thread
+ * (blocking tasks).
+ *
+ * @see QueueTask
+ */
+public interface QueueReactor {
+
+    /**
+     * Schedules a queue task to the reactor.
+     *
+     * @param task task to be scheduled.
+     */
+    void addTask(QueueTask task);
+
+    /**
+     * Starts the reactor's processing.
+     */
+    void start();
+
+    /**
+     * Stops the reactor's processing.
+     *
+     * @param timeout time to wait for shutdown
+     * @param timeUnit time unit to use
+     */
+    void stop(long timeout, TimeUnit timeUnit);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueRequest.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueRequest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.server.client.Client;
+
+/**
+ * A QueueRequest is an element of the request queue, containing the actual downlink request, its send expiration (a
+ * time until the sender will retry the send), the keep expiration (time until a deferred or an executed request is kept
+ * in the queue), the state of processing for this particular queue request, the sequence ID (means the queue request is
+ * a single request or it is bound into a sequence with queue requests of same sequence ID) and a response ID, which can
+ * be used to associate a response from the client with this particular queue request in ResponseProcessor.
+ *
+ * @see RequestState
+ * @see SequenceId
+ * @see ResponseProcessor
+ */
+public interface QueueRequest {
+
+    /**
+     * @return a sequence ID assigned to this queue request
+     */
+    SequenceId getSequenceId();
+
+    /**
+     * @return a response ID assigned to this queue request
+     */
+    Long getResponseId();
+
+    /**
+     * @return LwM2M client to send the request to
+     */
+    Client getClient();
+
+    /**
+     * @return the actual downlink request which is to be send
+     */
+    DownlinkRequest<?> getDownlinkRequest();
+
+    /**
+     * @return timestamp of the date, when the time-to-send for the request expires and the sender will not anymore try to send it.
+     */
+    long getSendExpiration();
+
+    /**
+     * @return true, if the time interval for sending the request passed, i.e. send time is elapsed.
+     */
+    boolean isSendExpirationReached();
+
+    /**
+     * @return timestamp of the date, when the time-to-keep for the request expires and the request may be removed from the queue.
+     */
+    long getKeepExpiration();
+
+    /**
+     * @return true, if the time interval to keep the request in queue passed, i.e. the keep time is elapsed.
+     */
+    boolean isKeepExpirationReached();
+
+    /**
+     * @return the current state of this request
+     */
+    RequestState getRequestState();
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueRequestFactory.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueRequestFactory.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.server.client.Client;
+
+/**
+ * Queue request factory is used for creation or transition of the queue requests.
+ */
+public interface QueueRequestFactory {
+
+    /**
+     * Creates a new (unqueued) queue request.
+     *
+     * @param client client to send the request to
+     * @param request request to send
+     * @param sendExpiration amount of time in nanoseconds, after that the request expires (will not be send anymore)
+     * @param keepExpiration amount of time in nanoseconds, after that the request may be removed from the queue
+     * @param responseId response ID associated with this request, may be used in ResponseProcessor
+     * @return new unqueued queue request
+     */
+    public QueueRequest createQueuedRequest(Client client, DownlinkRequest<?> request, long sendExpiration,
+            long keepExpiration, long responseId);
+
+    /**
+     * Transforms the queue request to a new state.
+     *
+     * @param request request to transform
+     * @param sequenceIdToSet new sequence ID to be set
+     * @param newState new state to set
+     * @return transformed queue request
+     */
+    public QueueRequest transformRequest(QueueRequest request, SequenceId sequenceIdToSet, RequestState newState);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueRequestSender.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueRequestSender.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
+
+/**
+ * A queue request sender is a special sender which is aware of LwM2M client's binding mode. If a client supports "Q"
+ * (queue) mode, the sender queues the request automatically and sends it when the client is back online.
+ */
+public interface QueueRequestSender extends LwM2mRequestSender {
+
+    /**
+     * Sets the time period in which the request being queued will be expired and will not be sent anymore.
+     *
+     * @param expirationInterval interval amount
+     * @param expirationIntervalTimeUnit interval time unit
+     */
+    void setSendExpirationInterval(long sendExpirationInterval, TimeUnit sendExpirationIntervalTimeUnit);
+
+    /**
+     * Sets the time period in which the request being queued will not be kept in queue anymore.
+     *
+     * @param keepExpirationInterval interval amount
+     * @param keepExpirationIntervalTimeUnit interval time unit
+     */
+    void setKeepExpirationInterval(long keepExpirationInterval, TimeUnit keepExpirationIntervalTimeUnit);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueTask.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+/**
+ * A queue task represents an piece of an execution run in the queue reactor. This execution which can be done either
+ * within the same reactor thread (for a short-timed operation), or a task which would block the queue reactor - in this
+ * case, the queue task should signal that it {@link #wouldBlock()} the reactor main thread and it will be executed in a
+ * separate worker thread.
+ *
+ * @see QueueReactor
+ */
+public interface QueueTask extends Runnable {
+
+    /**
+     * @return true, if the execution of this task would block the execution of the subsequently queued tasks, otherwise
+     *         false.
+     */
+    boolean wouldBlock();
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/RequestQueue.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/RequestQueue.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A request queue represents a queue which is used to queue and process LwM2M downlink requests. It supports a simple
+ * state transition operations for queue requests which is used in the queue's implementation, for instance:
+ * <ul>
+ * <li>A request is initially enqueued;</li>
+ * <li>A request is being processed;</li>
+ * <li>A request is deferred (because of a timeout);</li>
+ * <li>A request's time-to-live is elapsed;</li>
+ * <li>A request is executed;</li>
+ * <li>A request is unqueued from the queue.</li>
+ * </ul>
+ *
+ * @see SequenceId
+ * @see QueueRequest
+ * @see RequestState
+ */
+public interface RequestQueue {
+
+    /**
+     * Enqueues a request and returns a unique sequence ID which is associated to this request.
+     *
+     * @param queueRequest request to enqueue
+     * @return sequence ID associated with the request
+     */
+    SequenceId enqueueRequest(QueueRequest queueRequest);
+
+    /**
+     * Enqueues a request which is also associated with an existing sequence ID.
+     *
+     * @param queueRequest request to enqueue
+     * @param existingId sequence ID to add the queue request to
+     */
+    void enqueueRequest(QueueRequest queueRequest, SequenceId existingId);
+
+    /**
+     * Sets the request in a processing state (it is currently being sent).
+     *
+     * @param queueRequest request which is being processed
+     */
+    void processingRequest(QueueRequest queueRequest);
+
+    /**
+     * Sets the request to a deferred state (i.e. the request could not be sent and is deferred for a next client's
+     * update).
+     *
+     * @param queueRequest queue request to defer
+     */
+    void deferRequest(QueueRequest queueRequest);
+
+    /**
+     * Sets the request in TTL_ELAPSED state (the time-to-live for the request has been reached, it will be not sent
+     * anymore, but is kept at least until keep expiration has reached).
+     *
+     * @param queueRequest queue request to promote to TTL_ELAPSED state
+     */
+    void ttlElapsedRequest(QueueRequest queueRequest);
+
+    /**
+     * Sets the request to executed state, i.e. the request was transmitted successfully.
+     *
+     * @param queueRequest request to set to the executed state
+     */
+    void executedRequest(QueueRequest queueRequest);
+
+    /**
+     * Remove (unqueue) the request from the queue, for instance, if its keep expiration has been reached.
+     *
+     * @param queueRequest queue request to unqueue
+     */
+    void unqueueRequest(QueueRequest queueRequest);
+
+    /**
+     * Provides an unmodifiable collection (snapshot) of all requests for a client with the given endpoint ID.
+     *
+     * @param endpoint endpoint ID of a LwM2M client
+     * @return unmodifiable collection (snapshot) of all requests for a given client.
+     */
+    Collection<QueueRequest> getRequests(String endpoint);
+
+    /**
+     * Provides an unmodifiable set (snapshot) of endpoint IDs of clients which have their requests in the queue.
+     *
+     * @return an unmodifiable set (snapshot) of endpoint IDs of clients which have their requests in the queue.
+     */
+    Set<String> getEndpoints();
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/RequestState.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/RequestState.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+/**
+ * Request state represents the processing state of a queue request.
+ *
+ * Every created QueueRequest is first in UNKNOWN state, until it is enqueued. After the request has been enqueued, it
+ * is promoted to the ENQUEUED state. The request remains in ENQUEUED state, until a LwM2M client sends a registration
+ * update (means the client is online now), then the request sender schedules the processing of the request on top,
+ * promoting it in the PROCESSING state. A sending can be either successful (request goes to the EXECUTED state) or the
+ * server receives a timeout on send, then the request is transferred to the DEFERRED state. A deferred request will be
+ * resent next time, when the client is back online, or TTL_ELAPSED, if the time-to-live is elapsed: For all requests in
+ * the queue, there is a time-to-live (maximum time until send) and a time-to-keep (maximum time to keep the request in
+ * the queue, even after it is sent or deferred).
+ */
+public enum RequestState {
+    /** Unknown (unassigned) state. */
+    UNKNOWN,
+    /** A request has been initially put into the request queue. */
+    ENQUEUED,
+    /** A request is currently being processed (sending). */
+    PROCESSING,
+    /** A request could not be sent and is deferred after client is back with an update. */
+    DEFERRED,
+    /** A maximum Time-To-Live for the request has been reached and now it is just stored for time-to-keep. */
+    TTL_ELAPSED,
+    /** A request was executed successfully and now it is stored for time-to-keep. */
+    EXECUTED
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/SequenceId.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/SequenceId.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import org.eclipse.leshan.util.Validate;
+
+/**
+ * A sequence ID represents a unique identifier, which can be used in order to "group" queue requests in sequences.
+ * Because it is allowed to move requests up and down the queue, there are sometimes situations that some requests
+ * cannot be shifted and has to remain their sequential order in the queue. For this reason, requests can be assigned to
+ * the same sequence ID and though can only be moved up and down the queue as a complete sequence.
+ *
+ */
+public final class SequenceId implements Comparable<SequenceId> {
+
+    /** Sequence ID, which stands for uninitialized sequence. */
+    public static final SequenceId NONE = new SequenceId();
+
+    private final long sequenceNumber;
+
+    private SequenceId() {
+        this.sequenceNumber = Long.MAX_VALUE;
+    }
+
+    /**
+     * Creates a new sequence ID with the given number.
+     *
+     * @param sequenceNumber sequence number to use
+     */
+    public SequenceId(long sequenceNumber) {
+        Validate.isTrue(sequenceNumber != Long.MAX_VALUE, "sequence number may not be the maximum long value",
+                sequenceNumber);
+        this.sequenceNumber = sequenceNumber;
+    }
+
+    /**
+     * @return sequence number assigned to this sequence ID.
+     */
+    public long getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else {
+            return ((SequenceId) obj).getSequenceNumber() == getSequenceNumber();
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) this.sequenceNumber;
+    }
+
+    @Override
+    public int compareTo(SequenceId sequenceId) {
+        if (sequenceId == null)
+            return -1;
+        return (int) (getSequenceNumber() - ((SequenceId) sequenceId).getSequenceNumber());
+    }
+
+    @Override
+    public String toString() {
+        return new String("SequenceId (" + sequenceNumber + ")");
+    }
+
+    /**
+     * @return true, if the sequence ID has been set.
+     */
+    public boolean isSet() {
+        return !SequenceId.NONE.equals(this);
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/QueueRequestFactoryImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/QueueRequestFactoryImpl.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.impl;
+
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueRequestFactory;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.eclipse.leshan.server.queue.SequenceId;
+import org.eclipse.leshan.util.Validate;
+
+/**
+ * The queue request factory is responsible to create queue requests and do state transitions on them. In this
+ * particular implementation, the queue requests are mutable and only this class is in charge of manipulation on queue
+ * requests.
+ *
+ * @see QueueRequest
+ * @see RequestState
+ */
+public class QueueRequestFactoryImpl implements QueueRequestFactory {
+
+    /**
+     * A simple mutable implementation of a queue request.
+     */
+    public static class QueueRequestImpl implements QueueRequest {
+
+        private final Client client;
+        private final DownlinkRequest<?> downlinkRequest;
+        private SequenceId sequenceId;
+        private RequestState requestState;
+        private final long sendExpiration;
+        private final long keepExpiration;
+        private final Long responseId;
+
+        private QueueRequestImpl(Client client, DownlinkRequest<?> downlinkRequest, long sendExpiration,
+                long keepExpiration, long responseId) {
+            Validate.notNull(client, "client cannot be null");
+            Validate.notNull(downlinkRequest, "request cannot be null");
+            Validate.isTrue(keepExpiration >= sendExpiration, "keep expiration date must be after the send expiration");
+            this.client = client;
+            this.downlinkRequest = downlinkRequest;
+            this.sequenceId = SequenceId.NONE;
+            this.requestState = RequestState.UNKNOWN;
+
+            this.sendExpiration = System.nanoTime() + sendExpiration;
+            this.keepExpiration = System.nanoTime() + keepExpiration;
+            this.responseId = responseId;
+        }
+
+        @Override
+        public SequenceId getSequenceId() {
+            return sequenceId;
+        }
+
+        @Override
+        public Client getClient() {
+            return client;
+        }
+
+        @Override
+        public DownlinkRequest<?> getDownlinkRequest() {
+            return downlinkRequest;
+        }
+
+        @Override
+        public long getSendExpiration() {
+            return sendExpiration;
+        }
+
+        @Override
+        public long getKeepExpiration() {
+            return keepExpiration;
+        }
+
+        @Override
+        public RequestState getRequestState() {
+            return requestState;
+        }
+
+        private void setRequestState(RequestState state) {
+            this.requestState = state;
+        }
+
+        private void setSequenceId(SequenceId newSeqId) {
+            this.sequenceId = newSeqId;
+        }
+
+        @Override
+        public Long getResponseId() {
+            return responseId;
+        }
+
+        @Override
+        public boolean isSendExpirationReached() {
+            return System.nanoTime() >= sendExpiration;
+        }
+
+        @Override
+        public boolean isKeepExpirationReached() {
+            return System.nanoTime() >= keepExpiration;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("QueueRequestImpl [client=");
+            builder.append(client);
+            builder.append(", downlinkRequest=");
+            builder.append(downlinkRequest);
+            builder.append(", sequenceId=");
+            builder.append(sequenceId);
+            builder.append(", requestState=");
+            builder.append(requestState);
+            builder.append(", sendExpiration=");
+            builder.append(sendExpiration);
+            builder.append(", keepExpiration=");
+            builder.append(keepExpiration);
+            builder.append(", responseId=");
+            builder.append(responseId);
+            builder.append("]");
+            return builder.toString();
+        }
+    }
+
+    @Override
+    public QueueRequest createQueuedRequest(Client client, DownlinkRequest<?> request, long sendExpiration,
+            long keepExpiration, long responseId) {
+        return new QueueRequestImpl(client, request, sendExpiration, keepExpiration, responseId);
+    }
+
+    @Override
+    public QueueRequest transformRequest(QueueRequest request, SequenceId sequenceIdToSet, RequestState newState) {
+        ((QueueRequestImpl) request).setRequestState(newState);
+        ((QueueRequestImpl) request).setSequenceId(sequenceIdToSet);
+        return request;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/QueueRequestSenderImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/QueueRequestSenderImpl.java
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.impl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientRegistry;
+import org.eclipse.leshan.server.client.ClientRegistryListener;
+import org.eclipse.leshan.server.observation.Observation;
+import org.eclipse.leshan.server.observation.ObservationRegistry;
+import org.eclipse.leshan.server.observation.ObservationRegistryListener;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueRequestFactory;
+import org.eclipse.leshan.server.queue.QueueRequestSender;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.eclipse.leshan.server.queue.reactor.QueueProcessingTask;
+import org.eclipse.leshan.server.queue.reactor.StateTransitionTask;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
+import org.eclipse.leshan.util.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This sender is a special implementation of a {@link QueueRequestSender}, which is aware of a LwM2M client's binding
+ * mode. If the client supports "Q" (queue) mode, then the request is processed using the internal queue, i.e. the
+ * request is enqueued first and then sent if a client is back online. If the client does not support the queue mode in
+ * its binding, then the delegate sender is call in order to send the request.
+ *
+ * <b>Please note:</b> the synchronous {@link #send(Client, DownlinkRequest, Long)} operation is not supported with this
+ * sender.
+ */
+public class QueueRequestSenderImpl implements QueueRequestSender {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueueRequestSenderImpl.class);
+    private final RequestQueue requestQueue;
+    private final LwM2mRequestSender delegateSender;
+    private final QueueRequestFactory queuedRequestFactory;
+    private final QueueReactor queueReactor;
+    private final long requestTimeout;
+
+    private long sendExpirationInterval = 86400000000L;  // default send interval of a day in nanos
+    private long keepExpirationInterval = 172800000000L; // default keep interval of two days in nanos
+
+    private Lock intervalLock = new ReentrantLock();
+
+    private Map<Long, ResponseContext> responseContext = new ConcurrentHashMap<>();
+
+    private AtomicLong responseIdCounter = new AtomicLong();
+    private long queueCleaningPeriod;
+    private TimeUnit queueCleaningTimeUnit;
+
+    /**
+     * Creates a new QueueRequestSender using given parameters.
+     *
+     * @param queueReactor queue reactor, which is used for processing and scheduling of queue requests
+     * @param requestQueue a request queue, used for storing the queue requests
+     * @param delegateSender delegate {@link LwM2mRequestSender}, which is used for sending the requests
+     * @param queuedRequestFactory queue request factory is used for creating the requests
+     * @param clientRegistry used for client lookup, to continue processing on client updates
+     * @param observationRegistry used for observation lookup, to continue processing on notifications
+     * @param queueCleaningPeriod period for rescheduling queue's self managing tasks
+     * @param queueCleaningTimeUnit time unit for rescheduling queue's self managing tasks
+     * @param requestTimeout sender's request timeout
+     */
+    public QueueRequestSenderImpl(final QueueReactor queueReactor, final RequestQueue requestQueue,
+            final LwM2mRequestSender delegateSender, final QueueRequestFactory queuedRequestFactory,
+            final ClientRegistry clientRegistry, final ObservationRegistry observationRegistry,
+            final long queueCleaningPeriod, final TimeUnit queueCleaningTimeUnit, final Long requestTimeout) {
+        Validate.notNull(queueReactor, "queueReactor cannot be null");
+        Validate.notNull(requestQueue, "requestQueue cannot be null");
+        Validate.notNull(delegateSender, "delegateSender cannot be null");
+        Validate.notNull(queuedRequestFactory, "queuedRequestFactory cannot be null");
+        Validate.notNull(clientRegistry, "clientRegistry cannot be null");
+        Validate.notNull(observationRegistry, "observationRegistry cannot be null");
+        Validate.isTrue(queueCleaningPeriod > 0, "queueCleaningPeriod may not be less or equal zero");
+        Validate.notNull(requestTimeout, "requestTimeout cannot be null");
+
+        this.queueReactor = queueReactor;
+        this.requestQueue = requestQueue;
+        this.delegateSender = delegateSender;
+        this.queuedRequestFactory = queuedRequestFactory;
+        this.queueCleaningPeriod = queueCleaningPeriod;
+        this.queueCleaningTimeUnit = queueCleaningTimeUnit;
+        this.requestTimeout = requestTimeout;
+
+        clientRegistry.addListener(new ClientRegistryListener() {
+            @Override
+            public void registered(Client client) {
+                queueReactor.addTask(new QueueProcessingTask(delegateSender, responseContext, requestQueue, client,
+                        queueReactor, queueCleaningPeriod, queueCleaningTimeUnit, requestTimeout, true));
+            }
+
+            @Override
+            public void updated(Client clientUpdated) {
+                queueReactor.addTask(new QueueProcessingTask(delegateSender, responseContext, requestQueue,
+                        clientUpdated, queueReactor, queueCleaningPeriod, queueCleaningTimeUnit, requestTimeout, true));
+            }
+
+            @Override
+            public void unregistered(Client client) {
+            }
+        });
+        observationRegistry.addListener(new ObservationRegistryListener() {
+            @Override
+            public void newValue(Observation observation, LwM2mNode value) {
+                queueReactor.addTask(new QueueProcessingTask(delegateSender, responseContext, requestQueue, observation
+                        .getClient(), queueReactor, queueCleaningPeriod, queueCleaningTimeUnit, requestTimeout, true));
+            }
+
+            @Override
+            public void cancelled(Observation observation) {
+                // not used here
+            }
+
+            @Override
+            public void newObservation(Observation observation) {
+                // not used here
+            }
+        });
+    }
+
+    @Override
+    public void setSendExpirationInterval(long sendExpirationInterval, TimeUnit sendExpirationIntervalTimeUnit) {
+        if (sendExpirationInterval <= 0) {
+            throw new IllegalArgumentException("invalid send expiration interval");
+        }
+        intervalLock.lock();
+        try {
+            this.sendExpirationInterval = sendExpirationIntervalTimeUnit.toNanos(sendExpirationInterval);
+        } finally {
+            intervalLock.unlock();
+        }
+    }
+
+    @Override
+    public void setKeepExpirationInterval(long keepExpirationInterval, TimeUnit keepExpirationIntervalTimeUnit) {
+        if (sendExpirationInterval <= 0) {
+            throw new IllegalArgumentException("invalid keep expiration interval");
+        }
+        intervalLock.lock();
+        try {
+            this.keepExpirationInterval = keepExpirationIntervalTimeUnit.toNanos(keepExpirationInterval);
+        } finally {
+            intervalLock.unlock();
+        }
+    }
+
+    @Override
+    public <T extends LwM2mResponse> T send(Client destination, DownlinkRequest<T> request, Long requestTimeout) {
+        throw new UnsupportedOperationException("synchronous send() with the QueueRequestSender is not supported.");
+    }
+
+    @Override
+    public <T extends LwM2mResponse> void send(Client destination, DownlinkRequest<T> request,
+            final ResponseCallback<T> responseCallback, final ErrorCallback errorCallback) {
+
+        if (destination.getBindingMode().isQueueMode()) {
+            final Long responseId = responseIdCounter.incrementAndGet();
+            LOG.debug("created response ID {} for request {}", responseId, request);
+
+            long sendExpiration = 0;
+            long keepExpiration = 0;
+
+            intervalLock.lock();
+            try {
+                sendExpiration = sendExpirationInterval;
+                keepExpiration = keepExpirationInterval;
+            } finally {
+                intervalLock.unlock();
+            }
+
+            QueueRequest queueRequest = queuedRequestFactory.createQueuedRequest(destination, request,
+                    sendExpiration, keepExpiration, responseId);
+
+            responseContext.put(responseId, new ResponseContext() {
+                @Override
+                public ResponseCallback<? extends LwM2mResponse> getResponseCallback() {
+                    return responseCallback;
+                }
+
+                @Override
+                public ErrorCallback getErrorCallback() {
+                    return errorCallback;
+                }
+            });
+            queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.ENQUEUED));
+            queueReactor.addTask(new QueueProcessingTask(delegateSender, responseContext, requestQueue, destination, queueReactor,
+                    queueCleaningPeriod, queueCleaningTimeUnit, requestTimeout, true));
+        } else {
+            // send directly (client is not in queued mode)
+            delegateSender.send(destination, request, responseCallback, errorCallback);
+        }
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/RequestQueueImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/RequestQueueImpl.java
@@ -1,0 +1,376 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.queue.QueueManagement;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueRequestFactory;
+import org.eclipse.leshan.server.queue.QueueTask;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.eclipse.leshan.server.queue.SequenceId;
+
+/**
+ * A request queue implementation, which keeps all the requests in memory.
+ *
+ * @see RequestQueue
+ * @see QueueManagement
+ */
+public class RequestQueueImpl implements RequestQueue, QueueManagement {
+
+    private final Map<SequenceId, List<QueueRequest>> requests = new HashMap<>();
+    private final Map<String, List<SequenceId>> sequences = new HashMap<>();
+    private long counter = 0L;
+
+    private QueueRequestFactory requestFactory;
+    private QueueReactor queueReactor;
+
+    /**
+     * Creates a new request queue.
+     *
+     * @param requestFactory request factory used here
+     * @param queueReactor reactor which is used for scheduling queue management tasks
+     */
+    public RequestQueueImpl(QueueRequestFactory requestFactory, QueueReactor queueReactor) {
+        this.requestFactory = requestFactory;
+        this.queueReactor = queueReactor;
+    }
+
+    SequenceId getCreateSequenceId(QueueRequest queueRequest) {
+        SequenceId id = queueRequest.getSequenceId();
+        return id.isSet() ? id : createSequenceId();
+    }
+
+    List<SequenceId> getCreateClientSequences(Client client) {
+        List<SequenceId> clientSequences = sequences.get(client.getEndpoint());
+        return (clientSequences == null) ? new ArrayList<SequenceId>() : clientSequences;
+    }
+
+    List<QueueRequest> getCreateRequestsForSequenceId(SequenceId id) {
+        List<QueueRequest> clientRequests = requests.get(id);
+        return (clientRequests == null) ? new ArrayList<QueueRequest>() : clientRequests;
+    }
+
+    @Override
+    public SequenceId enqueueRequest(QueueRequest queueRequest) {
+        SequenceId id = getCreateSequenceId(queueRequest);
+        enqueueRequest(queueRequest, id);
+        return id;
+    }
+
+    @Override
+    public void enqueueRequest(QueueRequest queueRequest, SequenceId existingId) {
+        if (queueRequest.getSequenceId().isSet()) {
+            throw new IllegalStateException("request is already enqueued");
+        }
+        Client client = queueRequest.getClient();
+        List<SequenceId> clientSequences = getCreateClientSequences(client);
+        List<QueueRequest> clientRequests = getCreateRequestsForSequenceId(existingId);
+
+        QueueRequest newRequest = doRequestTransition(queueRequest, existingId, RequestState.ENQUEUED);
+
+        if (!clientSequences.contains(existingId)) {
+            clientSequences.add(existingId);
+        }
+        clientRequests.add(newRequest);
+        sequences.put(client.getEndpoint(), clientSequences);
+        requests.put(existingId, clientRequests);
+    }
+
+    QueueRequest doRequestTransition(QueueRequest request, SequenceId seqId, RequestState newState) {
+        return requestFactory.transformRequest(request, seqId, newState);
+    }
+
+    SequenceId createSequenceId() {
+        return new SequenceId(++counter);
+    }
+
+    @Override
+    public void processingRequest(QueueRequest queueRequest) {
+        doRequestTransition(queueRequest, queueRequest.getSequenceId(), RequestState.PROCESSING);
+    }
+
+    @Override
+    public void deferRequest(QueueRequest queueRequest) {
+        doRequestTransition(queueRequest, queueRequest.getSequenceId(), RequestState.DEFERRED);
+    }
+
+    @Override
+    public void ttlElapsedRequest(QueueRequest queueRequest) {
+        doRequestTransition(queueRequest, queueRequest.getSequenceId(), RequestState.TTL_ELAPSED);
+    }
+
+    @Override
+    public void executedRequest(QueueRequest queueRequest) {
+        doRequestTransition(queueRequest, queueRequest.getSequenceId(), RequestState.EXECUTED);
+    }
+
+    @Override
+    public void unqueueRequest(QueueRequest queueRequest) {
+        doRequestTransition(queueRequest, queueRequest.getSequenceId(), RequestState.UNKNOWN);
+        dropRequest(queueRequest);
+    }
+
+    @Override
+    public Collection<QueueRequest> getRequests(String endpoint) {
+        List<QueueRequest> result = new ArrayList<>();
+        List<SequenceId> clientSequences = sequences.get(endpoint);
+        if (clientSequences == null) {
+            return Collections.<QueueRequest> emptyList();
+        }
+        for (SequenceId seqId : clientSequences) {
+            List<QueueRequest> clientRequests = requests.get(seqId);
+            if (clientRequests != null) {
+                result.addAll(clientRequests);
+            }
+        }
+        return Collections.unmodifiableCollection(result);
+    }
+
+    @Override
+    public void moveTop(final QueueRequest queueRequest) {
+        queueReactor.addTask(new QueueTask() {
+            @Override
+            public void run() {
+                Client client = queueRequest.getClient();
+                List<SequenceId> clientSequences = sequences.get(client.getEndpoint());
+                SequenceId sequenceId = queueRequest.getSequenceId();
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf > 0) {
+                    clientSequences.remove(indexOf);
+                    clientSequences.add(0, sequenceId);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void moveSequenceTop(final String endpoint, final SequenceId sequenceId) {
+        queueReactor.addTask(new QueueTask() {
+            @Override
+            public void run() {
+                List<SequenceId> clientSequences = sequences.get(endpoint);
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf > 0) {
+                    clientSequences.remove(indexOf);
+                    clientSequences.add(0, sequenceId);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void moveBottom(final QueueRequest queueRequest) {
+        queueReactor.addTask(new QueueTask() {
+            @Override
+            public void run() {
+                Client client = queueRequest.getClient();
+                List<SequenceId> clientSequences = sequences.get(client.getEndpoint());
+                SequenceId sequenceId = queueRequest.getSequenceId();
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf < clientSequences.size() - 1) {
+                    clientSequences.remove(indexOf);
+                    clientSequences.add(sequenceId);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void moveSequenceBottom(final String endpoint, final SequenceId sequenceId) {
+        queueReactor.addTask(new QueueTask() {
+
+            @Override
+            public void run() {
+                List<SequenceId> clientSequences = sequences.get(endpoint);
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf < clientSequences.size() - 1) {
+                    clientSequences.remove(indexOf);
+                    clientSequences.add(sequenceId);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void moveUp(final QueueRequest queueRequest) {
+        queueReactor.addTask(new QueueTask() {
+
+            @Override
+            public void run() {
+                Client client = queueRequest.getClient();
+                List<SequenceId> clientSequences = sequences.get(client.getEndpoint());
+                SequenceId sequenceId = queueRequest.getSequenceId();
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf > 0) {
+                    Collections.swap(clientSequences, indexOf, indexOf - 1);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void moveSequenceUp(final String endpoint, final SequenceId sequenceId) {
+        queueReactor.addTask(new QueueTask() {
+
+            @Override
+            public void run() {
+                List<SequenceId> clientSequences = sequences.get(endpoint);
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf > 0) {
+                    Collections.swap(clientSequences, indexOf, indexOf - 1);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void moveDown(final QueueRequest queueRequest) {
+        queueReactor.addTask(new QueueTask() {
+            @Override
+            public void run() {
+                Client client = queueRequest.getClient();
+                List<SequenceId> clientSequences = sequences.get(client.getEndpoint());
+                SequenceId sequenceId = queueRequest.getSequenceId();
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf < clientSequences.size() - 1) {
+                    Collections.swap(clientSequences, indexOf, indexOf + 1);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void moveSequenceDown(final String endpoint, final SequenceId sequenceId) {
+        queueReactor.addTask(new QueueTask() {
+            @Override
+            public void run() {
+                List<SequenceId> clientSequences = sequences.get(endpoint);
+                int indexOf = clientSequences.indexOf(sequenceId);
+                if (indexOf < clientSequences.size() - 1) {
+                    Collections.swap(clientSequences, indexOf, indexOf + 1);
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void dropRequest(final QueueRequest queueRequest) {
+        queueReactor.addTask(new QueueTask() {
+            @Override
+            public void run() {
+                SequenceId sequenceId = queueRequest.getSequenceId();
+                if (!sequenceId.isSet()) {
+                    throw new IllegalStateException("unable to drop unqueued request");
+                }
+                Client client = queueRequest.getClient();
+                String endpoint = client.getEndpoint();
+                if (requests.containsKey(sequenceId)) {
+                    List<QueueRequest> listRequests = requests.get(sequenceId);
+                    listRequests.remove(queueRequest);
+                    if (listRequests.isEmpty()) {
+                        requests.remove(sequenceId);
+                        List<SequenceId> listSequences = sequences.get(endpoint);
+                        listSequences.remove(sequenceId);
+                        listRequests = null;
+                    }
+                }
+            }
+
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public void dropSequence(final String endpoint, final SequenceId sequenceId) {
+        queueReactor.addTask(new QueueTask() {
+            @Override
+            public void run() {
+                if (!sequenceId.isSet()) {
+                    throw new IllegalStateException("unable to drop illegal sequence ID");
+                }
+                if (requests.containsKey(sequenceId)) {
+                    requests.remove(sequenceId);
+                    List<SequenceId> listSequences = sequences.get(endpoint);
+                    listSequences.remove(sequenceId);
+                }
+            }
+            @Override
+            public boolean wouldBlock() {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public Set<String> getEndpoints() {
+        return Collections.unmodifiableSet(sequences.keySet());
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/ResponseContext.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/ResponseContext.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.impl;
+
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ResponseCallback;
+
+/**
+ * Response context is a holder for response and error callbacks.
+ */
+public interface ResponseContext {
+
+    /**
+     * @return response callback
+     */
+    ResponseCallback<? extends LwM2mResponse> getResponseCallback();
+
+    /**
+     * @return error callback
+     */
+    ErrorCallback getErrorCallback();
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/DeferredTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/DeferredTask.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.reactor;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.server.queue.QueueTask;
+
+/**
+ * A deferred task does not execute immediately, but schedules the task to be executed after the given delay.
+ */
+public class DeferredTask implements QueueTask {
+
+    private static final ScheduledExecutorService DEFERRED_TASK_EXECUTOR = Executors.newSingleThreadScheduledExecutor();
+
+    private long period;
+    private TimeUnit unit;
+    private QueueTask task;
+
+    /**
+     * Creates a task, which execution is deferred after the given delay.
+     *
+     * @param period delay to wait until execution
+     * @param unit time unit of delay
+     * @param task task to be executed
+     */
+    public DeferredTask(long period, TimeUnit unit, QueueTask task) {
+        this.period = period;
+        this.unit = unit;
+        this.task = task;
+    }
+
+    @Override
+    public void run() {
+        DEFERRED_TASK_EXECUTOR.schedule(task, period, unit);
+    }
+
+    @Override
+    public boolean wouldBlock() {
+        return false;
+    }
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/QueueProcessingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/QueueProcessingTask.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.reactor;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueTask;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.eclipse.leshan.server.queue.impl.ResponseContext;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
+
+/**
+ * The queue processing task is intended to check the queue and to promote the requests in their next state, if
+ * necessary. This queue processing task has two modes of operation: queue processing only (without sending of pending
+ * requests) or full queue processing inclusively sending of the pending requests.
+ */
+public class QueueProcessingTask implements QueueTask {
+
+    private boolean mayTriggerSend;
+    private RequestQueue requestQueue;
+    private Client client;
+    private QueueReactor queueReactor;
+    private long deferPeriod;
+    private TimeUnit deferTimeUnit;
+    private LwM2mRequestSender requestSender;
+    private Long requestTimeout;
+    private Map<Long, ResponseContext> responseContext;
+
+    /**
+     * Creates a new QueueProcessingTask with given parameters,
+     *
+     * @param requestSender request sender to use
+     * @param responseContext map with response contexts for response mapping
+     * @param requestQueue request queue to get requests from
+     * @param client LWM2M client
+     * @param queueReactor queue reactor for scheduling tasks
+     * @param deferPeriod time amount to defer (reschedule the task to process later again)
+     * @param deferTimeUnit time unit to defer
+     * @param requestTimeout how long for request to time out
+     * @param mayTriggerSend if the queue processing task may trigger sending or just tidying up the queue.
+     */
+    public QueueProcessingTask(final LwM2mRequestSender requestSender,
+            final Map<Long, ResponseContext> responseContext, final RequestQueue requestQueue, final Client client,
+            final QueueReactor queueReactor, final long deferPeriod, final TimeUnit deferTimeUnit,
+            final Long requestTimeout, final boolean mayTriggerSend) {
+        this.requestSender = requestSender;
+        this.responseContext = responseContext;
+        this.requestQueue = requestQueue;
+        this.client = client;
+        this.queueReactor = queueReactor;
+        this.deferPeriod = deferPeriod;
+        this.deferTimeUnit = deferTimeUnit;
+        this.requestTimeout = requestTimeout;
+        this.mayTriggerSend = mayTriggerSend;
+    }
+
+    @Override
+    public void run() {
+
+        Iterator<QueueRequest> iterator = requestQueue.getRequests(client.getEndpoint()).iterator();
+
+        while (iterator.hasNext()) {
+
+            // we have to find first ENQUEUED or DEFERRED request which is still valid
+            boolean shouldProceedToNextRequest = false;
+
+            QueueRequest queueRequest = iterator.next();
+
+            switch (queueRequest.getRequestState()) {
+            case ENQUEUED:
+                if (!isEnqueuedRequestPromoted(queueRequest)) {
+                    if (mayTriggerSend) {
+                        queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue,
+                                RequestState.PROCESSING));
+                        queueReactor.addTask(new RequestSendingTask(requestSender, responseContext, client,
+                                queueRequest, requestQueue, queueReactor, deferPeriod, deferTimeUnit, requestTimeout));
+                    }
+                }
+                break;
+            case DEFERRED:
+                if (!isDeferredRequestPromoted(queueRequest)) {
+                    if (mayTriggerSend) {
+                        queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue,
+                                RequestState.PROCESSING));
+                        queueReactor.addTask(new RequestSendingTask(requestSender, responseContext, client,
+                                queueRequest, requestQueue, queueReactor, deferPeriod, deferTimeUnit, requestTimeout));
+                    }
+                }
+                break;
+            case TTL_ELAPSED:
+                tryPromoteTtlElapsedRequest(queueRequest);
+                shouldProceedToNextRequest = true;
+                break;
+
+            case EXECUTED:
+                tryPromoteExecutedRequest(queueRequest);
+                shouldProceedToNextRequest = true;
+                break;
+
+            case PROCESSING:
+                // some worker is sending right now, do nothing here
+                break;
+
+            default:
+                throw new IllegalStateException("request is in unknown or invalid state "
+                        + queueRequest.getRequestState());
+            }
+            // queue is still not empty and we are not know if we will be triggered from client again,
+            // so postpone a task for checking the queue later.
+            if (!shouldProceedToNextRequest) {
+                if (!mayTriggerSend) {
+                    queueReactor.addTask(new DeferredTask(deferPeriod, deferTimeUnit, new QueueProcessingTask(
+                            requestSender, responseContext, requestQueue, client, queueReactor, deferPeriod,
+                            deferTimeUnit, requestTimeout, false)));
+                }
+                break;
+            }
+        }
+    }
+
+    private void tryPromoteTtlElapsedRequest(QueueRequest queueRequest) {
+        if (queueRequest.isKeepExpirationReached()) {
+            queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.UNKNOWN));
+        }
+    }
+
+    private void tryPromoteExecutedRequest(QueueRequest queueRequest) {
+        if (queueRequest.isKeepExpirationReached()) {
+            queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.UNKNOWN));
+        }
+    }
+
+    private boolean isEnqueuedRequestPromoted(QueueRequest queueRequest) {
+        if (queueRequest.isSendExpirationReached()) {
+            if (queueRequest.isKeepExpirationReached()) {
+                queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.UNKNOWN));
+                return true;
+            } else {
+                queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.TTL_ELAPSED));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isDeferredRequestPromoted(QueueRequest queueRequest) {
+        if (queueRequest.isSendExpirationReached()) {
+            if (queueRequest.isKeepExpirationReached()) {
+                queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.UNKNOWN));
+                return true;
+            } else {
+                queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.TTL_ELAPSED));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean wouldBlock() {
+        return false;
+    }
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/QueuePurgeTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/QueuePurgeTask.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.reactor;
+
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueTask;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This queue task can be used to purge the queue for a specified client (endpoint).
+ */
+public class QueuePurgeTask implements QueueTask {
+
+    private final Logger LOG = LoggerFactory.getLogger(QueuePurgeTask.class);
+    private RequestQueue requestQueue;
+    private String endpoint;
+
+    /**
+     * Creates a new queue purge task.
+     *
+     * @param endpoint endpoint name of the client to purge the queue for.
+     */
+    public QueuePurgeTask(RequestQueue requestQueue, String endpoint) {
+        this.requestQueue = requestQueue;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public void run() {
+
+        for (final QueueRequest queueRequest : requestQueue.getRequests(endpoint)) {
+            LOG.trace("purging request {} for client {}", queueRequest.getDownlinkRequest(), queueRequest.getClient()
+                    .getEndpoint());
+            requestQueue.unqueueRequest(queueRequest);
+        }
+    }
+
+    @Override
+    public boolean wouldBlock() {
+        return false;
+    }
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/QueueReactorImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/QueueReactorImpl.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.reactor;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.server.queue.QueueTask;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This simple reactor implementation allows concurrent processing of the requests without changing the order of
+ * execution. Because of a highly concurrent nature of the Queue Mode (responses from clients may arrive anytime,
+ * changing the state of the pending requests, as well as the queue management can do at the same time), this reactor
+ * serves as a scheduler for queue tasks, which can run in the same thread of execution (non-blocking tasks) or in a
+ * separate worker thread (blocking tasks).
+ *
+ * @see QueueTask
+ */
+public class QueueReactorImpl implements QueueReactor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueueReactorImpl.class);
+
+    private final BlockingQueue<QueueTask> commands = new LinkedBlockingDeque<>();
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final ExecutorService workerExecutorService;
+
+    /**
+     * Creates a new queue reactor with a given size of pool workers.
+     *
+     * @param workerPoolSize size of pool workers. This size determines how many of the <i>blocking</i> tasks can be run
+     *        in parallel. For instance, a RequestSendingTask is such a blocking task, because it blocks for ACK_TIMEOUT
+     *        time.
+     */
+    public QueueReactorImpl(int workerPoolSize) {
+        int workers = workerPoolSize <= 0 ? Runtime.getRuntime().availableProcessors() : workerPoolSize;
+        workerExecutorService = Executors.newFixedThreadPool(workers);
+    }
+
+    @Override
+    public void addTask(QueueTask task) {
+        try {
+            commands.put(task);
+        } catch (InterruptedException e) {
+            LOG.warn("queue task could not be added");
+        }
+    }
+
+    @Override
+    public void start() {
+        executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    while (true) {
+                        QueueTask task = commands.take();
+                        if (task.wouldBlock()) {
+                            workerExecutorService.submit(task);
+                        } else {
+                            task.run();
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    workerExecutorService.shutdownNow();
+                    LOG.info("queue reactor processing was interrupted");
+                }
+            }
+        });
+    }
+
+    @Override
+    public void stop(long timeout, TimeUnit timeUnit) {
+        executorService.shutdown();
+        try {
+            boolean termination = executorService.awaitTermination(timeout, timeUnit);
+            if (!termination) {
+                LOG.warn("Queue reactor could not be terminated within expected timeout");
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("queue reactor was terminated while shutting down");
+        }
+    }
+
+    /**
+     * Stops using default grace period of 5 seconds.
+     */
+    public void stop() {
+        stop(5, TimeUnit.SECONDS);
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/RequestSendingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/RequestSendingTask.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.reactor;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueTask;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.eclipse.leshan.server.queue.impl.ResponseContext;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This blocking queue task is intended for the actual sending of an outstanding DownlinkRequest. The request timeout
+ * exception is handled separately here, because it leads the request to be DEFERRED for later execution.
+ */
+public class RequestSendingTask implements QueueTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RequestSendingTask.class);
+
+    private LwM2mRequestSender requestSender;
+    private Client client;
+    private QueueRequest queueRequest;
+    private QueueReactor queueReactor;
+    private Long requestTimeout;
+    private RequestQueue requestQueue;
+    private long queueCleaningPeriod;
+    private TimeUnit queueCleaningTimeUnit;
+    private Map<Long, ResponseContext> responseContext;
+
+    /**
+     * Creates a new sending task with given parameters.
+     *
+     * @param requestSender
+     * @param responseContext
+     * @param client
+     * @param queueRequest
+     * @param requestQueue
+     * @param queueReactor
+     * @param queueCleaningPeriod
+     * @param queueCleaningTimeUnit
+     * @param requestTimeout
+     */
+    public RequestSendingTask(LwM2mRequestSender requestSender, Map<Long, ResponseContext> responseContext,
+            Client client, QueueRequest queueRequest, RequestQueue requestQueue, QueueReactor queueReactor,
+            long queueCleaningPeriod, TimeUnit queueCleaningTimeUnit, Long requestTimeout) {
+
+        this.requestSender = requestSender;
+        this.responseContext = responseContext;
+        this.client = client;
+        this.queueRequest = queueRequest;
+        this.requestQueue = requestQueue;
+        this.queueReactor = queueReactor;
+        this.queueCleaningPeriod = queueCleaningPeriod;
+        this.queueCleaningTimeUnit = queueCleaningTimeUnit;
+        this.requestTimeout = requestTimeout;
+    }
+
+    @Override
+    public void run() {
+
+        try {
+            LOG.debug("sending request: {}", queueRequest.getDownlinkRequest());
+
+            LwM2mResponse response = requestSender.send(client, queueRequest.getDownlinkRequest(), requestTimeout);
+
+            if (response == null) {
+                // timeout
+                LOG.debug("request timed out: {}", queueRequest.getDownlinkRequest());
+                queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.DEFERRED));
+                queueReactor.addTask(new QueueProcessingTask(requestSender, responseContext, requestQueue, client,
+                        queueReactor, queueCleaningPeriod, queueCleaningTimeUnit, requestTimeout, false));
+            } else {
+                LOG.debug("request is sent successfully: {}", queueRequest.getDownlinkRequest());
+
+                queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.EXECUTED));
+                queueReactor.addTask(new ResponseProcessingTask(queueRequest, responseContext, response));
+                queueReactor.addTask(new QueueProcessingTask(requestSender, responseContext, requestQueue, client,
+                        queueReactor, queueCleaningPeriod, queueCleaningTimeUnit, requestTimeout, true));
+            }
+
+        } catch (Exception e) {
+            LOG.debug("exception on sending the request: {}", queueRequest.getDownlinkRequest());
+
+            queueReactor.addTask(new StateTransitionTask(queueRequest, requestQueue, RequestState.EXECUTED));
+            queueReactor.addTask(new ResponseProcessingTask(queueRequest, responseContext, e));
+            queueReactor.addTask(new QueueProcessingTask(requestSender, responseContext, requestQueue, client,
+                    queueReactor, queueCleaningPeriod, queueCleaningTimeUnit, requestTimeout, true));
+        }
+    }
+
+    @Override
+    public boolean wouldBlock() {
+        return true;
+    }
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/ResponseProcessingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/ResponseProcessingTask.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.reactor;
+
+import java.util.Map;
+
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueRequestSender;
+import org.eclipse.leshan.server.queue.QueueTask;
+import org.eclipse.leshan.server.queue.impl.ResponseContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A response processing task is responsible for calling back the registered listeners with response or error result.
+ *
+ * @see QueueRequestSender
+ */
+public class ResponseProcessingTask implements QueueTask {
+
+    private final Logger LOG = LoggerFactory.getLogger(ResponseProcessingTask.class);
+
+    private Exception exception;
+    private boolean hasException;
+    private LwM2mResponse response;
+    private Map<Long, ResponseContext> responseContext;
+    private QueueRequest queueRequest;
+
+    /**
+     * Creates a new task for processing response on exception.
+     *
+     * @param queueRequest request being processed
+     * @param responseContext response context map for mapping response ID to the callback
+     * @param exception exception to propagate
+     */
+    public ResponseProcessingTask(QueueRequest queueRequest, Map<Long, ResponseContext> responseContext,
+            Exception exception) {
+        this.queueRequest = queueRequest;
+        this.exception = exception;
+        this.hasException = true;
+    }
+
+    /**
+     * Creates a new task for processing response on an ordinary response result.
+     *
+     * @param queueRequest request being processed
+     * @param responseContext response context map for mapping response ID to the callback
+     * @param response response to propagate
+     */
+    public <T> ResponseProcessingTask(QueueRequest queueRequest, Map<Long, ResponseContext> responseContext,
+            LwM2mResponse response) {
+        this.queueRequest = queueRequest;
+        this.hasException = false;
+        this.responseContext = responseContext;
+        this.response = response;
+    }
+
+    @Override
+    public void run() {
+        Long responseId = queueRequest.getResponseId();
+        LOG.trace("response processing for {}, responseId: {}", queueRequest, responseId);
+
+        ResponseContext context = responseContext.get(responseId);
+
+        if (context != null) {
+            try {
+                if (hasException) {
+                    ErrorCallback errorCallback = context.getErrorCallback();
+                    if (errorCallback != null) {
+                        LOG.debug("calling response processor for response ID {} (on exception)", responseId);
+                        errorCallback.onError(exception);
+                    }
+                } else {
+                    ResponseCallback<LwM2mResponse> responseCallback = (ResponseCallback<LwM2mResponse>) context
+                            .getResponseCallback();
+                    if (responseCallback != null) {
+                        LOG.trace("calling response processor for response ID {} (on response)", responseId);
+                        responseCallback.onResponse(response);
+                    }
+                }
+            } finally {
+                responseContext.remove(responseId);
+            }
+        }
+    }
+
+    @Override
+    public boolean wouldBlock() {
+        return true;
+    }
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/StateTransitionTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/reactor/StateTransitionTask.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.reactor;
+
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.QueueTask;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * State transition task used for synchronization of transition operations for all queue requests.
+ */
+public class StateTransitionTask implements QueueTask {
+    private final static Logger LOG = LoggerFactory.getLogger(StateTransitionTask.class);
+
+    private RequestState newState;
+    private QueueRequest queueRequest;
+    private RequestQueue requestQueue;
+
+    /**
+     * Creates a new state transition task to apply the given new state to the given request.
+     *
+     * @param queueRequest queue request to transform
+     * @param requestQueue request queue
+     * @param newState new state to apply
+     */
+    public StateTransitionTask(QueueRequest queueRequest, RequestQueue requestQueue, RequestState newState) {
+        this.queueRequest = queueRequest;
+        this.requestQueue = requestQueue;
+        this.newState = newState;
+    }
+
+    @Override
+    public boolean wouldBlock() {
+        return false;
+    }
+
+    @Override
+    public void run() {
+
+        switch (newState) {
+        case ENQUEUED:
+            LOG.debug("{} -> ENQUEUED", queueRequest.getDownlinkRequest());
+            requestQueue.enqueueRequest(queueRequest);
+            break;
+        case DEFERRED:
+            LOG.debug("{} -> DEFERRED", queueRequest.getDownlinkRequest());
+            requestQueue.deferRequest(queueRequest);
+            break;
+        case PROCESSING:
+            LOG.debug("{} -> PROCESSING", queueRequest.getDownlinkRequest());
+            requestQueue.processingRequest(queueRequest);
+            break;
+        case TTL_ELAPSED:
+            LOG.debug("{} -> TTL_ELAPSED", queueRequest.getDownlinkRequest());
+            requestQueue.ttlElapsedRequest(queueRequest);
+            break;
+        case EXECUTED:
+            LOG.debug("{} -> EXECUTED", queueRequest.getDownlinkRequest());
+            requestQueue.executedRequest(queueRequest);
+            break;
+        case UNKNOWN:
+            LOG.debug("{} -> UNKNOWN (unqueue)", queueRequest.getDownlinkRequest());
+            requestQueue.unqueueRequest(queueRequest);
+            break;
+        default:
+            throw new IllegalStateException("attempted a transition to an invalid state: " + newState);
+        }
+    }
+}

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/QueueRequestTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/QueueRequestTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.response.ValueResponse;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.queue.impl.QueueRequestFactoryImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueRequestTest {
+
+    private static final long ONE_DAY_NANOS = 86400000000L;
+
+    @Mock
+    private Client clientMock;
+    @Mock
+    private DownlinkRequest<ValueResponse> downlinkRequestMock;
+
+    @Test
+    public void verifyCreatedRequestHasNoSequenceIdAssigned() throws Exception {
+        QueueRequestFactory queueRequestFactory = new QueueRequestFactoryImpl();
+
+        QueueRequest queueRequestUnderTest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                ONE_DAY_NANOS, ONE_DAY_NANOS, 123L);
+
+        assertEquals("sequence ID should be NONE", queueRequestUnderTest.getSequenceId(), SequenceId.NONE);
+    }
+}

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/QueueRequestFactoryImplTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/QueueRequestFactoryImplTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.response.ValueResponse;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.eclipse.leshan.server.queue.SequenceId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueRequestFactoryImplTest {
+    @Mock
+    private Client clientMock;
+    @Mock
+    private DownlinkRequest<ValueResponse> downlinkRequestMock;
+
+    private long sendExpiration = 10000L;
+    private long keepExpiration = 12000L;
+    private static final long RESPONSE_ID = 123L;
+
+    @Test
+    public void testCreateRequest() throws Exception {
+        QueueRequestFactoryImpl factoryUnderTest = new QueueRequestFactoryImpl();
+
+        QueueRequest queueRequest = factoryUnderTest.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        assertEquals("client is not the same", clientMock, queueRequest.getClient());
+        assertEquals("request is not the same", downlinkRequestMock, queueRequest.getDownlinkRequest());
+        assertEquals("request state is not as expected", RequestState.UNKNOWN, queueRequest.getRequestState());
+        assertEquals("sequence ID is not as expected", SequenceId.NONE, queueRequest.getSequenceId());
+    }
+
+    @Test
+    public void testTransformRequest() throws Exception {
+        QueueRequestFactoryImpl factoryUnderTest = new QueueRequestFactoryImpl();
+        QueueRequest queueRequest = factoryUnderTest.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        SequenceId sequenceId = new SequenceId(12345);
+
+        factoryUnderTest.transformRequest(queueRequest, sequenceId, RequestState.ENQUEUED);
+
+        assertEquals("sequence ID is not as expected", queueRequest.getSequenceId(), sequenceId);
+        assertEquals("request state is not as expected", queueRequest.getRequestState(), RequestState.ENQUEUED);
+    }
+}

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/QueueRequestSenderTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/QueueRequestSenderTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.impl;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.core.response.ValueResponse;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientRegistry;
+import org.eclipse.leshan.server.observation.ObservationRegistry;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.eclipse.leshan.server.queue.QueueRequestFactory;
+import org.eclipse.leshan.server.queue.RequestQueue;
+import org.eclipse.leshan.server.queue.reactor.QueueReactorImpl;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueRequestSenderTest {
+    @Mock
+    private Client clientMock;
+    @Mock
+    private LwM2mRequestSender requestSenderMock;
+    @Mock
+    private RequestQueue requestQueueMock;
+    @Mock
+    private QueueRequestFactory queueRequestFactoryMock;
+    @Mock
+    private DownlinkRequest<ValueResponse> downlinkRequestMock;
+    @Mock
+    private ResponseCallback<ValueResponse> responseCallbackMock;
+    @Mock
+    private ErrorCallback errorCallbackMock;
+    @Mock
+    private ClientRegistry clientRegistryMock;
+    @Mock
+    private ObservationRegistry observationRegistryMock;
+
+    private QueueReactor queueReactor = new QueueReactorImpl(2);
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void verifySynchronousSendThrows() throws Exception {
+        QueueRequestSenderImpl requestSenderUnderTest = new QueueRequestSenderImpl(queueReactor, requestQueueMock,
+                requestSenderMock, queueRequestFactoryMock, clientRegistryMock, observationRegistryMock, 2,
+                TimeUnit.MINUTES, 0L);
+        requestSenderUnderTest.send(clientMock, downlinkRequestMock, 0L);
+    }
+
+    @Test
+    public void verifySendForClientInNonQueueModeDelegates() throws Exception {
+
+        QueueRequestSenderImpl requestSenderUnderTest = new QueueRequestSenderImpl(queueReactor, requestQueueMock,
+                requestSenderMock, queueRequestFactoryMock, clientRegistryMock, observationRegistryMock, 2,
+                TimeUnit.MINUTES, 0L);
+        Mockito.when(clientMock.getBindingMode()).thenReturn(BindingMode.U);
+
+        requestSenderUnderTest.send(clientMock, downlinkRequestMock, responseCallbackMock, errorCallbackMock);
+
+        Mockito.verify(requestSenderMock)
+                .send(clientMock, downlinkRequestMock, responseCallbackMock, errorCallbackMock);
+    }
+}

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/RequestQueueImplTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/RequestQueueImplTest.java
@@ -1,0 +1,542 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Alexander Ellwein (Bosch Software Innovations GmbH)
+ *                     - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.response.ValueResponse;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.queue.QueueReactor;
+import org.eclipse.leshan.server.queue.QueueRequest;
+import org.eclipse.leshan.server.queue.RequestState;
+import org.eclipse.leshan.server.queue.SequenceId;
+import org.eclipse.leshan.server.queue.impl.QueueRequestFactoryImpl.QueueRequestImpl;
+import org.eclipse.leshan.server.queue.reactor.QueueReactorImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequestQueueImplTest {
+    private static final String ENDPOINT_ID = "myEndpoint";
+    @Mock
+    private Client clientMock;
+    @Mock
+    private QueueRequestImpl queueRequestMock;
+    @Mock
+    private DownlinkRequest<ValueResponse> downlinkRequestMock;
+
+    private QueueRequestFactoryImpl queueRequestFactory;
+    private QueueReactor queueReactor = new QueueReactorImpl(1);
+
+    private static final Long RESPONSE_ID = 123L;
+    private final long sendExpiration = 10000L;
+    private final long keepExpiration = 12000L;
+
+    @Before
+    public void before() {
+        Mockito.when(clientMock.getEndpoint()).thenReturn(ENDPOINT_ID);
+        queueRequestFactory = new QueueRequestFactoryImpl();
+        queueReactor.start();
+    }
+
+    @Test
+    public void verifySequenceIsSetAfterEnqueueRequest() throws Exception {
+        QueueRequest queueRequest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        SequenceId sequenceId = requestQueueUnderTest.enqueueRequest(queueRequest);
+
+        assertNotEquals("SequenceID was not set", SequenceId.NONE, sequenceId);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void verifyThatIsNotPossibleToEnqueueTwice() throws Exception {
+        QueueRequest queueRequest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        requestQueueUnderTest.enqueueRequest(queueRequest);
+        requestQueueUnderTest.enqueueRequest(queueRequest);
+    }
+
+    @Test
+    public void verifyStateIsChangedAfterEnqueueRequest() throws Exception {
+        QueueRequest queueRequest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+        requestQueueUnderTest.enqueueRequest(queueRequest);
+
+        assertEquals("State was not changed", RequestState.ENQUEUED, queueRequest.getRequestState());
+    }
+
+    @Test
+    public void verifyStateIsChangedAfterProcessingRequest() throws Exception {
+        QueueRequest queueRequest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+        requestQueueUnderTest.enqueueRequest(queueRequest);
+        requestQueueUnderTest.processingRequest(queueRequest);
+
+        assertEquals("State was not changed", RequestState.PROCESSING, queueRequest.getRequestState());
+    }
+
+    @Test
+    public void verifyStateIsChangedAfterDeferringRequest() throws Exception {
+        QueueRequest queueRequest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+        requestQueueUnderTest.enqueueRequest(queueRequest);
+        requestQueueUnderTest.deferRequest(queueRequest);
+
+        assertEquals("State was not changed", RequestState.DEFERRED, queueRequest.getRequestState());
+    }
+
+    @Test
+    public void verifyStateIsChangedAfterTtlElapsingRequest() throws Exception {
+        QueueRequest queueRequest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+        requestQueueUnderTest.enqueueRequest(queueRequest);
+        requestQueueUnderTest.ttlElapsedRequest(queueRequest);
+
+        assertEquals("State was not changed", RequestState.TTL_ELAPSED, queueRequest.getRequestState());
+    }
+
+    @Test
+    public void verifyStateIsChangedAfterExecutedRequest() throws Exception {
+        QueueRequest queueRequest = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+        requestQueueUnderTest.enqueueRequest(queueRequest);
+        requestQueueUnderTest.executedRequest(queueRequest);
+
+        assertEquals("State was not changed", RequestState.EXECUTED, queueRequest.getRequestState());
+    }
+
+    @Test
+    public void testGetSeparatedQueuedRequests() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        // create 2 queue requests
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest2);
+
+        Collection<QueueRequest> requests = requestQueueUnderTest.getRequests(clientMock.getEndpoint());
+
+        assertEquals("request queue has not the expected size", 2, requests.size());
+        Iterator<QueueRequest> iterator = requests.iterator();
+        assertEquals("first sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void testGetQueuedRequestsFromSameSequenceInRightOrder() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        // create 3 queue requests
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest3);
+        requestQueueUnderTest.enqueueRequest(queueRequest2, sequenceId1);
+
+        Collection<QueueRequest> requests = requestQueueUnderTest.getRequests(clientMock.getEndpoint());
+
+        assertEquals("request queue has not the expected size", 3, requests.size());
+        Iterator<QueueRequest> iterator = requests.iterator();
+        assertEquals("first sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+        assertEquals("third sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveRequestUpOverRequest() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest2);
+
+        requestQueueUnderTest.moveUp(queueRequest2);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveRequestUpOverSequence() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2, sequenceId1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest3);
+
+        requestQueueUnderTest.moveUp(queueRequest3);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+        assertEquals("third sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveSequenceUpOverRequest() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest2);
+        requestQueueUnderTest.enqueueRequest(queueRequest3, sequenceId2);
+
+        requestQueueUnderTest.moveSequenceUp(clientMock.getEndpoint(), sequenceId2);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("third sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveSequenceUpOverSequence() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest4 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2, sequenceId1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest3);
+        requestQueueUnderTest.enqueueRequest(queueRequest4, sequenceId2);
+
+        requestQueueUnderTest.moveSequenceUp(clientMock.getEndpoint(), sequenceId2);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("third sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+        assertEquals("fourth sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveRequestDownOverRequest() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest2);
+
+        requestQueueUnderTest.moveDown(queueRequest1);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveRequestDownOverSequence() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest2);
+        requestQueueUnderTest.enqueueRequest(queueRequest3, sequenceId2);
+
+        requestQueueUnderTest.moveDown(queueRequest1);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("third sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveSequenceDownOverRequest() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2, sequenceId1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest3);
+
+        requestQueueUnderTest.moveSequenceDown(clientMock.getEndpoint(), sequenceId1);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+        assertEquals("third sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveSequenceDownOverSequence() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest4 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2, sequenceId1);
+        SequenceId sequenceId2 = requestQueueUnderTest.enqueueRequest(queueRequest3);
+        requestQueueUnderTest.enqueueRequest(queueRequest4, sequenceId2);
+
+        requestQueueUnderTest.moveSequenceDown(clientMock.getEndpoint(), sequenceId1);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("first sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("second sequence ID did not match", sequenceId2, iterator.next().getSequenceId());
+        assertEquals("third sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+        assertEquals("fourth sequence ID did not match", sequenceId1, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveRequestTop() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2);
+        SequenceId sequenceId3 = requestQueueUnderTest.enqueueRequest(queueRequest3);
+
+        requestQueueUnderTest.moveTop(queueRequest3);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("request is not on top of the queue", sequenceId3, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveRequestBottom() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId1 = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2);
+        requestQueueUnderTest.enqueueRequest(queueRequest3);
+
+        requestQueueUnderTest.moveBottom(queueRequest1);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+       Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+       QueueRequest last = null;
+       while(iterator.hasNext()) {
+           last = iterator.next();
+       }
+        assertEquals("request is not on bottom of the queue", sequenceId1, last.getSequenceId());
+    }
+
+    @Test
+    public void moveSequenceTop() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest4 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2);
+        SequenceId sequenceId = requestQueueUnderTest.enqueueRequest(queueRequest3);
+        requestQueueUnderTest.enqueueRequest(queueRequest4, sequenceId);
+
+        requestQueueUnderTest.moveSequenceTop(clientMock.getEndpoint(), sequenceId);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        Iterator<QueueRequest> iterator = requestQueueUnderTest.getRequests(clientMock.getEndpoint()).iterator();
+        assertEquals("sequence is not on top of the queue", sequenceId, iterator.next().getSequenceId());
+    }
+
+    @Test
+    public void moveSequenceBottom() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest4 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        SequenceId sequenceId = requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2, sequenceId);
+        requestQueueUnderTest.enqueueRequest(queueRequest3);
+        requestQueueUnderTest.enqueueRequest(queueRequest4);
+
+        requestQueueUnderTest.moveSequenceBottom(clientMock.getEndpoint(), sequenceId);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        assertEquals("sequence is not on bottom of the queue", sequenceId, requestQueueUnderTest
+                .getRequests(clientMock.getEndpoint()).toArray(new QueueRequest[] {})[3].getSequenceId());
+    }
+
+    @Test
+    public void dropRequest() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2);
+
+        requestQueueUnderTest.dropRequest(queueRequest1);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        assertFalse("request was not removed", requestQueueUnderTest.getRequests(clientMock.getEndpoint()).contains(queueRequest1));
+    }
+
+    @Test
+    public void dropSequence() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest2 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest3 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+        QueueRequest queueRequest4 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.enqueueRequest(queueRequest2);
+        SequenceId sequenceId = requestQueueUnderTest.enqueueRequest(queueRequest3);
+        requestQueueUnderTest.enqueueRequest(queueRequest4, sequenceId);
+
+        requestQueueUnderTest.dropSequence(clientMock.getEndpoint(), sequenceId);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        assertEquals("queue has a wrong size", 2, requestQueueUnderTest.getRequests(clientMock.getEndpoint()).size());
+        assertFalse("first queue request is not removed",
+                requestQueueUnderTest.getRequests(clientMock.getEndpoint()).contains(queueRequest3));
+        assertFalse("second queue request is not removed",
+                requestQueueUnderTest.getRequests(clientMock.getEndpoint()).contains(queueRequest4));
+    }
+
+    @Test
+    public void unqueueRequest() throws Exception {
+        RequestQueueImpl requestQueueUnderTest = new RequestQueueImpl(queueRequestFactory, queueReactor);
+        QueueRequest queueRequest1 = queueRequestFactory.createQueuedRequest(clientMock, downlinkRequestMock,
+                sendExpiration, keepExpiration, RESPONSE_ID);
+
+        requestQueueUnderTest.enqueueRequest(queueRequest1);
+        requestQueueUnderTest.unqueueRequest(queueRequest1);
+        queueReactor.stop(100, TimeUnit.MILLISECONDS);
+
+        assertEquals("queue has a wrong size", 0, requestQueueUnderTest.getRequests(clientMock.getEndpoint()).size());
+    }
+
+}


### PR DESCRIPTION
Intro
-----

A "queue mode" is an operation mode of LWM2M protocol (since the early versions
of Lightweight M2M 1.0 Specification), which describes a special operation mode
of a server/client if a client is not always expected to be online.

The specification states that:

* A Client has to register using specified binding mode (e.g. using "UQ" for
  "UDP+Queue");
* A Server has to understand this binding mode (it is *mandatory*);
* A client is not expected to be always online - instead, a server must queue the
  requests and only allowed to send downlink requests one by one to the client
  when server received client's registration update
  (according to the spec, the client has to wait at least ACK_TIMEOUT seconds
  before it may go offline).

Basic Concepts
--------------

This implementation focuses on creating a new ``LwM2mRequestSender`` called
``QueueRequestSender``. This sender is meant to be a decoration for the already
existing ``CaliforniumLwM2mRequestSender`` and to provide only an asynchronous
mode sending. The queue sender is aware of client's binding mode and transparently
delegates the requests to the underlying ``CaliforniumRequestSender``, if a client
is not in queue mode. In case of queue mode operation, the ``QueueModeRequestSender``
maintains an in-memory request queue and the outstanding (Downlink-)request is
wrapped into ``QueueRequest`` object (with additional attributes, see below),
created by the ``QueueRequestFactory``, and is enqueued to the queue (with the
status "ENQUEUED", see below for the request state descriptions). The queue is
processed by the queue reactor, which schedules the queue tasks, responsible
for queue processing and request state transitions.

The queue requests are created as single requests by default. It is also
possible to create queue request sequences, i.e. a sequence of requests which
keeps the sequential order inside the sequence and allows to priorize the
request sequences up and down across the queue (see "Queue Management").

Queue Persistence
-----------------

In the current implementation, the request queue (or queues, as they are
organized per client) are persisted only in memory, however, one can easily
replace a ``RequestQueue`` implementation to provide, for instance, a DB-based
queue persistence. The ``QueueRequestSender`` supports, along with the usual
request sending timeout, two configurable intervals. These are:

* send expiration interval - how long should the queue sender try to send a request
  before it gets expired or no longer needed;

* keep expiration interval - how long should the queue keep the requests (even
  elapsed ones) archived in the queue for the history purpose.

Queue Request States
--------------------

1. A fresh created queue request which is sent via ``QueueRequestSender`` is
put in the queue with the state ``ENQUEUED``. A request remains in this state,
until the destination client sends registration update or a notify. (exception:
client has not yet updated for its first time, so the queue will try to send
the request as best effort as soon as possible).

2. A client's update or notify triggers a queue request to be put in
``PROCESSING`` state. This indicates that the queue request is currently being
sent. For every client, there can be only one request in a processing state,
because all of the requests are processed strictly sequential (per client).

3a. If a processing request is timed out, it returns to the queue with the
state ``DEFERRED``. This means, that after next client's update/notify this
request will be sent as first (unless the send expiration interval is
already elapsed, in this case it will be put into ``TTL_ELAPSED`` state as
described in 4a.)

3b. If a processing request could be sent, then it is put into ``EXECUTED``
state. The request remains archived in the queue with this state, until
a keep expiration interval is elapsed.

4a. A ``DEFERRED`` request, which could not be sent at all, is put into
``TTL_ELAPSED`` state. It is kept in the queue, until the keep expiration
interval elapses.

Queue Management
----------------

The additional ``QueueManagement`` interface provides basic functionality
for managing requests in the queue. The management includes following
functions:

* move a single request up/down the queue;
* move a single request to the top/bottom of the queue;
* move a request sequence up/down the queue;
* move a request sequence to the top/bottom of the queue.
* drop a single request or request sequence.

Limitations
-----------

As said before, this particular implementation of the queue mode allows
only an in-memory persistence of the request queue. The queue management
also lacks a frontend/UI or REST API and is also limited to programmatic
management only. However, there are possibilities for extension of the
functionality upon the defined interfaces:

* ``RequestQueue``
* ``QueueManagement``
* ``QueueRequest``
* ``QueueRequestFactory``

and so on.

Signed-off-by: Alexander Ellwein <alexander.ellwein@bosch-si.com>