### PR TITLE
Clear DTLS Session when bootstrap session is finished.

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
@@ -18,6 +18,8 @@ package org.eclipse.leshan.client.servers;
 import static org.eclipse.leshan.LwM2mId.SECURITY;
 import static org.eclipse.leshan.LwM2mId.SERVER;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +42,7 @@ public class BootstrapHandler {
 
     private ServerInfo bootstrapServerInfo;
     private final Map<Integer, LwM2mObjectEnabler> objects;
+    private final List<BootstrapListener> listeners = new ArrayList<>();
 
     public BootstrapHandler(Map<Integer, LwM2mObjectEnabler> objectEnablers) {
         objects = objectEnablers;
@@ -108,6 +111,18 @@ public class BootstrapHandler {
         bootstrapServerInfo = null;
         bootstrappingLatch = null;
         bootstrapping = false;
+
+        for (BootstrapListener listener : listeners) {
+            listener.bootstrapFinished();
+        }
+    }
+
+    public void addBootstrapListener(BootstrapListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeBootstrapListener(BootstrapListener listener) {
+        listeners.remove(listener);
     }
 
     /**

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapListener.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapListener.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.servers;
+
+/**
+ * Listen for bootstrap session event.
+ */
+public interface BootstrapListener {
+
+    /**
+     * Invoked when a bootstrap session is closed.<br/>
+     * 
+     * Generally when we receive a bootstrap finished request or when the bootstrap session ends in an unexpected
+     * way.(e.g. bootstrap server is not responding anymore)
+     */
+    void bootstrapFinished();
+}


### PR DESCRIPTION
A fix for the #80 issue.
When Boostrap session is finished, we clear all DTLS connections from the store.