### PR TITLE
Added Optional Registration Parameter (as a Map)

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
@@ -15,6 +15,9 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.leshan.LinkObject;
 import org.eclipse.leshan.core.response.RegisterResponse;
 
@@ -30,6 +33,7 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
     private final BindingMode bindingMode;
     private final String smsNumber;
     private final LinkObject[] objectLinks;
+    private final Map<String, String> queryParameters;
 
     public RegisterRequest(String endpointName) {
         this.endpointName = endpointName;
@@ -38,16 +42,18 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         this.bindingMode = null;
         this.smsNumber = null;
         this.objectLinks = null;
+        this.queryParameters = new HashMap<String, String>();
     }
 
     public RegisterRequest(String endpointName, Long lifetime, String lwVersion, BindingMode bindingMode,
-            String smsNumber, LinkObject[] objectLinks) {
+            String smsNumber, LinkObject[] objectLinks, Map<String, String> queryParameters) {
         this.endpointName = endpointName;
         this.lifetime = lifetime;
         this.lwVersion = lwVersion;
         this.bindingMode = bindingMode;
         this.smsNumber = smsNumber;
         this.objectLinks = objectLinks;
+        this.queryParameters = queryParameters;
     }
 
     public String getEndpointName() {
@@ -74,8 +80,13 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         return objectLinks;
     }
 
+    public Map<String, String> getQueryParameters() {
+        return queryParameters;
+    }
+
     @Override
     public void accept(UplinkRequestVisitor visitor) {
         visitor.visit(this);
     }
+
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
     private final BindingMode bindingMode;
     private final String smsNumber;
     private final LinkObject[] objectLinks;
-    private final Map<String, String> otherParameters;
+    private final Map<String, String> additionalParameters;
 
     public RegisterRequest(String endpointName) {
         this.endpointName = endpointName;
@@ -42,18 +43,18 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         this.bindingMode = null;
         this.smsNumber = null;
         this.objectLinks = null;
-        this.otherParameters = new HashMap<String, String>();
+        this.additionalParameters = Collections.unmodifiableMap(new HashMap<String, String>());
     }
 
     public RegisterRequest(String endpointName, Long lifetime, String lwVersion, BindingMode bindingMode,
-            String smsNumber, LinkObject[] objectLinks, Map<String, String> queryParameters) {
+            String smsNumber, LinkObject[] objectLinks, Map<String, String> additionalParameters) {
         this.endpointName = endpointName;
         this.lifetime = lifetime;
         this.lwVersion = lwVersion;
         this.bindingMode = bindingMode;
         this.smsNumber = smsNumber;
         this.objectLinks = objectLinks;
-        this.otherParameters = queryParameters;
+        this.additionalParameters = Collections.unmodifiableMap(additionalParameters);
     }
 
     public String getEndpointName() {
@@ -80,8 +81,8 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         return objectLinks;
     }
 
