### PR TITLE
Add Observation to Observe request response

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
@@ -35,6 +35,7 @@ import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ValueResponse;
 import org.eclipse.leshan.server.observation.Observation;
 import org.eclipse.leshan.server.observation.ObservationRegistryListener;
+import org.eclipse.leshan.server.response.ObserveResponse;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,9 +66,16 @@ public class ObserveTest {
         TestObservationListener listener = new TestObservationListener();
         helper.server.getObservationRegistry().addListener(listener);
 
-        // observe devive timezone
+        // observe device timezone
         ValueResponse response = helper.server.send(helper.getClient(), new ObserveRequest(3, 0, 15));
         assertEquals(ResponseCode.CONTENT, response.getCode());
+
+        // an observation response should have been sent
+        assertTrue(response instanceof ObserveResponse);
+        ObserveResponse observeResponse = (ObserveResponse) response;
+        Observation observation = observeResponse.getObservation();
+        assertEquals("/3/0/15", observation.getPath().toString());
+        assertEquals(helper.getClient(), observation.getClient());
 
         // write device timezone
         LwM2mResource newValue = new LwM2mResource(15, Value.newStringValue("Europe/Paris"));

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ObserveResponse.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ObserveResponse.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.response;
+
+import org.eclipse.leshan.ResponseCode;
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.response.ValueResponse;
+import org.eclipse.leshan.server.observation.Observation;
+
+/**
+ * Specialized ValueResponse to a Observe request, with the corresponding Observation.
+ *
+ * This can be useful to listen to updates on the specific Observation.
+ */
+public class ObserveResponse extends ValueResponse {
+
+    private Observation observation;
+
+    public ObserveResponse(ResponseCode code, Observation observation) {
+        this(code, null, observation);
+    }
+
+    public ObserveResponse(ResponseCode code, LwM2mNode content, Observation observation) {
+        super(code, content);
+        this.observation = observation;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ObserveResponse [content=%s, code=%s, observation=%s]", this.getContent(), this.getCode(),
+                observation);
+    }
+
+    public Observation getObservation() {
+        return observation;
+    }
+}


### PR DESCRIPTION
A subclass of ValueResponse is used to get the
Observation created during an Observe request.

Signed-off-by: Pierre-Henri Trivier <phtrivier@sierrawireless.com>