### PR TITLE
Add restart support to Leshan Client

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -124,7 +124,7 @@ public class LeshanClient implements LwM2mClient {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                LeshanClient.this.destroy();
+                LeshanClient.this.destroy(true); // send de-registration request before destroy
             }
         });
     }
@@ -138,17 +138,17 @@ public class LeshanClient implements LwM2mClient {
     }
 
     @Override
-    public void stop() {
+    public void stop(boolean deregister) {
         LOG.info("Stopping Leshan Client ...");
-        engine.stop();
+        engine.stop(deregister);
         clientSideServer.stop();
         LOG.info("Leshan client stopped.");
     }
 
     @Override
-    public void destroy() {
+    public void destroy(boolean deregister) {
         LOG.info("Destroying Leshan client ...");
-        engine.stop();
+        engine.stop(deregister);
         clientSideServer.destroy();
         LOG.info("Leshan client destroyed.");
     }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -148,7 +148,7 @@ public class LeshanClient implements LwM2mClient {
     @Override
     public void destroy(boolean deregister) {
         LOG.info("Destroying Leshan client ...");
-        engine.stop(deregister);
+        engine.destroy(deregister);
         clientSideServer.destroy();
         LOG.info("Leshan client destroyed.");
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LwM2mClient.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LwM2mClient.java
@@ -29,13 +29,17 @@ public interface LwM2mClient {
     /**
      * Stops the client, i.e. unbinds it from all ports. Frees as much system resources as possible to still be able to
      * be started.
+     * 
+     * @param deregister if true the device will send deregister request before.
      */
-    public void stop();
+    public void stop(boolean deregister);
 
     /**
      * Destroys the client, i.e. unbinds from all ports and frees all system resources.
+     * 
+     * @param deregister if true the device will send deregister request before.
      */
-    void destroy();
+    void destroy(boolean deregister);
 
     Collection<LwM2mObjectEnabler> getObjectEnablers();
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
@@ -286,12 +286,13 @@ public class RegistrationEngine {
         }
     }
 
-    public void stop() {
+    public void stop(boolean deregister) {
         // TODO we should manage the case where we stop in the middle of a bootstrap session ...
         schedExecutor.shutdownNow();
         try {
             schedExecutor.awaitTermination(BS_TIMEOUT, TimeUnit.SECONDS);
-            deregister();
+            if (deregister)
+                deregister();
         } catch (InterruptedException e) {
         }
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -15,7 +15,9 @@
  *******************************************************************************/
 package org.eclipse.leshan.integration.tests;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.eclipse.leshan.util.Hex;
 import org.junit.After;
@@ -37,7 +39,7 @@ public class BootstrapTest {
     @After
     public void stop() {
 
-        helper.client.stop();
+        helper.client.stop(true);
         helper.bootstrapServer.stop();
         helper.server.stop();
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/CreateTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/CreateTest.java
@@ -46,7 +46,7 @@ public class CreateTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.stop();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
@@ -42,7 +42,7 @@ public class DeleteTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.stop();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DiscoverTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DiscoverTest.java
@@ -43,7 +43,7 @@ public class DiscoverTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.stop();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
@@ -41,7 +41,7 @@ public class ExecuteTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.stop();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -104,9 +104,7 @@ public class IntegrationTestHelper {
         server = builder.build();
 
         // monitor client registration
-        registerLatch = new CountDownLatch(1);
-        deregisterLatch = new CountDownLatch(1);
-        updateLatch = new CountDownLatch(1);
+        resetLatch();
         server.getClientRegistry().addListener(new ClientRegistryListener() {
             @Override
             public void updated(Client clientUpdated) {
@@ -130,6 +128,12 @@ public class IntegrationTestHelper {
                 }
             }
         });
+    }
+
+    public void resetLatch() {
+        registerLatch = new CountDownLatch(1);
+        deregisterLatch = new CountDownLatch(1);
+        updateLatch = new CountDownLatch(1);
     }
 
     public boolean waitForRegistration(long timeInSeconds) {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
@@ -56,7 +56,7 @@ public class ObserveTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.stop();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
@@ -46,7 +46,7 @@ public class ReadTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.stop();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
@@ -79,7 +79,7 @@ public class RegistrationTest {
         assertEquals(1, helper.server.getClientRegistry().allClients().size());
 
         // Check deregistration
-        helper.client.stop();
+        helper.client.stop(true);
         helper.waitForDeregistration(1);
         assertTrue(helper.server.getClientRegistry().allClients().isEmpty());
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
@@ -160,7 +160,7 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                 LwM2mId.SECURITY,
                 Security.psk("coaps://" + server.getSecureAddress().getHostString() + ":"
                         + server.getSecureAddress().getPort(), 12345, pskIdentity.getBytes(Charsets.UTF_8), pskKey));
-        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, 30, BindingMode.U, false));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.U, false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         List<LwM2mObjectEnabler> objects = initializer.createMandatory();
         objects.add(initializer.create(2));
@@ -180,7 +180,7 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                 Security.rpk("coaps://" + server.getSecureAddress().getHostString() + ":"
                         + server.getSecureAddress().getPort(), 12345, clientPublicKey.getEncoded(),
                         clientPrivateKey.getEncoded(), serverPublicKey.getEncoded()));
-        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, 30, BindingMode.U, false));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.U, false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         List<LwM2mObjectEnabler> objects = initializer.createMandatory();
         objects.add(initializer.create(2));
@@ -208,7 +208,7 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                 LwM2mId.SECURITY,
                 Security.noSec("coaps://" + server.getSecureAddress().getHostString() + ":"
                         + server.getSecureAddress().getPort(), 12345));
-        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, 30, BindingMode.U, false));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.U, false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         List<LwM2mObjectEnabler> objects = initializer.createMandatory();
         objects.add(initializer.create(2));

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
@@ -36,7 +36,7 @@ public class SecurityTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.destroy();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
@@ -46,7 +46,7 @@ public class WriteTest {
 
     @After
     public void stop() {
-        helper.client.stop();
+        helper.client.stop(false);
         helper.server.stop();
     }
 


### PR DESCRIPTION
We can now stop/destroyed client with or without deregistration, then restart it.
We still have an issue on restart with secure connection because of a [scandium issue](https://github.com/eclipse/californium/pull/11).