### PR TITLE
Use Json Type if we don't have model when decoding

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
@@ -75,8 +75,9 @@ public class LwM2mNodeJsonDecoder {
     private static Map<Integer, LwM2mResource> parseJsonPayLoadLwM2mResources(JsonRootObject jsonObject,
             LwM2mPath path, LwM2mModel model) throws InvalidValueException {
         Map<Integer, LwM2mResource> lwM2mResourceMap = new HashMap<>();
-        Map<Integer, Map<Integer, Object>> multiResourceMap = new HashMap<>();
+        Map<Integer, Map<Integer, JsonArrayEntry>> multiResourceMap = new HashMap<>();
 
+        // we does not support base name for now
         if (jsonObject.getBaseName() != null && !jsonObject.getBaseName().isEmpty()) {
             throw new UnsupportedOperationException("Basename support is not implemented.");
         }
@@ -87,34 +88,36 @@ public class LwM2mNodeJsonDecoder {
             Integer resourceId = Integer.valueOf(resourcePath[0]);
 
             if (!multiResourceMap.isEmpty() && multiResourceMap.get(resourceId) != null) {
-                multiResourceMap.get(resourceId).put(Integer.valueOf(resourcePath[1]), resourceElt.getResourceValue());
+                multiResourceMap.get(resourceId).put(Integer.valueOf(resourcePath[1]), resourceElt);
                 continue;
             }
             if (resourcePath.length > 1) {
                 // multi resource
                 // store multi resource values in a map
-                Map<Integer, Object> values = new HashMap<>();
-                values.put(Integer.valueOf(resourcePath[1]), resourceElt.getResourceValue());
-                multiResourceMap.put(resourceId, values);
+                Map<Integer, JsonArrayEntry> jsonEntries = new HashMap<>();
+                jsonEntries.put(Integer.valueOf(resourcePath[1]), resourceElt);
+                multiResourceMap.put(resourceId, jsonEntries);
             } else {
                 // single resource
                 LwM2mPath rscPath = new LwM2mPath(path.getObjectId(), path.getObjectInstanceId(), resourceId);
-                Type expectedType = getResourceType(rscPath, model);
+                Type expectedType = getResourceType(rscPath, model, resourceElt);
                 LwM2mResource res = LwM2mSingleResource.newResource(resourceId,
                         parseJsonValue(resourceElt.getResourceValue(), expectedType, rscPath), expectedType);
                 lwM2mResourceMap.put(resourceId, res);
             }
         }
 
-        for (Map.Entry<Integer, Map<Integer, Object>> entry : multiResourceMap.entrySet()) {
+        for (Map.Entry<Integer, Map<Integer, JsonArrayEntry>> entry : multiResourceMap.entrySet()) {
             Integer key = entry.getKey();
-            Map<Integer, Object> values = entry.getValue();
+            Map<Integer, JsonArrayEntry> jsonEntries = entry.getValue();
 
-            if (values != null && !values.isEmpty()) {
+            if (jsonEntries != null && !jsonEntries.isEmpty()) {
                 LwM2mPath rscPath = new LwM2mPath(path.getObjectId(), path.getObjectInstanceId(), key);
-                Type expectedType = getResourceType(rscPath, model);
-                for (Entry<Integer, Object> e : values.entrySet()) {
-                    values.put(e.getKey(), parseJsonValue(e.getValue(), expectedType, rscPath));
+                Type expectedType = getResourceType(rscPath, model, jsonEntries.values().iterator().next());
+                Map<Integer, Object> values = new HashMap<>();
+                for (Entry<Integer, JsonArrayEntry> e : jsonEntries.entrySet()) {
+
+                    values.put(e.getKey(), parseJsonValue(e.getValue().getResourceValue(), expectedType, rscPath));
                 }
                 LwM2mResource res = LwM2mMultipleResource.newResource(key, values, expectedType);
                 lwM2mResourceMap.put(key, res);
@@ -154,11 +157,15 @@ public class LwM2mNodeJsonDecoder {
         }
     }
 
-    public static Type getResourceType(LwM2mPath rscPath, LwM2mModel model) throws InvalidValueException {
+    public static Type getResourceType(LwM2mPath rscPath, LwM2mModel model, JsonArrayEntry resourceElt)
+            throws InvalidValueException {
         ResourceModel rscDesc = model.getResourceModel(rscPath.getObjectId(), rscPath.getResourceId());
         if (rscDesc == null || rscDesc.type == null) {
-            LOG.trace("unknown type for resource : {}", rscPath);
-            // no resource description... string
+            Type type = resourceElt.getType();
+            if (type != null)
+                return type;
+
+            LOG.trace("unknown type for resource use string as default: {}", rscPath);
             return Type.STRING;
         } else {
             return rscDesc.type;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
@@ -87,8 +87,9 @@ public class LwM2mNodeJsonDecoder {
             String[] resourcePath = resourceElt.getName().split("/");
             Integer resourceId = Integer.valueOf(resourcePath[0]);
 
-            if (!multiResourceMap.isEmpty() && multiResourceMap.get(resourceId) != null) {
-                multiResourceMap.get(resourceId).put(Integer.valueOf(resourcePath[1]), resourceElt);
+            Map<Integer, JsonArrayEntry> multiResource = multiResourceMap.get(resourceId);
+            if (multiResource != null) {
+                multiResource.put(Integer.valueOf(resourcePath[1]), resourceElt);
                 continue;
             }
             if (resourcePath.length > 1) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/json/JsonArrayEntry.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/json/JsonArrayEntry.java
@@ -17,6 +17,9 @@
 
 package org.eclipse.leshan.json;
 
+import org.eclipse.leshan.core.model.ResourceModel;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+
 import com.google.gson.annotations.SerializedName;
 
 public class JsonArrayEntry {
@@ -38,6 +41,23 @@ public class JsonArrayEntry {
 
     @SerializedName("t")
     private Integer time;
+
+    public ResourceModel.Type getType() {
+        if (booleanValue != null) {
+            return Type.BOOLEAN;
+        }
+        if (floatValue != null) {
+            return Type.FLOAT;
+        }
+        if (objectLinkValue != null) {
+            // TODO handle object link or not ..
+            return null;
+        }
+        if (stringValue != null) {
+            return Type.STRING;
+        }
+        return null;
+    }
 
     public String getName() {
         return name;

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
@@ -16,7 +16,9 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node.codec;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 import java.util.Date;
 
@@ -252,5 +254,23 @@ public class LwM2mNodeDecoderTest {
                 ContentFormat.JSON, new LwM2mPath(3, 0), model);
 
         assertDeviceInstance(oInstance);
+    }
+
+    @Test
+    public void json_custom_object_instance() throws InvalidValueException {
+        // json content for instance 0 of device object
+        StringBuilder b = new StringBuilder();
+        b.append("{\"e\":[");
+        b.append("{\"n\":\"0\",\"sv\":\"a string\"},");
+        b.append("{\"n\":\"1\",\"v\":10.5},");
+        b.append("{\"n\":\"2\",\"bv\":true}]}");
+        LwM2mObjectInstance oInstance = (LwM2mObjectInstance) LwM2mNodeDecoder.decode(b.toString().getBytes(),
+                ContentFormat.JSON, new LwM2mPath(1024, 0), model);
+
+        assertEquals(0, oInstance.getId());
+
+        assertEquals("a string", oInstance.getResource(0).getValue());
+        assertEquals(10.5, oInstance.getResource(1).getValue());
+        assertEquals(true, oInstance.getResource(2).getValue());
     }
 }


### PR DESCRIPTION
When Leshan have no model for an object it supposes that all resources was a `STRING`.
See discussion of [wakaama mailing list](https://dev.eclipse.org/mhonarc/lists/wakaama-dev/msg00226.html).

For JSON format we can be a bit smarter using type carried by the format.
