### PR TITLE
Allow multiple security info on BS

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
@@ -30,6 +30,8 @@ import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.leshan.server.bootstrap.demo.servlet.BootstrapServlet;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.californium.impl.LwM2mBootstrapServerImpl;
+import org.eclipse.leshan.server.impl.BootstrapAuthServiceImpl;
+import org.eclipse.leshan.server.security.BootstrapAuthService;
 import org.eclipse.leshan.server.security.BootstrapSecurityStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,10 +139,11 @@ public class LeshanBootstrapServerDemo {
         // Prepare and start bootstrap server
         BootstrapStoreImpl bsStore = new BootstrapStoreImpl();
         BootstrapSecurityStore securityStore = new BootstrapSecurityStoreImpl(bsStore);
+        BootstrapAuthService bsAuthService = new BootstrapAuthServiceImpl(securityStore);
 
         LwM2mBootstrapServerImpl bsServer = new LwM2mBootstrapServerImpl(
                 new InetSocketAddress(localAddress, localPort), new InetSocketAddress(secureLocalAddress,
-                        secureLocalPort), bsStore, securityStore);
+                        secureLocalPort), bsStore, securityStore, bsAuthService);
         bsServer.start();
 
         // Now prepare and start jetty

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
@@ -30,7 +30,7 @@ import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.leshan.server.bootstrap.demo.servlet.BootstrapServlet;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.californium.impl.LwM2mBootstrapServerImpl;
-import org.eclipse.leshan.server.security.SecurityStore;
+import org.eclipse.leshan.server.security.BootstrapSecurityStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,7 +136,7 @@ public class LeshanBootstrapServerDemo {
 
         // Prepare and start bootstrap server
         BootstrapStoreImpl bsStore = new BootstrapStoreImpl();
-        SecurityStore securityStore = new BootstrapSecurityStore(bsStore);
+        BootstrapSecurityStore securityStore = new BootstrapSecurityStoreImpl(bsStore);
 
         LwM2mBootstrapServerImpl bsServer = new LwM2mBootstrapServerImpl(
                 new InetSocketAddress(localAddress, localPort), new InetSocketAddress(secureLocalAddress,

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
@@ -32,8 +32,8 @@ import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
 import org.eclipse.leshan.server.bootstrap.BootstrapStore;
 import org.eclipse.leshan.server.bootstrap.SecurityMode;
 import org.eclipse.leshan.server.californium.impl.LwM2mBootstrapServerImpl;
+import org.eclipse.leshan.server.security.BootstrapSecurityStore;
 import org.eclipse.leshan.server.security.SecurityInfo;
-import org.eclipse.leshan.server.security.SecurityStore;
 
 /**
  * Helper for running a server and executing a client against it.
@@ -76,14 +76,14 @@ public class BootstrapIntegrationTestHelper extends IntegrationTestHelper {
                 return bsConfig;
             }
         };
-        SecurityStore securityStore = new SecurityStore() {
+        BootstrapSecurityStore securityStore = new BootstrapSecurityStore() {
             @Override
             public SecurityInfo getByIdentity(String identity) {
                 return null;
             }
 
             @Override
-            public SecurityInfo getByEndpoint(String endpoint) {
+            public List<SecurityInfo> getAllByEndpoint(String endpoint) {
                 return null;
             }
         };

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
@@ -26,12 +26,14 @@ import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
+import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
 import org.eclipse.leshan.server.bootstrap.BootstrapStore;
 import org.eclipse.leshan.server.bootstrap.SecurityMode;
 import org.eclipse.leshan.server.californium.impl.LwM2mBootstrapServerImpl;
+import org.eclipse.leshan.server.security.BootstrapAuthService;
 import org.eclipse.leshan.server.security.BootstrapSecurityStore;
 import org.eclipse.leshan.server.security.SecurityInfo;
 
@@ -88,8 +90,15 @@ public class BootstrapIntegrationTestHelper extends IntegrationTestHelper {
             }
         };
 
+        BootstrapAuthService bsAuthService = new BootstrapAuthService() {
+            @Override
+            public boolean authenticate(String endpoint, Identity clientIdentity) {
+                return true;
+            }
+        };
+
         bootstrapServer = new LwM2mBootstrapServerImpl(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), bsStore, securityStore);
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), bsStore, securityStore, bsAuthService);
     }
 
     public void createClient() {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
@@ -16,11 +16,18 @@
 package org.eclipse.leshan.server.californium.impl;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.security.Principal;
+import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -31,11 +38,15 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.scandium.auth.PreSharedKeyIdentity;
+import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
 import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
 import org.eclipse.leshan.server.bootstrap.BootstrapStore;
+import org.eclipse.leshan.server.security.BootstrapAuthService;
 import org.eclipse.leshan.tlv.Tlv;
 import org.eclipse.leshan.tlv.Tlv.TlvType;
 import org.eclipse.leshan.tlv.TlvEncoder;
@@ -47,13 +58,15 @@ public class BootstrapResource extends CoapResource {
     private static final Logger LOG = LoggerFactory.getLogger(BootstrapResource.class);
     private static final String QUERY_PARAM_ENDPOINT = "ep=";
 
-    private BootstrapStore store;
+    private BootstrapAuthService bsAuthService;
+    private BootstrapStore bsStore;
 
     private Executor e = Executors.newFixedThreadPool(5);
 
-    public BootstrapResource(BootstrapStore store) {
+    public BootstrapResource(BootstrapStore store, BootstrapAuthService bsAuthService) {
         super("bs");
-        this.store = store;
+        this.bsStore = store;
+        this.bsAuthService = bsAuthService;
     }
 
     @Override
@@ -64,6 +77,32 @@ public class BootstrapResource extends CoapResource {
             LOG.error("Exception while handling a request on the /bs resource", e);
             exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
         }
+    }
+
+    // TODO(pht) leshan-core-cf: this code should be factorized in a leshan-core-cf project.
+    // TODO(pht) code is also in RegisterResource from leshan-server-cf
+    private static Identity extractIdentity(CoapExchange exchange) {
+        InetSocketAddress peerAddress = new InetSocketAddress(exchange.getSourceAddress(), exchange.getSourcePort());
+
+        Principal senderIdentity = exchange.advanced().getRequest().getSenderIdentity();
+        if (senderIdentity != null) {
+            if (senderIdentity instanceof PreSharedKeyIdentity) {
+                return Identity.psk(peerAddress, senderIdentity.getName());
+            } else if (senderIdentity instanceof RawPublicKeyIdentity) {
+                PublicKey publicKey = ((RawPublicKeyIdentity) senderIdentity).getKey();
+                return Identity.rpk(peerAddress, publicKey);
+            } else if (senderIdentity instanceof X500Principal) {
+                // Extract common name
+                Matcher endpointMatcher = Pattern.compile("CN=.*?,").matcher(senderIdentity.getName());
+                if (endpointMatcher.find()) {
+                    String x509CommonName = endpointMatcher.group().substring(3, endpointMatcher.group().length() - 1);
+                    return Identity.x509(peerAddress, x509CommonName);
+                } else {
+                    return null;
+                }
+            }
+        }
+        return Identity.unsecure(peerAddress);
     }
 
     @Override
@@ -91,15 +130,22 @@ public class BootstrapResource extends CoapResource {
         }
         final String endpoint = endpointTmp;
 
-        // TODO check security of the endpoint
+        final BootstrapConfig cfg = bsStore.getBootstrap(endpoint);
 
-        final BootstrapConfig cfg = store.getBootstrap(endpoint);
         if (cfg == null) {
             LOG.error("No bootstrap config for {}", endpoint);
             exchange.respond(ResponseCode.BAD_REQUEST);
             return;
         }
         exchange.respond(ResponseCode.CHANGED);
+
+        // Check security of the endpoint
+        Identity clientIdentity = extractIdentity(exchange);
+
+        if (!bsAuthService.authenticate(endpoint, clientIdentity)) {
+            exchange.respond(ResponseCode.UNAUTHORIZED);
+            return;
+        }
 
         // now push the config
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mBootstrapPskStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mBootstrapPskStore.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.impl;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.eclipse.leshan.server.security.BootstrapSecurityStore;
+import org.eclipse.leshan.server.security.SecurityInfo;
+
+/**
+ * PSK Store to feed a Bootstrap server.
+ * 
+ * Only supports getting the PSK key for a given identity. (Getting identity from IP only makes sense on the client
+ * side.)
+ */
+public class LwM2mBootstrapPskStore implements PskStore {
+
+    private BootstrapSecurityStore bsSecurityStore;
+
+    public LwM2mBootstrapPskStore(BootstrapSecurityStore bsSecurityStore) {
+        this.bsSecurityStore = bsSecurityStore;
+    }
+
+    @Override
+    public byte[] getKey(String identity) {
+        SecurityInfo info = bsSecurityStore.getByIdentity(identity);
+        if (info == null || info.getPreSharedKey() == null) {
+            return null;
+        } else {
+            // defensive copy
+            return Arrays.copyOf(info.getPreSharedKey(), info.getPreSharedKey().length);
+        }
+    }
+
+    @Override
+    public String getIdentity(InetSocketAddress inetAddress) {
+        throw new UnsupportedOperationException("Getting PSK Id by IP addresss dos not make sense on BS server side.");
+    }
+}

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mBootstrapServerImpl.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mBootstrapServerImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.leshan.server.bootstrap.BootstrapStore;
 import org.eclipse.leshan.server.bootstrap.LwM2mBootstrapServer;
+import org.eclipse.leshan.server.security.BootstrapAuthService;
 import org.eclipse.leshan.server.security.BootstrapSecurityStore;
 import org.eclipse.leshan.util.Validate;
 import org.slf4j.Logger;
@@ -51,14 +52,15 @@ public class LwM2mBootstrapServerImpl implements LwM2mBootstrapServer {
     private final BootstrapStore bsStore;
     private final BootstrapSecurityStore bsSecurityStore;
 
-    public LwM2mBootstrapServerImpl(BootstrapStore bsStore, BootstrapSecurityStore securityStore) {
+    public LwM2mBootstrapServerImpl(BootstrapStore bsStore, BootstrapSecurityStore securityStore,
+            BootstrapAuthService bsAuthService) {
         this(new InetSocketAddress((InetAddress) null, PORT), new InetSocketAddress((InetAddress) null, PORT_DTLS),
-                bsStore, securityStore);
+                bsStore, securityStore, bsAuthService);
 
     }
 
     public LwM2mBootstrapServerImpl(InetSocketAddress localAddress, InetSocketAddress localAddressSecure,
-            BootstrapStore bsStore, BootstrapSecurityStore bsSecurityStore) {
+            BootstrapStore bsStore, BootstrapSecurityStore bsSecurityStore, BootstrapAuthService bsAuthService) {
         Validate.notNull(bsStore, "bootstrap store must not be null");
 
         this.bsStore = bsStore;
@@ -78,7 +80,7 @@ public class LwM2mBootstrapServerImpl implements LwM2mBootstrapServer {
 
         // define /bs ressource
 
-        BootstrapResource bsResource = new BootstrapResource(bsStore);
+        BootstrapResource bsResource = new BootstrapResource(bsStore, bsAuthService);
         coapServer.add(bsResource);
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/BootstrapAuthServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/BootstrapAuthServiceImpl.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.impl;
+
+import java.util.List;
+
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.server.security.BootstrapAuthService;
+import org.eclipse.leshan.server.security.BootstrapSecurityStore;
+import org.eclipse.leshan.server.security.SecurityCheck;
+import org.eclipse.leshan.server.security.SecurityInfo;
+
+public class BootstrapAuthServiceImpl implements BootstrapAuthService {
+
+    private BootstrapSecurityStore bsSecurityStore;
+
+    public BootstrapAuthServiceImpl(BootstrapSecurityStore bsSecurityStore) {
+        this.bsSecurityStore = bsSecurityStore;
+    }
+
+    @Override
+    public boolean authenticate(String endpoint, Identity clientIdentity) {
+        List<SecurityInfo> securityInfos = bsSecurityStore.getAllByEndpoint(endpoint);
+        return SecurityCheck.checkSecurityInfos(endpoint, clientIdentity, securityInfos);
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/BootstrapAuthService.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/BootstrapAuthService.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.security;
+
+import org.eclipse.leshan.core.request.Identity;
+
+/**
+ * Interface for the authentication of a device trying to bootstrap.
+ */
+public interface BootstrapAuthService {
+    /**
+     * Try to authenticate a bootstrapping client given an identity
+     * 
+     * @param endpoint
+     * @param clientIdentity typically extracted from LWM2M Exchange
+     * @return
+     */
+    public boolean authenticate(String endpoint, Identity clientIdentity);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/BootstrapSecurityStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/BootstrapSecurityStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2015 Sierra Wireless and others.
+ * Copyright (c) 2016 Sierra Wireless and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,30 +13,25 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
-package org.eclipse.leshan.server.bootstrap;
+package org.eclipse.leshan.server.security;
 
-import org.eclipse.leshan.server.security.BootstrapSecurityStore;
+import java.util.List;
 
-/**
- * 
- * A Lightweight M2M server in charge of handling device bootstrap on the /bs resource.
- *
- */
-public interface LwM2mBootstrapServer {
+public interface BootstrapSecurityStore {
 
     /**
-     * Access to the bootstrap configuration store. It's used for sending configuration to the devices initiating a
-     * bootstrap.
+     * Returns all acceptable security information for a given end-point.
+     * 
+     * @param endpoint the client end-point
+     * @return the security information of <code>null</code> if not found.
      */
-    BootstrapStore getBoostrapStore();
+    List<SecurityInfo> getAllByEndpoint(String endpoint);
 
     /**
-     * security store used for DTLS authentication on the bootstrap ressource.
+     * Returns the security information for an identity.
+     * 
+     * @param identity of the client
+     * @return the security information of <code>null</code> if not found.
      */
-    BootstrapSecurityStore getBootstrapSecurityStore();
-
-    void start();
-
-    void stop();
-
+    SecurityInfo getByIdentity(String identity);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityCheck.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityCheck.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.security;
+
+import java.security.PublicKey;
+import java.util.List;
+
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.util.Hex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SecurityCheck {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SecurityCheck.class);
+
+    /**
+     * Return true if any of the securityInfos is valid for the given endpoint and client identity.
+     * 
+     * @see #checkSecurityInfo(String, Identity, SecurityInfo)
+     * 
+     * @param endpoint
+     * @param clientIdentity
+     * @param securityInfos
+     * 
+     */
+    public static boolean checkSecurityInfos(String endpoint, Identity clientIdentity, List<SecurityInfo> securityInfos) {
+
+        // Client is presenting itself as not secure, but we have known Security info ;
+        // we must refuse it.
+        if (!clientIdentity.isSecure() && securityInfos != null && !securityInfos.isEmpty()) {
+            LOG.warn("client {} must connect using DTLS ", endpoint);
+            return false;
+        }
+
+        if (clientIdentity.isSecure() && (securityInfos == null || securityInfos.isEmpty())) {
+            LOG.warn("A client {} without security info try to connect through the secure endpont", endpoint);
+            return false;
+        }
+
+        for (SecurityInfo securityInfo : securityInfos) {
+            if (checkSecurityInfo(endpoint, clientIdentity, securityInfo)) {
+                return true;
+            }
+        }
+        return false;
+
+    }
+
+    /**
+     * Validates security info against a known endpoint and identity.
+     * 
+     * @param endpoint
+     * @param clientIdentity
+     * @param securityInfo
+     * @return true if the security info are valid.
+     */
+    public static boolean checkSecurityInfo(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
+
+        // if this is a secure end-point, we must check that the registering client is using the right identity.
+        if (clientIdentity.isSecure()) {
+            if (securityInfo == null) {
+
+                LOG.warn("A client {} without security info try to connect through the secure endpont", endpoint);
+                return false;
+
+            } else if (clientIdentity.isPSK()) {
+
+                return checkPskIdentity(endpoint, clientIdentity, securityInfo);
+
+            } else if (clientIdentity.isRPK()) {
+
+                return checkRpkIdentity(endpoint, clientIdentity, securityInfo);
+
+            } else if (clientIdentity.isX509()) {
+
+                return checkX509Identity(endpoint, clientIdentity, securityInfo);
+
+            } else {
+                LOG.warn("Unable to authenticate client {}: unknown authentication mode.", endpoint);
+                return false;
+            }
+        } else {
+            if (securityInfo != null) {
+                LOG.warn("client {} must connect using DTLS ", endpoint);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean checkPskIdentity(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
+        // Manage PSK authentication
+        // ----------------------------------------------------
+        String pskIdentity = clientIdentity.getPskIdentity();
+        LOG.debug("Registration request received using the secure endpoint with identity {}", pskIdentity);
+
+        if (pskIdentity == null || !pskIdentity.equals(securityInfo.getIdentity())) {
+            LOG.warn("Invalid identity for client {}: expected '{}' but was '{}'", endpoint,
+                    securityInfo.getIdentity(), pskIdentity);
+            return false;
+        } else {
+            LOG.debug("authenticated client {} using DTLS PSK", endpoint);
+            return true;
+        }
+    }
+
+    private static boolean checkRpkIdentity(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
+        // Manage RPK authentication
+        // ----------------------------------------------------
+        PublicKey publicKey = clientIdentity.getRawPublicKey();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Registration request received using the secure endpoint with rpk {}",
+                    Hex.encodeHexString(publicKey.getEncoded()));
+        }
+
+        if (publicKey == null || !publicKey.equals(securityInfo.getRawPublicKey())) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Invalid rpk for client {}: expected \n'{}'\n but was \n'{}'", endpoint,
+                        Hex.encodeHexString(securityInfo.getRawPublicKey().getEncoded()),
+                        Hex.encodeHexString(publicKey.getEncoded()));
+            }
+            return false;
+        } else {
+            LOG.debug("authenticated client {} using DTLS RPK", endpoint);
+            return true;
+        }
+    }
+
+    private static boolean checkX509Identity(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
+        // Manage X509 certificate authentication
+        // ----------------------------------------------------
+        String x509CommonName = clientIdentity.getX509CommonName();
+        LOG.debug("Registration request received using the secure endpoint with X509 identity {}", x509CommonName);
+
+        if (!securityInfo.useX509Cert()) {
+            LOG.warn("Client {} is not supposed to use X509 certificate to authenticate", endpoint);
+            return false;
+        }
+
+        if (!x509CommonName.equals(endpoint)) {
+            LOG.warn("Invalid certificate common name for client {}: expected \n'{}'\n but was \n'{}'", endpoint,
+                    endpoint, x509CommonName);
+            return false;
+        } else {
+            LOG.debug("authenticated client {} using DTLS X509 certificates", endpoint);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
- Separated SecurityStore and BootstrapSecurityStore interfaces
- BootstrapSecurityStore supports checking multiple identities
  for a given endpoint
- Added identity check on bootstrap
- Added accessors for BootstrapConfig internal maps

Signed-off-by: Pierre-Henri Trivier <phtrivier@sierrawireless.com>