### PR TITLE
Fix for IPV6 host:port using environment variables

### DIFF
--- a/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/LeshanStandalone.java
+++ b/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/LeshanStandalone.java
@@ -60,12 +60,12 @@ public class LeshanStandalone {
         // Build LWM2M server
         LeshanServerBuilder builder = new LeshanServerBuilder();
         if (iface != null && !iface.isEmpty()) {
-            String[] add = iface.split(":");
-            builder.setLocalAddress(add[0], Integer.parseInt(add[1]));
+            builder.setLocalAddress(iface.substring(0, iface.lastIndexOf(':')),
+                Integer.parseInt(iface.substring(iface.lastIndexOf(':') + 1, iface.length())));
         }
         if (ifaces != null && !ifaces.isEmpty()) {
-            String[] adds = ifaces.split(":");
-            builder.setLocalAddressSecure(adds[0], Integer.parseInt(adds[1]));
+            builder.setLocalAddress(ifaces.substring(0, ifaces.lastIndexOf(':')),
+                Integer.parseInt(ifaces.substring(ifaces.lastIndexOf(':') + 1, ifaces.length())));
         }
 
         // Get public and private server key


### PR DESCRIPTION
While using Leshan I noticed that when trying to set the address and port using COAPIFACE or COAPSIFACE for IPV6 it would result in an error. This is a quick fix for that, now something like this will work :
export COAPIFACE=2001:d::1:4242 && java -jar target/leshan-standalone-0.1.11-M6-SNAPSHOT-jar-with-dependencies.jar (where 4242 is the desired port)