### PR TITLE
Fix TLV identifier serialization and COAPs support

### DIFF
--- a/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/LeshanStandalone.java
+++ b/leshan-standalone/src/main/java/org/eclipse/leshan/standalone/LeshanStandalone.java
@@ -64,7 +64,7 @@ public class LeshanStandalone {
                 Integer.parseInt(iface.substring(iface.lastIndexOf(':') + 1, iface.length())));
         }
         if (ifaces != null && !ifaces.isEmpty()) {
-            builder.setLocalAddress(ifaces.substring(0, ifaces.lastIndexOf(':')),
+            builder.setLocalAddressSecure(ifaces.substring(0, ifaces.lastIndexOf(':')),
                 Integer.parseInt(ifaces.substring(ifaces.lastIndexOf(':') + 1, ifaces.length())));
         }
 


### PR DESCRIPTION
* Current head build does not work at all with setting COAPIFACES, as the value is not propagated to the correct setter
* TLV identifiers in the range 8-16 bit are not serialized according to spec