-    public Map<String, String> getOtherParameters() {
-        return otherParameters;
+    public Map<String, String> getAdditionalParameters() {
+        return additionalParameters;
     }
 
     @Override

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
@@ -34,7 +34,7 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
     private final BindingMode bindingMode;
     private final String smsNumber;
     private final LinkObject[] objectLinks;
-    private final Map<String, String> additionalParameters;
+    private final Map<String, String> additionalAttributes;
 
     public RegisterRequest(String endpointName) {
         this.endpointName = endpointName;
@@ -43,18 +43,18 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         this.bindingMode = null;
         this.smsNumber = null;
         this.objectLinks = null;
-        this.additionalParameters = Collections.unmodifiableMap(new HashMap<String, String>());
+        this.additionalAttributes = Collections.unmodifiableMap(new HashMap<String, String>());
     }
 
     public RegisterRequest(String endpointName, Long lifetime, String lwVersion, BindingMode bindingMode,
-            String smsNumber, LinkObject[] objectLinks, Map<String, String> additionalParameters) {
+            String smsNumber, LinkObject[] objectLinks, Map<String, String> additionalAttributes) {
         this.endpointName = endpointName;
         this.lifetime = lifetime;
         this.lwVersion = lwVersion;
         this.bindingMode = bindingMode;
         this.smsNumber = smsNumber;
         this.objectLinks = objectLinks;
-        this.additionalParameters = Collections.unmodifiableMap(additionalParameters);
+        this.additionalAttributes = Collections.unmodifiableMap(additionalAttributes);
     }
 
     public String getEndpointName() {
@@ -81,8 +81,8 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         return objectLinks;
     }
 
-    public Map<String, String> getAdditionalParameters() {
-        return additionalParameters;
+    public Map<String, String> getAdditionalAttributes() {
+        return additionalAttributes;
     }
 
     @Override

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
@@ -33,7 +33,7 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
     private final BindingMode bindingMode;
     private final String smsNumber;
     private final LinkObject[] objectLinks;
-    private final Map<String, String> queryParameters;
+    private final Map<String, String> otherParameters;
 
     public RegisterRequest(String endpointName) {
         this.endpointName = endpointName;
@@ -42,7 +42,7 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         this.bindingMode = null;
         this.smsNumber = null;
         this.objectLinks = null;
-        this.queryParameters = new HashMap<String, String>();
+        this.otherParameters = new HashMap<String, String>();
     }
 
     public RegisterRequest(String endpointName, Long lifetime, String lwVersion, BindingMode bindingMode,
@@ -53,7 +53,7 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         this.bindingMode = bindingMode;
         this.smsNumber = smsNumber;
         this.objectLinks = objectLinks;
-        this.queryParameters = queryParameters;
+        this.otherParameters = queryParameters;
     }
 
     public String getEndpointName() {
@@ -80,8 +80,8 @@ public class RegisterRequest implements UplinkRequest<RegisterResponse> {
         return objectLinks;
     }
 
-    public Map<String, String> getQueryParameters() {
-        return queryParameters;
+    public Map<String, String> getOtherParameters() {
+        return otherParameters;
     }
 
     @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -18,7 +18,9 @@ package org.eclipse.leshan.server.californium.impl;
 import java.net.InetSocketAddress;
 import java.security.Principal;
 import java.security.PublicKey;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -167,9 +169,20 @@ public class RegisterResource extends CoapResource {
         if (request.getPayload() != null) {
             objectLinks = LinkObject.parse(request.getPayload());
         }
+
+        Map<String, String> registerParams = new HashMap<String, String>();
+        for (String param : request.getOptions().getUriQuery()) {
+            if (param != null) {
+                String[] tokens = param.split("\\=");
+                if (tokens != null && tokens.length == 2) {
+                    registerParams.put(tokens[0], tokens[1]);
+                }
+            }
+        }
+
         // Create request
         RegisterRequest registerRequest = new RegisterRequest(endpoint, lifetime, lwVersion, binding, smsNumber,
-                objectLinks);
+                objectLinks, registerParams);
 
         // Handle request
         // -------------------------------

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -88,6 +88,7 @@ public class RegisterResource extends CoapResource {
         try {
             super.handleRequest(exchange);
         } catch (Exception e) {
+            e.printStackTrace();
             LOG.error("Exception while handling a request on the /rd resource", e);
             exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
         }
@@ -151,6 +152,9 @@ public class RegisterResource extends CoapResource {
         String lwVersion = null;
         BindingMode binding = null;
         LinkObject[] objectLinks = null;
+
+        Map<String, String> registerParams = new HashMap<String, String>();
+
         // Get parameters
         for (String param : request.getOptions().getUriQuery()) {
             if (param.startsWith(QUERY_PARAM_ENDPOINT)) {
@@ -163,21 +167,16 @@ public class RegisterResource extends CoapResource {
                 lwVersion = param.substring(6);
             } else if (param.startsWith(QUERY_PARAM_BINDING_MODE)) {
                 binding = BindingMode.valueOf(param.substring(2));
-            }
-        }
-        // Get object Links
-        if (request.getPayload() != null) {
-            objectLinks = LinkObject.parse(request.getPayload());
-        }
-
-        Map<String, String> registerParams = new HashMap<String, String>();
-        for (String param : request.getOptions().getUriQuery()) {
-            if (param != null) {
+            } else {
                 String[] tokens = param.split("\\=");
                 if (tokens != null && tokens.length == 2) {
                     registerParams.put(tokens[0], tokens[1]);
                 }
             }
+        }
+        // Get object Links
+        if (request.getPayload() != null) {
+            objectLinks = LinkObject.parse(request.getPayload());
         }
 
         // Create request

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -88,7 +88,6 @@ public class RegisterResource extends CoapResource {
         try {
             super.handleRequest(exchange);
         } catch (Exception e) {
-            e.printStackTrace();
             LOG.error("Exception while handling a request on the /rd resource", e);
             exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
         }
@@ -153,7 +152,7 @@ public class RegisterResource extends CoapResource {
         BindingMode binding = null;
         LinkObject[] objectLinks = null;
 
-        Map<String, String> registerParams = new HashMap<String, String>();
+        Map<String, String> additionalParams = new HashMap<String, String>();
 
         // Get parameters
         for (String param : request.getOptions().getUriQuery()) {
@@ -170,7 +169,7 @@ public class RegisterResource extends CoapResource {
             } else {
                 String[] tokens = param.split("\\=");
                 if (tokens != null && tokens.length == 2) {
-                    registerParams.put(tokens[0], tokens[1]);
+                    additionalParams.put(tokens[0], tokens[1]);
                 }
             }
         }
@@ -181,7 +180,7 @@ public class RegisterResource extends CoapResource {
 
         // Create request
         RegisterRequest registerRequest = new RegisterRequest(endpoint, lifetime, lwVersion, binding, smsNumber,
-                objectLinks, registerParams);
+                objectLinks, additionalParams);
 
         // Handle request
         // -------------------------------

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CaliforniumTestSupport.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CaliforniumTestSupport.java
@@ -30,7 +30,11 @@ public class CaliforniumTestSupport {
 
     public void givenASimpleClient() throws UnknownHostException {
         registrationAddress = InetSocketAddress.createUnresolved("localhost", 5683);
-        client = new Client("ID", "urn:client", InetAddress.getLocalHost(), 10000, "1.0", 10000L, null, null, null,
+
+        Client.Builder builder = new Client.Builder("ID", "urn:client", InetAddress.getLocalHost(), 10000,
                 registrationAddress);
+
+        client = builder.build();
+
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
@@ -76,7 +76,7 @@ public class Client {
             Long lifetimeInSec, String smsNumber, BindingMode bindingMode, LinkObject[] objectLinks,
             InetSocketAddress registrationEndpointAddress,
 
-            Date registrationDate, Date lastUpdate, Map<String, String> otherRegistrationAttributes) {
+            Date registrationDate, Date lastUpdate, Map<String, String> additionalRegistrationAttributes) {
 
         Validate.notNull(registrationId);
         Validate.notEmpty(endpoint);
@@ -109,9 +109,9 @@ public class Client {
         this.bindingMode = bindingMode == null ? BindingMode.U : bindingMode;
         this.registrationDate = registrationDate == null ? new Date() : registrationDate;
         this.lastUpdate = lastUpdate == null ? new Date() : lastUpdate;
-        this.additionalRegistrationAttributes = otherRegistrationAttributes == null ? Collections
+        this.additionalRegistrationAttributes = additionalRegistrationAttributes == null ? Collections
                 .unmodifiableMap(new HashMap<String, String>()) : Collections
-                .unmodifiableMap(otherRegistrationAttributes);
+                .unmodifiableMap(additionalRegistrationAttributes);
 
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.server.client;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -64,7 +65,7 @@ public class Client {
 
     private final LinkObject[] objectLinks;
 
-    private Map<String, String> otherRegistrationAttributes = new HashMap<String, String>();
+    private Map<String, String> additionalRegistrationAttributes = new HashMap<String, String>();
 
     /** The location where LWM2M objects are hosted on the device */
     private final String rootPath;
@@ -109,8 +110,9 @@ public class Client {
         this.bindingMode = bindingMode == null ? BindingMode.U : bindingMode;
         this.registrationDate = registrationDate == null ? new Date() : registrationDate;
         this.lastUpdate = lastUpdate == null ? new Date() : lastUpdate;
-        this.otherRegistrationAttributes = otherRegistrationAttributes == null ? new HashMap<String, String>()
-                : otherRegistrationAttributes;
+        this.additionalRegistrationAttributes = otherRegistrationAttributes == null ? Collections
+                .unmodifiableMap(new HashMap<String, String>()) : Collections
+                .unmodifiableMap(otherRegistrationAttributes);
 
     }
 
@@ -273,12 +275,12 @@ public class Client {
         return lastUpdate.getTime() + lifeTimeInSec * 1000 > System.currentTimeMillis();
     }
 
-    public Map<String, String> getRegistrationQueryParams() {
-        return otherRegistrationAttributes;
+    public Map<String, String> getAdditionalRegistrationParams() {
+        return additionalRegistrationAttributes;
     }
 
-    public void setRegistrationQueryParams(Map<String, String> registrationQueryParams) {
-        this.otherRegistrationAttributes = registrationQueryParams;
+    public void setAdditionalRegistrationParams(Map<String, String> additionalRegistrationParams) {
+        this.additionalRegistrationAttributes = Collections.unmodifiableMap(additionalRegistrationParams);
     }
 
     @Override
@@ -329,7 +331,7 @@ public class Client {
         private BindingMode bindingMode;
         private String lwM2mVersion;
         private LinkObject[] objectLinks;
-        private Map<String, String> otherRegistrationAttributes;
+        private Map<String, String> additionalRegistrationAttributes;
 
         public Builder(String registrationId, String endpoint, InetAddress address, int port,
                 InetSocketAddress registrationEndpointAddress) {
@@ -382,8 +384,8 @@ public class Client {
             return this;
         }
 
-        public Builder otherRegistrationAttributes(Map<String, String> otherRegistrationAttributes) {
-            this.otherRegistrationAttributes = otherRegistrationAttributes;
+        public Builder additionalRegistrationAttributes(Map<String, String> additionalRegistrationAttributes) {
+            this.additionalRegistrationAttributes = additionalRegistrationAttributes;
             return this;
         }
 
@@ -391,7 +393,7 @@ public class Client {
             return new Client(Builder.this.registrationId, Builder.this.endpoint, Builder.this.address,
                     Builder.this.port, Builder.this.lwM2mVersion, Builder.this.lifeTimeInSec, Builder.this.smsNumber,
                     this.bindingMode, this.objectLinks, this.registrationEndpointAddress, this.registrationDate,
-                    this.lastUpdate, this.otherRegistrationAttributes);
+                    this.lastUpdate, this.additionalRegistrationAttributes);
         }
 
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
@@ -20,6 +20,8 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.leshan.LinkObject;
 import org.eclipse.leshan.core.request.BindingMode;
@@ -61,6 +63,8 @@ public class Client {
     private final String registrationId;
 
     private final LinkObject[] objectLinks;
+
+    private Map<String, String> registrationQueryParams = new HashMap<String, String>();
 
     /** The location where LWM2M objects are hosted on the device */
     private final String rootPath;
@@ -273,6 +277,14 @@ public class Client {
 
     public boolean isAlive() {
         return lastUpdate.getTime() + lifeTimeInSec * 1000 > System.currentTimeMillis();
+    }
+
+    public Map<String, String> getRegistrationQueryParams() {
+        return registrationQueryParams;
+    }
+
+    public void setRegistrationQueryParams(Map<String, String> registrationQueryParams) {
+        this.registrationQueryParams = registrationQueryParams;
     }
 
     @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
@@ -64,29 +64,21 @@ public class Client {
 
     private final LinkObject[] objectLinks;
 
-    private Map<String, String> registrationQueryParams = new HashMap<String, String>();
+    private Map<String, String> otherRegistrationAttributes = new HashMap<String, String>();
 
     /** The location where LWM2M objects are hosted on the device */
     private final String rootPath;
 
     private final Date lastUpdate;
 
-    public Client(String registrationId, String endpoint, InetAddress address, int port,
-            InetSocketAddress registrationEndpointAddress) {
-        this(registrationId, endpoint, address, port, null, null, null, null, null, registrationEndpointAddress);
-    }
-
+    @Deprecated
     public Client(String registrationId, String endpoint, InetAddress address, int port, String lwM2mVersion,
             Long lifetimeInSec, String smsNumber, BindingMode bindingMode, LinkObject[] objectLinks,
-            InetSocketAddress registrationEndpointAddress) {
-        this(registrationId, endpoint, address, port, lwM2mVersion, lifetimeInSec, smsNumber, bindingMode, objectLinks,
-                registrationEndpointAddress, null, null);
-    }
+            InetSocketAddress registrationEndpointAddress,
 
-    public Client(String registrationId, String endpoint, InetAddress address, int port, String lwM2mVersion,
-            Long lifetimeInSec, String smsNumber, BindingMode bindingMode, LinkObject[] objectLinks,
-            InetSocketAddress registrationEndpointAddress, Date registrationDate, Date lastUpdate) {
+            Date registrationDate, Date lastUpdate, Map<String, String> otherRegistrationAttributes) {
 
+        Validate.notNull(registrationId);
         Validate.notEmpty(endpoint);
         Validate.notNull(address);
         Validate.notNull(port);
@@ -96,9 +88,10 @@ public class Client {
         this.endpoint = endpoint;
         this.address = address;
         this.port = port;
+        this.smsNumber = smsNumber;
+        this.registrationEndpointAddress = registrationEndpointAddress;
 
         this.objectLinks = objectLinks;
-
         // extract the root objects path from the object links
         String rootPath = "/";
         if (objectLinks != null) {
@@ -111,13 +104,14 @@ public class Client {
         }
         this.rootPath = rootPath;
 
-        this.registrationDate = registrationDate == null ? new Date() : registrationDate;
         this.lifeTimeInSec = lifetimeInSec == null ? DEFAULT_LIFETIME_IN_SEC : lifetimeInSec;
         this.lwM2mVersion = lwM2mVersion == null ? DEFAULT_LWM2M_VERSION : lwM2mVersion;
         this.bindingMode = bindingMode == null ? BindingMode.U : bindingMode;
-        this.smsNumber = smsNumber;
-        this.registrationEndpointAddress = registrationEndpointAddress;
+        this.registrationDate = registrationDate == null ? new Date() : registrationDate;
         this.lastUpdate = lastUpdate == null ? new Date() : lastUpdate;
+        this.otherRegistrationAttributes = otherRegistrationAttributes == null ? new HashMap<String, String>()
+                : otherRegistrationAttributes;
+
     }
 
     public String getRegistrationId() {
@@ -280,11 +274,11 @@ public class Client {
     }
 
     public Map<String, String> getRegistrationQueryParams() {
-        return registrationQueryParams;
+        return otherRegistrationAttributes;
     }
 
     public void setRegistrationQueryParams(Map<String, String> registrationQueryParams) {
-        this.registrationQueryParams = registrationQueryParams;
+        this.otherRegistrationAttributes = registrationQueryParams;
     }
 
     @Override
@@ -320,4 +314,86 @@ public class Client {
             return false;
         }
     }
+
+    public static class Builder {
+        private final String registrationId;
+        private final String endpoint;
+        private final InetAddress address;
+        private final int port;
+        private final InetSocketAddress registrationEndpointAddress;
+
+        private Date registrationDate;
+        private Date lastUpdate;
+        private Long lifeTimeInSec;
+        private String smsNumber;
+        private BindingMode bindingMode;
+        private String lwM2mVersion;
+        private LinkObject[] objectLinks;
+        private Map<String, String> otherRegistrationAttributes;
+
+        public Builder(String registrationId, String endpoint, InetAddress address, int port,
+                InetSocketAddress registrationEndpointAddress) {
+
+            Validate.notNull(registrationId);
+            Validate.notEmpty(endpoint);
+            Validate.notNull(address);
+            Validate.notNull(port);
+            Validate.notNull(registrationEndpointAddress);
+            this.registrationId = registrationId;
+            this.endpoint = endpoint;
+            this.address = address;
+            this.port = port;
+            this.registrationEndpointAddress = registrationEndpointAddress;
+
+        }
+
+        public Builder registrationDate(Date registrationDate) {
+            this.registrationDate = registrationDate;
+            return this;
+        }
+
+        public Builder lastUpdate(Date lastUpdate) {
+            this.lastUpdate = lastUpdate;
+            return this;
+        }
+
+        public Builder lifeTimeInSec(Long lifetimeInSec) {
+            this.lifeTimeInSec = lifetimeInSec;
+            return this;
+        }
+
+        public Builder smsNumber(String smsNumber) {
+            this.smsNumber = smsNumber;
+            return this;
+        }
+
+        public Builder bindingMode(BindingMode bindingMode) {
+            this.bindingMode = bindingMode;
+            return this;
+        }
+
+        public Builder lwm2mVersion(String lwm2mVersion) {
+            this.lwM2mVersion = lwm2mVersion;
+            return this;
+        }
+
+        public Builder objectLinks(LinkObject[] objectLinks) {
+            this.objectLinks = objectLinks;
+            return this;
+        }
+
+        public Builder otherRegistrationAttributes(Map<String, String> otherRegistrationAttributes) {
+            this.otherRegistrationAttributes = otherRegistrationAttributes;
+            return this;
+        }
+
+        public Client build() {
+            return new Client(Builder.this.registrationId, Builder.this.endpoint, Builder.this.address,
+                    Builder.this.port, Builder.this.lwM2mVersion, Builder.this.lifeTimeInSec, Builder.this.smsNumber,
+                    this.bindingMode, this.objectLinks, this.registrationEndpointAddress, this.registrationDate,
+                    this.lastUpdate, this.otherRegistrationAttributes);
+        }
+
+    }
+
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/Client.java
@@ -65,15 +65,14 @@ public class Client {
 
     private final LinkObject[] objectLinks;
 
-    private Map<String, String> additionalRegistrationAttributes = new HashMap<String, String>();
+    private final Map<String, String> additionalRegistrationAttributes;
 
     /** The location where LWM2M objects are hosted on the device */
     private final String rootPath;
 
     private final Date lastUpdate;
 
-    @Deprecated
-    public Client(String registrationId, String endpoint, InetAddress address, int port, String lwM2mVersion,
+    protected Client(String registrationId, String endpoint, InetAddress address, int port, String lwM2mVersion,
             Long lifetimeInSec, String smsNumber, BindingMode bindingMode, LinkObject[] objectLinks,
             InetSocketAddress registrationEndpointAddress,
 
@@ -277,10 +276,6 @@ public class Client {
 
     public Map<String, String> getAdditionalRegistrationParams() {
         return additionalRegistrationAttributes;
-    }
-
-    public void setAdditionalRegistrationParams(Map<String, String> additionalRegistrationParams) {
-        this.additionalRegistrationAttributes = Collections.unmodifiableMap(additionalRegistrationParams);
     }
 
     @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientUpdate.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/client/ClientUpdate.java
@@ -68,9 +68,15 @@ public class ClientUpdate {
         // to extend the client registration's time-to-live period ...
         Date lastUpdate = new Date();
 
-        return new Client(client.getRegistrationId(), client.getEndpoint(), address, port, client.getLwM2mVersion(),
-                lifeTimeInSec, smsNumber, bindingMode, linkObject, client.getRegistrationEndpointAddress(),
-                client.getRegistrationDate(), lastUpdate);
+        Client.Builder builder = new Client.Builder(client.getRegistrationId(), client.getEndpoint(), address, port,
+                client.getRegistrationEndpointAddress());
+
+        builder.lwm2mVersion(client.getLwM2mVersion()).lifeTimeInSec(lifeTimeInSec).smsNumber(smsNumber)
+                .bindingMode(bindingMode).objectLinks(linkObject).registrationDate(client.getRegistrationDate())
+                .lastUpdate(lastUpdate);
+
+        return builder.build();
+
     }
 
     public String getRegistrationId() {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -67,6 +67,8 @@ public class RegistrationHandler {
                 registerRequest.getLwVersion(), registerRequest.getLifetime(), registerRequest.getSmsNumber(),
                 registerRequest.getBindingMode(), registerRequest.getObjectLinks(), serverEndpoint);
 
+        client.setRegistrationQueryParams(registerRequest.getQueryParameters());
+
         if (clientRegistry.registerClient(client)) {
             LOG.debug("New registered client: {}", client);
             return RegisterResponse.success(client.getRegistrationId());

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.server.registration;
 
 import java.net.InetSocketAddress;
 import java.security.PublicKey;
+import java.util.Date;
 
 import org.eclipse.leshan.core.request.DeregisterRequest;
 import org.eclipse.leshan.core.request.Identity;
@@ -62,12 +63,16 @@ public class RegistrationHandler {
             return RegisterResponse.forbidden(null);
         }
 
-        Client client = new Client(RegistrationHandler.createRegistrationId(), registerRequest.getEndpointName(),
-                sender.getPeerAddress().getAddress(), sender.getPeerAddress().getPort(),
-                registerRequest.getLwVersion(), registerRequest.getLifetime(), registerRequest.getSmsNumber(),
-                registerRequest.getBindingMode(), registerRequest.getObjectLinks(), serverEndpoint);
+        Client.Builder builder = new Client.Builder(RegistrationHandler.createRegistrationId(),
+                registerRequest.getEndpointName(), sender.getPeerAddress().getAddress(), sender.getPeerAddress()
+                        .getPort(), serverEndpoint);
 
-        client.setRegistrationQueryParams(registerRequest.getQueryParameters());
+        builder = builder.lwm2mVersion(registerRequest.getLwVersion()).lifeTimeInSec(registerRequest.getLifetime())
+                .bindingMode(registerRequest.getBindingMode()).objectLinks(registerRequest.getObjectLinks())
+                .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
+                .otherRegistrationAttributes(registerRequest.getOtherParameters());
+
+        Client client = builder.build();
 
         if (clientRegistry.registerClient(client)) {
             LOG.debug("New registered client: {}", client);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -70,7 +70,7 @@ public class RegistrationHandler {
         builder.lwm2mVersion(registerRequest.getLwVersion()).lifeTimeInSec(registerRequest.getLifetime())
                 .bindingMode(registerRequest.getBindingMode()).objectLinks(registerRequest.getObjectLinks())
                 .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
-                .additionalRegistrationAttributes(registerRequest.getAdditionalParameters());
+                .additionalRegistrationAttributes(registerRequest.getAdditionalAttributes());
 
         Client client = builder.build();
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -67,7 +67,7 @@ public class RegistrationHandler {
                 registerRequest.getEndpointName(), sender.getPeerAddress().getAddress(), sender.getPeerAddress()
                         .getPort(), serverEndpoint);
 
-        builder = builder.lwm2mVersion(registerRequest.getLwVersion()).lifeTimeInSec(registerRequest.getLifetime())
+        builder.lwm2mVersion(registerRequest.getLwVersion()).lifeTimeInSec(registerRequest.getLifetime())
                 .bindingMode(registerRequest.getBindingMode()).objectLinks(registerRequest.getObjectLinks())
                 .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
                 .additionalRegistrationAttributes(registerRequest.getAdditionalParameters());

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -70,7 +70,7 @@ public class RegistrationHandler {
         builder = builder.lwm2mVersion(registerRequest.getLwVersion()).lifeTimeInSec(registerRequest.getLifetime())
                 .bindingMode(registerRequest.getBindingMode()).objectLinks(registerRequest.getObjectLinks())
                 .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
-                .otherRegistrationAttributes(registerRequest.getOtherParameters());
+                .additionalRegistrationAttributes(registerRequest.getAdditionalParameters());
 
         Client client = builder.build();
 

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/client/ClientSortObjectTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/client/ClientSortObjectTest.java
@@ -21,7 +21,6 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
 import org.eclipse.leshan.LinkObject;
-import org.eclipse.leshan.server.client.Client;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,8 +32,11 @@ public class ClientSortObjectTest {
         objs[0] = new LinkObject("/0/1024/2");
         objs[1] = new LinkObject("/0/2");
         objs[2] = null;
-        Client c = new Client("registrationId", "endpoint", Inet4Address.getByName("127.0.0.1"), 1, "1.0", null, null,
-                null, objs, new InetSocketAddress(212));
+
+        Client.Builder builder = new Client.Builder("registrationId", "endpoint", Inet4Address.getByName("127.0.0.1"),
+                1, new InetSocketAddress(212)).objectLinks(objs);
+
+        Client c = builder.build();
 
         LinkObject[] res = c.getSortedObjectLinks();
         Assert.assertEquals(3, res.length);

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/impl/BasicTestSupport.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/impl/BasicTestSupport.java
@@ -30,7 +30,10 @@ public class BasicTestSupport {
 
     public void givenASimpleClient() throws UnknownHostException {
         registrationAddress = InetSocketAddress.createUnresolved("localhost", 5683);
-        client = new Client("ID", "urn:client", InetAddress.getLocalHost(), 10000, "1.0", 10000L, null, null, null,
+
+        Client.Builder builder = new Client.Builder("ID", "urn:client", InetAddress.getLocalHost(), 10000,
                 registrationAddress);
+
+        client = builder.build();
     }
 }

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/impl/ClientRegistryImplTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/impl/ClientRegistryImplTest.java
@@ -84,7 +84,10 @@ public class ClientRegistryImplTest {
     }
 
     private void givenASimpleClient(Long lifetime) {
-        client = new Client(registrationId, ep, address, port, null, lifetime, sms, binding, objectLinks,
+
+        Client.Builder builder = new Client.Builder(registrationId, ep, address, port,
                 InetSocketAddress.createUnresolved("localhost", 5683));
+
+        client = builder.lifeTimeInSec(lifetime).smsNumber(sms).bindingMode(binding).objectLinks(objectLinks).build();
     }
 }


### PR DESCRIPTION
Client can now be passed a free-form map of registration query parameters.

Some context : 

I have a custom `ClientRegistry`, that will respond to `Register` requests with an extra, non-standard "imei" parameter. It needs to do some validation on this parameter.

Rather than adding yet another field to the `RegisterRequest`, I added a free-form map (String to String) with all register query parameters. (Sounds future-proof enough)

I initially though about passing the `RegisterRequest` object in `ClientRegistry.register`, but I suppose this would break backward compatibility. So instead, I attached the parameter map to the client itself. 

(An alternative would be to have two `register` method with different arities , and using defaults methods - but is leshan supposed to be compiled for java 8 compatibility ?)

What do you think ?