### PR TITLE
Remove instance Id from Create Request path

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -81,7 +81,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
 
     @Override
     protected CreateResponse doCreate(CreateRequest request) {
-        Integer instanceId = request.getPath().getObjectInstanceId();
+        Integer instanceId = request.getInstanceId();
         if (instanceId == null) {
             // the client is in charge to generate the id of the new instance
             if (instances.isEmpty()) {
@@ -170,8 +170,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
             for (LwM2mObjectInstance instanceNode : ((LwM2mObject) request.getNode()).getInstances().values()) {
                 LwM2mInstanceEnabler instanceEnabler = instances.get(instanceNode.getId());
                 if (instanceEnabler == null) {
-                    doCreate(new CreateRequest(path.getObjectId(), path.getObjectInstanceId(), instanceNode
-                            .getResources().values()));
+                    doCreate(new CreateRequest(path.getObjectId(), instanceNode));
                 } else {
                     doWrite(new WriteRequest(Mode.REPLACE, path.getObjectId(), path.getObjectInstanceId(), instanceNode
                             .getResources().values()));
@@ -185,8 +184,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
             LwM2mObjectInstance instanceNode = (LwM2mObjectInstance) request.getNode();
             LwM2mInstanceEnabler instanceEnabler = instances.get(path.getObjectInstanceId());
             if (instanceEnabler == null) {
-                doCreate(new CreateRequest(path.getObjectId(), path.getObjectInstanceId(), instanceNode.getResources()
-                        .values()));
+                doCreate(new CreateRequest(path.getObjectId(), instanceNode));
             } else {
                 doWrite(new WriteRequest(Mode.REPLACE, request.getContentFormat(), path.getObjectId(),
                         path.getObjectInstanceId(), instanceNode.getResources().values()));
@@ -198,7 +196,8 @@ public class ObjectEnabler extends BaseObjectEnabler {
         LwM2mResource resource = (LwM2mResource) request.getNode();
         LwM2mInstanceEnabler instanceEnabler = instances.get(path.getObjectInstanceId());
         if (instanceEnabler == null) {
-            doCreate(new CreateRequest(path.getObjectId(), path.getObjectInstanceId(), resource));
+            doCreate(new CreateRequest(path.getObjectId(),
+                    new LwM2mObjectInstance(path.getObjectInstanceId(), resource)));
         } else {
             instanceEnabler.write(path.getResourceId(), resource);
         }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObjectInstance.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObjectInstance.java
@@ -28,6 +28,9 @@ import org.eclipse.leshan.util.Validate;
  */
 public class LwM2mObjectInstance implements LwM2mNode {
 
+    /** Undefined instance Id */
+    public static final int UNDEFINED = -1;
+
     private final int id;
 
     private final Map<Integer, LwM2mResource> resources;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
@@ -20,19 +20,22 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.response.CreateResponse;
+import org.eclipse.leshan.util.Validate;
 
 /**
  * A Lightweight M2M request for creating Object Instance(s) within the LWM2M Client.
  */
 public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
 
+    private final Integer instanceId;
     private final List<LwM2mResource> resources;
     private final ContentFormat contentFormat;
 
-    // ***************** constructor without object instance id ******************* /
+    // ***************** constructors without object id ******************* /
 
     /**
      * Creates a request for creating an instance of a particular object without specifying the id of this new instance.
@@ -43,7 +46,7 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(ContentFormat contentFormat, int objectId, LwM2mResource... resources) {
-        this(contentFormat, new LwM2mPath(objectId), resources);
+        this(contentFormat, new LwM2mPath(objectId), null, resources);
     }
 
     /**
@@ -54,7 +57,7 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(int objectId, LwM2mResource... resources) {
-        this(null, new LwM2mPath(objectId), resources);
+        this(null, new LwM2mPath(objectId), null, resources);
     }
 
     /**
@@ -66,7 +69,7 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(ContentFormat contentFormat, int objectId, Collection<LwM2mResource> resources) {
-        this(contentFormat, new LwM2mPath(objectId), resources.toArray(new LwM2mResource[resources.size()]));
+        this(contentFormat, objectId, resources.toArray(new LwM2mResource[resources.size()]));
     }
 
     /**
@@ -77,57 +80,31 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(int objectId, Collection<LwM2mResource> resources) {
-        this(null, objectId, resources.toArray(new LwM2mResource[resources.size()]));
+        this(objectId, resources.toArray(new LwM2mResource[resources.size()]));
     }
 
-    // ***************** constructor with object instance id ******************* /
+    // ***************** constructor with object instance ******************* /
 
     /**
      * Creates a request for creating an instance of a particular object.
      * 
      * @param contentFormat the payload format
      * @param objectId the object id
-     * @param objectInstanceId the id of the new instance
-     * @param resources the resource values for the new instance
+     * @param instance the object instance
      */
-    public CreateRequest(ContentFormat contentFormat, int objectId, int objectInstanceId, LwM2mResource... resources) {
-        this(contentFormat, new LwM2mPath(objectId, objectInstanceId), resources);
+    public CreateRequest(ContentFormat contentFormat, int objectId, LwM2mObjectInstance instance) {
+        this(contentFormat, new LwM2mPath(objectId), instance.getId(), instance.getResources().values()
+                .toArray(new LwM2mResource[0]));
     }
 
     /**
      * Creates a request for creating an instance of a particular object using the TLV content format.
      * 
      * @param objectId the object id
-     * @param objectInstanceId the id of the new instance
-     * @param resources the resource values for the new instance
+     * @param instance the object instance
      */
-    public CreateRequest(int objectId, int objectInstanceId, LwM2mResource... resources) {
-        this(null, new LwM2mPath(objectId, objectInstanceId), resources);
-    }
-
-    /**
-     * Creates a request for creating an instance of a particular object.
-     * 
-     * @param contentFormat the payload format
-     * @param objectId the object id
-     * @param objectInstanceId the id of the new instance
-     * @param resources the resource values for the new instance
-     */
-    public CreateRequest(ContentFormat contentFormat, int objectId, int objectInstanceId,
-            Collection<LwM2mResource> resources) {
-        this(contentFormat, new LwM2mPath(objectId, objectInstanceId), resources.toArray(new LwM2mResource[resources
-                .size()]));
-    }
-
-    /**
-     * Creates a request for creating an instance of a particular object using the TLV content format.
-     * 
-     * @param objectId the object id
-     * @param objectInstanceId the id of the new instance
-     * @param resources the resource values for the new instance
-     */
-    public CreateRequest(int objectId, int objectInstanceId, Collection<LwM2mResource> resources) {
-        this(null, new LwM2mPath(objectId, objectInstanceId), resources.toArray(new LwM2mResource[resources.size()]));
+    public CreateRequest(int objectId, LwM2mObjectInstance instance) {
+        this(null, objectId, instance);
     }
 
     // ***************** string path constructor ******************* /
@@ -138,7 +115,7 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(String path, Collection<LwM2mResource> resources) {
-        this(null, new LwM2mPath(path), resources.toArray(new LwM2mResource[resources.size()]));
+        this(path, resources.toArray(new LwM2mResource[resources.size()]));
     }
 
     /**
@@ -149,7 +126,7 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(ContentFormat contentFormat, String path, Collection<LwM2mResource> resources) {
-        this(contentFormat, new LwM2mPath(path), resources.toArray(new LwM2mResource[resources.size()]));
+        this(contentFormat, path, resources.toArray(new LwM2mResource[resources.size()]));
     }
 
     /**
@@ -159,7 +136,7 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(String path, LwM2mResource... resources) {
-        this(null, new LwM2mPath(path), resources);
+        this(null, new LwM2mPath(path), null, resources);
     }
 
     /**
@@ -170,18 +147,20 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
      * @param resources the resource values for the new instance
      */
     public CreateRequest(ContentFormat contentFormat, String path, LwM2mResource... resources) {
-        this(contentFormat, new LwM2mPath(path), resources);
+        this(contentFormat, new LwM2mPath(path), null, resources);
     }
 
     // ***************** generic constructor ******************* /
 
-    private CreateRequest(ContentFormat format, LwM2mPath target, LwM2mResource[] resources) {
+    private CreateRequest(ContentFormat format, LwM2mPath target, Integer instanceId, LwM2mResource[] resources) {
         super(target);
 
-        if (target.isResource()) {
-            throw new IllegalArgumentException("Cannot create a resource node");
+        if (!target.isObject()) {
+            throw new IllegalArgumentException("Create request must target an object");
         }
 
+        Validate.isTrue(instanceId == null || instanceId >= 0, "Invalid instance id: " + instanceId);
+        this.instanceId = instanceId;
         this.resources = Collections.unmodifiableList(Arrays.asList(resources));
         this.contentFormat = format != null ? format : ContentFormat.TLV; // default to TLV
     }
@@ -193,6 +172,13 @@ public class CreateRequest extends AbstractDownlinkRequest<CreateResponse> {
 
     public List<LwM2mResource> getResources() {
         return resources;
+    }
+
+    /**
+     * @return the id of the new instance. <code>null</code> if not assigned by the server.
+     */
+    public Integer getInstanceId() {
+        return instanceId;
     }
 
     public ContentFormat getContentFormat() {

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
@@ -96,8 +96,8 @@ public class LwM2mNodeDecoderTest {
         assertEquals(value, resource.getValue());
     }
 
-    // tlv content for instance 0 of device object
-    private final static byte[] DEVICE_CONTENT = new byte[] { -56, 0, 20, 79, 112, 101, 110, 32, 77, 111, 98, 105, 108,
+    // tlv content for instance 0 of device object (encoded as an array of resource TLVs)
+    private final static byte[] ENCODED_DEVICE = new byte[] { -56, 0, 20, 79, 112, 101, 110, 32, 77, 111, 98, 105, 108,
                             101, 32, 65, 108, 108, 105, 97, 110, 99, 101, -56, 1, 22, 76, 105, 103, 104, 116, 119, 101,
                             105, 103, 104, 116, 32, 77, 50, 77, 32, 67, 108, 105, 101, 110, 116, -56, 2, 9, 51, 52, 53,
                             48, 48, 48, 49, 50, 51, -61, 3, 49, 46, 48, -122, 6, 65, 0, 1, 65, 1, 5, -120, 7, 8, 66, 0,
@@ -106,7 +106,7 @@ public class LwM2mNodeDecoderTest {
 
     @Test
     public void tlv_device_object_mono_instance() throws Exception {
-        LwM2mObjectInstance oInstance = ((LwM2mObject) LwM2mNodeDecoder.decode(DEVICE_CONTENT, ContentFormat.TLV,
+        LwM2mObjectInstance oInstance = ((LwM2mObject) LwM2mNodeDecoder.decode(ENCODED_DEVICE, ContentFormat.TLV,
                 new LwM2mPath(3), model)).getInstance(0);
         assertDeviceInstance(oInstance);
     }
@@ -138,10 +138,31 @@ public class LwM2mNodeDecoderTest {
     }
 
     @Test
-    public void tlv_device_object_instance0() throws InvalidValueException {
+    public void tlv_device_object_instance0_from_resources_tlv() throws InvalidValueException {
 
-        LwM2mObjectInstance oInstance = (LwM2mObjectInstance) LwM2mNodeDecoder.decode(DEVICE_CONTENT,
+        LwM2mObjectInstance oInstance = (LwM2mObjectInstance) LwM2mNodeDecoder.decode(ENCODED_DEVICE,
                 ContentFormat.TLV, new LwM2mPath(3, 0), model);
+        assertDeviceInstance(oInstance);
+    }
+
+    @Test
+    public void tlv_device_object_instance0_from_resources_tlv__instance_expected() throws InvalidValueException {
+
+        LwM2mObjectInstance oInstance = (LwM2mObjectInstance) LwM2mNodeDecoder.decode(ENCODED_DEVICE,
+                ContentFormat.TLV, new LwM2mPath(3), model, LwM2mObjectInstance.class);
+        assertDeviceInstance(oInstance);
+    }
+
+    @Test
+    public void tlv_device_object_instance0_from_instance_tlv() throws InvalidValueException {
+
+        // TLV instance = { type=INSTANCE, instanceId=0, length=DEVICE_ENCODED.lentgh, value=DEVICE_ENCODED }
+        byte[] instanceTlv = new byte[ENCODED_DEVICE.length + 3];
+        System.arraycopy(new byte[] { 8, 0, 119 }, 0, instanceTlv, 0, 3);
+        System.arraycopy(ENCODED_DEVICE, 0, instanceTlv, 3, ENCODED_DEVICE.length);
+
+        LwM2mObjectInstance oInstance = (LwM2mObjectInstance) LwM2mNodeDecoder.decode(instanceTlv, ContentFormat.TLV,
+                new LwM2mPath(3, 0), model);
         assertDeviceInstance(oInstance);
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
@@ -18,8 +18,12 @@ package org.eclipse.leshan.integration.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
+
 import org.eclipse.leshan.ResponseCode;
+import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.request.CreateRequest;
 import org.eclipse.leshan.core.request.DeleteRequest;
 import org.eclipse.leshan.core.response.DeleteResponse;
@@ -49,7 +53,10 @@ public class DeleteTest {
     @Test
     public void delete_created_object_instance() throws InterruptedException {
         // create ACL instance
-        helper.server.send(helper.getClient(), new CreateRequest(2, 0, new LwM2mResource[0]));
+        helper.server.send(
+                helper.getClient(),
+                new CreateRequest(2, new LwM2mObjectInstance(0, Arrays.asList(new LwM2mResource[] { LwM2mSingleResource
+                        .newIntegerResource(0, 123) }))));
 
         // try to delete this instance
         DeleteResponse deleteResponse = helper.server.send(helper.getClient(), new DeleteRequest(2, 0));

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CoapRequestBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CoapRequestBuilder.java
@@ -94,8 +94,9 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     public void visit(CreateRequest request) {
         coapRequest = Request.newPost();
         coapRequest.getOptions().setContentFormat(request.getContentFormat().getCode());
-        // wrap the resources into an object instance layer (with a fake instance id).
-        coapRequest.setPayload(LwM2mNodeEncoder.encode(new LwM2mObjectInstance(-1, request.getResources()),
+        // if no instance id, the client will assign it.
+        int instanceId = request.getInstanceId() != null ? request.getInstanceId() : LwM2mObjectInstance.UNDEFINED;
+        coapRequest.setPayload(LwM2mNodeEncoder.encode(new LwM2mObjectInstance(instanceId, request.getResources()),
                 request.getContentFormat(), request.getPath(), model));
         setTarget(coapRequest, destination, request.getPath());
     }


### PR DESCRIPTION
Following a specification change, the instance Id is not part the the Create Request path anymore.
The request payload contains an object instance or list of resources (if the client is in charge of picking the new instance Id).

Encoders/decoders were updated to be able to encode/decode an object instance as an instance or as a array of resources. Some work is stil to be done for JSON format.

This PR fixes the related issue on the client-side (#75). 