### PR TITLE
Now the bootstrap server send end-of-boostrap message

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
@@ -114,7 +114,7 @@ public class BootstrapResource extends CoapResource {
                 deleteAll.setDestination(exchange.getSourceAddress());
                 deleteAll.setDestinationPort(exchange.getSourcePort());
 
-                deleteAll.send(e).addMessageObserver(new MessageObserver() {
+                deleteAll.addMessageObserver( new MessageObserver() {
 
                     @Override
                     public void onTimeout() {
@@ -148,6 +148,7 @@ public class BootstrapResource extends CoapResource {
                         LOG.debug("Bootstrap delete {} acknowledgement", endpoint);
                     }
                 });
+                deleteAll.send(e);
             }
         });
     }
@@ -171,7 +172,7 @@ public class BootstrapResource extends CoapResource {
             postSecurity.setDestinationPort(targetPort);
             postSecurity.setPayload(encoded.array());
 
-            postSecurity.send(e).addMessageObserver(new MessageObserver() {
+            postSecurity.addMessageObserver(new MessageObserver() {
 
                 @Override
                 public void onTimeout() {
@@ -205,6 +206,7 @@ public class BootstrapResource extends CoapResource {
                     LOG.debug("Bootstrap security {} acknowledgement", endpoint);
                 }
             });
+            postSecurity.send(e);
 
         } else {
             // we are done, send the servers
@@ -231,7 +233,7 @@ public class BootstrapResource extends CoapResource {
             postServer.setDestination(targetAddress);
             postServer.setDestinationPort(targetPort);
             postServer.setPayload(encoded.array());
-            postServer.send(e).addMessageObserver(new MessageObserver() {
+            postServer.addMessageObserver(new MessageObserver() {
                 @Override
                 public void onTimeout() {
                     LOG.debug("Bootstrap servers {} timeout!", endpoint);
@@ -264,6 +266,7 @@ public class BootstrapResource extends CoapResource {
                     LOG.debug("Bootstrap servers {} acknowledgement", endpoint);
                 }
             });
+            postServer.send(e);
 
         } else {
             // done

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
@@ -268,6 +268,42 @@ public class BootstrapResource extends CoapResource {
         } else {
             // done
             LOG.debug("Bootstrap session done for endpoint {}", endpoint);
+            Request postServer = Request.newPost();
+            postServer.getOptions().addUriPath("bs");
+            postServer.setConfirmable(true);
+            postServer.setDestination(targetAddress);
+            postServer.setDestinationPort(targetPort);
+            postServer.send(e).addMessageObserver(new MessageObserver() {
+                @Override
+                public void onTimeout() {
+                    LOG.debug("End bootstrap for {} timeout!", endpoint);
+                }
+
+                @Override
+                public void onRetransmission() {
+                    LOG.debug("End bootstrap for {} retransmission", endpoint);
+                }
+
+                @Override
+                public void onResponse(Response response) {
+                    LOG.debug("End bootstrap for {} return code {}", endpoint, response.getCode());
+                }
+
+                @Override
+                public void onReject() {
+                    LOG.debug("End bootstrap for {} reject", endpoint);
+                }
+
+                @Override
+                public void onCancel() {
+                    LOG.debug("End bootstrap for {} cancel", endpoint);
+                }
+
+                @Override
+                public void onAcknowledgement() {
+                    LOG.debug("End bootstrap for {} acknowledgement", endpoint);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Following last spec revision, when the bootstrap is done we send a POST /bs to the device