### PR TITLE
Protect security object from invalid access.

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/BootstrapResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/BootstrapResource.java
@@ -12,15 +12,16 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.leshan.client.request.ExtendedIdentity;
 import org.eclipse.leshan.client.servers.BootstrapHandler;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
-import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapFinishResponse;
 
 /**
@@ -37,7 +38,7 @@ public class BootstrapResource extends CoapResource {
 
     @Override
     public void handlePOST(CoapExchange exchange) {
-        Identity identity = ResourceUtil.extractIdentity(exchange);
+        ExtendedIdentity identity = ResourceUtil.extractIdentity(exchange, bootstrapHandler);
         BootstrapFinishResponse response = bootstrapHandler.finished(identity, new BootstrapFinishRequest());
         exchange.respond(ResourceUtil.fromLwM2mCode(response.getCode()), response.getErrorMessage());
     }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/BootstrapResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/BootstrapResource.java
@@ -12,14 +12,14 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.servers.BootstrapHandler;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
 import org.eclipse.leshan.core.response.BootstrapFinishResponse;
@@ -38,7 +38,7 @@ public class BootstrapResource extends CoapResource {
 
     @Override
     public void handlePOST(CoapExchange exchange) {
-        ExtendedIdentity identity = ResourceUtil.extractIdentity(exchange, bootstrapHandler);
+        ServerIdentity identity = ResourceUtil.extractServerIdentity(exchange, bootstrapHandler);
         BootstrapFinishResponse response = bootstrapHandler.finished(identity, new BootstrapFinishRequest());
         exchange.respond(ResourceUtil.fromLwM2mCode(response.getCode()), response.getErrorMessage());
     }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ObjectResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ObjectResource.java
@@ -169,7 +169,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
             try {
                 LwM2mModel model = new LwM2mModel(nodeEnabler.getObjectModel());
                 lwM2mNode = LwM2mNodeDecoder.decode(coapExchange.getRequestPayload(), contentFormat, path, model);
-                if (identity.isBootstrap()) {
+                if (identity.isLwm2mBootstrapServer()) {
                     BootstrapWriteResponse response = nodeEnabler.write(identity, new BootstrapWriteRequest(path,
                             lwM2mNode, contentFormat));
                     coapExchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ObjectResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ObjectResource.java
@@ -13,7 +13,7 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - use ObserveRelationFilter
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
@@ -30,7 +30,7 @@ import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.leshan.LinkObject;
 import org.eclipse.leshan.ObserveSpec;
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.NotifySender;
 import org.eclipse.leshan.client.servers.BootstrapHandler;
@@ -96,7 +96,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
 
     @Override
     public void handleGET(CoapExchange exchange) {
-        ExtendedIdentity identity = extractIdentity(exchange, bootstrapHandler);
+        ServerIdentity identity = extractServerIdentity(exchange, bootstrapHandler);
         String URI = exchange.getRequestOptions().getUriPathString();
 
         // Manage Discover Request
@@ -143,7 +143,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
 
     @Override
     public void handlePUT(final CoapExchange coapExchange) {
-        ExtendedIdentity identity = extractIdentity(coapExchange, bootstrapHandler);
+        ServerIdentity identity = extractServerIdentity(coapExchange, bootstrapHandler);
 
         String URI = coapExchange.getRequestOptions().getUriPathString();
 
@@ -191,7 +191,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
 
     @Override
     public void handlePOST(final CoapExchange exchange) {
-        ExtendedIdentity identity = extractIdentity(exchange, bootstrapHandler);
+        ServerIdentity identity = extractServerIdentity(exchange, bootstrapHandler);
         String URI = exchange.getRequestOptions().getUriPathString();
 
         LwM2mPath path = new LwM2mPath(URI);
@@ -249,7 +249,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
     public void handleDELETE(final CoapExchange coapExchange) {
         // Manage Delete Request
         String URI = coapExchange.getRequestOptions().getUriPathString();
-        ExtendedIdentity identity = extractIdentity(coapExchange, bootstrapHandler);
+        ServerIdentity identity = extractServerIdentity(coapExchange, bootstrapHandler);
 
         DeleteResponse response = nodeEnabler.delete(identity, new DeleteRequest(URI));
         coapExchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ResourceUtil.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ResourceUtil.java
@@ -12,7 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
@@ -28,7 +28,7 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.scandium.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.servers.BootstrapHandler;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.util.Validate;
@@ -39,14 +39,17 @@ public class ResourceUtil {
     private static final Logger LOG = LoggerFactory.getLogger(ResourceUtil.class);
 
     // TODO: validate addresses using the security object instances?
-    public static ExtendedIdentity extractIdentity(CoapExchange exchange, BootstrapHandler bootstrapHandler) {
+    // in case of multiple bootstrap instances of the security object,
+    // using BootstrapHandler may be not the right choice, because it
+    // handles the current bootstrap server.
+    public static ServerIdentity extractServerIdentity(CoapExchange exchange, BootstrapHandler bootstrapHandler) {
         Identity identity = extractIdentity(exchange);
 
         if (bootstrapHandler.isBootstrapServer(identity)) {
-            return ExtendedIdentity.createLwm2mBootstrapServerIdentity(identity);
+            return ServerIdentity.createLwm2mBootstrapServerIdentity(identity);
         }
 
-        return ExtendedIdentity.createLwm2mServerIdentity(identity);
+        return ServerIdentity.createLwm2mServerIdentity(identity);
     }
 
     // TODO leshan-core-cf: this code should be factorized in a leshan-core-cf project.

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ResourceUtil.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ResourceUtil.java
@@ -43,10 +43,10 @@ public class ResourceUtil {
         Identity identity = extractIdentity(exchange);
 
         if (bootstrapHandler.isBootstrapServer(identity)) {
-            return ExtendedIdentity.bootstrap(identity);
+            return ExtendedIdentity.createLwm2mBootstrapServerIdentity(identity);
         }
 
-        return ExtendedIdentity.dataManagement(identity);
+        return ExtendedIdentity.createLwm2mServerIdentity(identity);
     }
 
     // TODO leshan-core-cf: this code should be factorized in a leshan-core-cf project.

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/RootResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/RootResource.java
@@ -12,15 +12,16 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.leshan.client.request.ExtendedIdentity;
 import org.eclipse.leshan.client.servers.BootstrapHandler;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
-import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapDeleteResponse;
 import org.eclipse.leshan.util.StringUtils;
 
@@ -43,7 +44,7 @@ public class RootResource extends CoapResource {
             return;
         }
 
-        Identity identity = ResourceUtil.extractIdentity(exchange);
+        ExtendedIdentity identity = ResourceUtil.extractIdentity(exchange, bootstrapHandler);
         BootstrapDeleteResponse response = bootstrapHandler.delete(identity, new BootstrapDeleteRequest());
         exchange.respond(ResourceUtil.fromLwM2mCode(response.getCode()), response.getErrorMessage());
     }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/RootResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/RootResource.java
@@ -12,14 +12,14 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.server.resources.CoapExchange;
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.servers.BootstrapHandler;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.response.BootstrapDeleteResponse;
@@ -44,7 +44,7 @@ public class RootResource extends CoapResource {
             return;
         }
 
-        ExtendedIdentity identity = ResourceUtil.extractIdentity(exchange, bootstrapHandler);
+        ServerIdentity identity = ResourceUtil.extractServerIdentity(exchange, bootstrapHandler);
         BootstrapDeleteResponse response = bootstrapHandler.delete(identity, new BootstrapDeleteRequest());
         exchange.respond(ResourceUtil.fromLwM2mCode(response.getCode()), response.getErrorMessage());
     }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/SecurityObjectPskStore.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/SecurityObjectPskStore.java
@@ -12,7 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity.SYSTEM
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity.SYSTEM
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
@@ -21,7 +21,7 @@ import static org.eclipse.leshan.LwM2mId.SEC_PUBKEY_IDENTITY;
 import static org.eclipse.leshan.LwM2mId.SEC_SECRET_KEY;
 import static org.eclipse.leshan.LwM2mId.SEC_SECURITY_MODE;
 import static org.eclipse.leshan.LwM2mId.SEC_SERVER_URI;
-import static org.eclipse.leshan.client.request.ExtendedIdentity.SYSTEM;
+import static org.eclipse.leshan.client.request.ServerIdentity.SYSTEM;
 
 import java.net.InetSocketAddress;
 import java.net.URI;

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/SecurityObjectPskStore.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/SecurityObjectPskStore.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity.SYSTEM
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
@@ -20,6 +21,7 @@ import static org.eclipse.leshan.LwM2mId.SEC_PUBKEY_IDENTITY;
 import static org.eclipse.leshan.LwM2mId.SEC_SECRET_KEY;
 import static org.eclipse.leshan.LwM2mId.SEC_SECURITY_MODE;
 import static org.eclipse.leshan.LwM2mId.SEC_SERVER_URI;
+import static org.eclipse.leshan.client.request.ExtendedIdentity.SYSTEM;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -51,7 +53,7 @@ public class SecurityObjectPskStore implements PskStore {
         if (identity == null)
             return null;
 
-        LwM2mObject securities = (LwM2mObject) securityEnabler.read(null, new ReadRequest(SECURITY)).getContent();
+        LwM2mObject securities = (LwM2mObject) securityEnabler.read(SYSTEM, new ReadRequest(SECURITY)).getContent();
         for (LwM2mObjectInstance security : securities.getInstances().values()) {
             long securityMode = (long) security.getResource(SEC_SECURITY_MODE).getValue();
             // TODO use SecurityMode from serve.core ?
@@ -70,7 +72,7 @@ public class SecurityObjectPskStore implements PskStore {
         if (inetAddress == null)
             return null;
 
-        LwM2mObject securities = (LwM2mObject) securityEnabler.read(null, new ReadRequest(SECURITY)).getContent();
+        LwM2mObject securities = (LwM2mObject) securityEnabler.read(SYSTEM, new ReadRequest(SECURITY)).getContent();
         for (LwM2mObjectInstance security : securities.getInstances().values()) {
             long securityMode = (long) security.getResource(SEC_SECURITY_MODE).getValue();
             // TODO use SecurityMode from server.core ?

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/ExtendedIdentity.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/ExtendedIdentity.java
@@ -20,43 +20,108 @@ import java.net.InetSocketAddress;
 
 import org.eclipse.leshan.core.request.Identity;
 
+/**
+ * Extend the identity with client relevant additional information. Introduce roles for the identity and makes those
+ * roles accessible within the processing context of the Identity.
+ * 
+ * @author Achim Kraus (Bosch Software Innovations GmbH)
+ *
+ */
 public class ExtendedIdentity extends Identity {
 
     enum Role {
-        SYSTEM, DATA_MANAGEMENT, BOOTSTRAP
+        /**
+         * Indicate internal call. Enables the "system" to read protected resources (e.g. resources of the security
+         * object).
+         */
+        SYSTEM,
+        /**
+         * Indicate call from a LWM2M server.
+         */
+        LWM2M_SERVER,
+        /**
+         * Indicate call from a LWM2M bootstrap server.
+         */
+        LWM2M_BOOTSTRAP_SERVER
     }
 
+    /**
+     * Identity for system calls.
+     */
     public final static ExtendedIdentity SYSTEM = new ExtendedIdentity(Identity.unsecure(InetSocketAddress
             .createUnresolved("system", 1)), Role.SYSTEM);
+
+    /**
+     * Role of the associated identity.
+     */
     private final Role role;
 
+    /**
+     * Create ExtendedIdentity using a Identity and the related role. Intended to be used by calling
+     * {@link #createLwm2mBootstrapServerIdentity(Identity)} or {@link #createLwm2mServerIdentity(Identity)}.
+     * 
+     * @param identity identity to be used
+     * @param role related role
+     */
     private ExtendedIdentity(final Identity identity, final Role role) {
         super(identity);
         this.role = role;
     }
 
+    /**
+     * Get related role.
+     * 
+     * @return {@link Role#SYSTEM}, {@link Role#LWM2M_SERVER}, or {@link Role#LWM2M_BOOTSTRAP_SERVER}.
+     */
     public Role getRole() {
         return role;
     }
 
-    public boolean isBootstrap() {
-        return Role.BOOTSTRAP == role;
+    /**
+     * Test, if identity has role {@link Role#LWM2M_BOOTSTRAP_SERVER}.
+     * 
+     * @return true, if identity is from a LWM2M bootstrap server, false, otherwise
+     */
+    public boolean isLwm2mBootstrapServer() {
+        return Role.LWM2M_BOOTSTRAP_SERVER == role;
     }
 
-    public boolean isDataManagement() {
-        return Role.DATA_MANAGEMENT == role;
+    /**
+     * Test, if identity has role {@link Role#LWM2M_SERVER}.
+     * 
+     * @return true, if identity is from a LWM2M server, false, otherwise
+     */
+    public boolean isLwm2mServer() {
+        return Role.LWM2M_SERVER == role;
     }
 
+    /**
+     * Test, if identity has role {@link Role#SYSTEM}.
+     * 
+     * @return true, if identity is from system, false, otherwise
+     */
     public boolean isSystem() {
         return Role.SYSTEM == role;
     }
 
-    public static ExtendedIdentity bootstrap(final Identity identity) {
-        return new ExtendedIdentity(identity, Role.BOOTSTRAP);
+    /**
+     * Create a extended identity with role {@link Role#LWM2M_BOOTSTRAP_SERVER}.
+     * 
+     * @param identity identity to be used
+     * @return extended identity with {@link Role#LWM2M_BOOTSTRAP_SERVER} associated.
+     */
+    public static ExtendedIdentity createLwm2mBootstrapServerIdentity(final Identity identity) {
+        return new ExtendedIdentity(identity, Role.LWM2M_BOOTSTRAP_SERVER);
     }
 
-    public static ExtendedIdentity dataManagement(final Identity identity) {
-        return new ExtendedIdentity(identity, Role.DATA_MANAGEMENT);
+    /**
+     * Create a extended identity with role {@link Role#LWM2M_SERVER}.
+     * 
+     * @param identity identity to be used
+     * @return extended identity with {@link Role#LWM2M_SERVER} associated.
+     */
+    public static ExtendedIdentity createLwm2mServerIdentity(final Identity identity) {
+        return new ExtendedIdentity(identity, Role.LWM2M_SERVER);
     }
 
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/ExtendedIdentity.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/ExtendedIdentity.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial creation
+ ******************************************************************************/
+
+package org.eclipse.leshan.client.request;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.leshan.core.request.Identity;
+
+public class ExtendedIdentity extends Identity {
+
+    enum Role {
+        SYSTEM, DATA_MANAGEMENT, BOOTSTRAP
+    }
+
+    public final static ExtendedIdentity SYSTEM = new ExtendedIdentity(Identity.unsecure(InetSocketAddress
+            .createUnresolved("system", 1)), Role.SYSTEM);
+    private final Role role;
+
+    private ExtendedIdentity(final Identity identity, final Role role) {
+        super(identity);
+        this.role = role;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public boolean isBootstrap() {
+        return Role.BOOTSTRAP == role;
+    }
+
+    public boolean isDataManagement() {
+        return Role.DATA_MANAGEMENT == role;
+    }
+
+    public boolean isSystem() {
+        return Role.SYSTEM == role;
+    }
+
+    public static ExtendedIdentity bootstrap(final Identity identity) {
+        return new ExtendedIdentity(identity, Role.BOOTSTRAP);
+    }
+
+    public static ExtendedIdentity dataManagement(final Identity identity) {
+        return new ExtendedIdentity(identity, Role.DATA_MANAGEMENT);
+    }
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/ServerIdentity.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/ServerIdentity.java
@@ -27,7 +27,7 @@ import org.eclipse.leshan.core.request.Identity;
  * @author Achim Kraus (Bosch Software Innovations GmbH)
  *
  */
-public class ExtendedIdentity extends Identity {
+public class ServerIdentity extends Identity {
 
     enum Role {
         /**
@@ -48,7 +48,7 @@ public class ExtendedIdentity extends Identity {
     /**
      * Identity for system calls.
      */
-    public final static ExtendedIdentity SYSTEM = new ExtendedIdentity(Identity.unsecure(InetSocketAddress
+    public final static ServerIdentity SYSTEM = new ServerIdentity(Identity.unsecure(InetSocketAddress
             .createUnresolved("system", 1)), Role.SYSTEM);
 
     /**
@@ -57,13 +57,13 @@ public class ExtendedIdentity extends Identity {
     private final Role role;
 
     /**
-     * Create ExtendedIdentity using a Identity and the related role. Intended to be used by calling
+     * Create ServerIdentity using a Identity and the related role. Intended to be used by calling
      * {@link #createLwm2mBootstrapServerIdentity(Identity)} or {@link #createLwm2mServerIdentity(Identity)}.
      * 
      * @param identity identity to be used
      * @param role related role
      */
-    private ExtendedIdentity(final Identity identity, final Role role) {
+    private ServerIdentity(final Identity identity, final Role role) {
         super(identity);
         this.role = role;
     }
@@ -105,23 +105,23 @@ public class ExtendedIdentity extends Identity {
     }
 
     /**
-     * Create a extended identity with role {@link Role#LWM2M_BOOTSTRAP_SERVER}.
+     * Create a server identity with role {@link Role#LWM2M_BOOTSTRAP_SERVER}.
      * 
      * @param identity identity to be used
-     * @return extended identity with {@link Role#LWM2M_BOOTSTRAP_SERVER} associated.
+     * @return server identity with {@link Role#LWM2M_BOOTSTRAP_SERVER} associated.
      */
-    public static ExtendedIdentity createLwm2mBootstrapServerIdentity(final Identity identity) {
-        return new ExtendedIdentity(identity, Role.LWM2M_BOOTSTRAP_SERVER);
+    public static ServerIdentity createLwm2mBootstrapServerIdentity(final Identity identity) {
+        return new ServerIdentity(identity, Role.LWM2M_BOOTSTRAP_SERVER);
     }
 
     /**
-     * Create a extended identity with role {@link Role#LWM2M_SERVER}.
+     * Create a server identity with role {@link Role#LWM2M_SERVER}.
      * 
      * @param identity identity to be used
-     * @return extended identity with {@link Role#LWM2M_SERVER} associated.
+     * @return server identity with {@link Role#LWM2M_SERVER} associated.
      */
-    public static ExtendedIdentity createLwm2mServerIdentity(final Identity identity) {
-        return new ExtendedIdentity(identity, Role.LWM2M_SERVER);
+    public static ServerIdentity createLwm2mServerIdentity(final Identity identity) {
+        return new ServerIdentity(identity, Role.LWM2M_SERVER);
     }
 
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -93,7 +93,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     public synchronized final ReadResponse read(ExtendedIdentity identity, ReadRequest request) {
         LwM2mPath path = request.getPath();
 
-        if (identity.isBootstrap()) {
+        if (identity.isLwm2mBootstrapServer()) {
             // read is not supported for bootstrap
             return ReadResponse.methodNotAllowed();
         }
@@ -127,7 +127,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     public synchronized final WriteResponse write(ExtendedIdentity identity, WriteRequest request) {
         LwM2mPath path = request.getPath();
 
-        if (identity.isBootstrap()) {
+        if (identity.isLwm2mBootstrapServer()) {
             // write is not supported for bootstrap, use bootstrap write
             return WriteResponse.methodNotAllowed();
         }
@@ -160,9 +160,9 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     public synchronized final BootstrapWriteResponse write(ExtendedIdentity identity, BootstrapWriteRequest request) {
         LwM2mPath path = request.getPath();
 
-        if (!identity.isBootstrap()) {
+        if (!identity.isLwm2mBootstrapServer()) {
             // write is not supported for bootstrap, use bootstrap write
-            return BootstrapWriteResponse.internalServerError("bootstrap write request decoding error");
+            return BootstrapWriteResponse.internalServerError("bootstrap write request from LWM2M server");
         }
 
         // check if the resource is writable
@@ -185,7 +185,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
 
     @Override
     public synchronized final DeleteResponse delete(ExtendedIdentity identity, DeleteRequest request) {
-        if (!identity.isBootstrap() && !identity.isSystem()) {
+        if (!identity.isLwm2mBootstrapServer() && !identity.isSystem()) {
 
             if (id == LwM2mId.SECURITY) {
                 return DeleteResponse.notFound();
@@ -196,7 +196,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
                 return DeleteResponse.methodNotAllowed();
             }
 
-            // we can not create new instance on single object
+            // we can not delete instance on single object
             if (objectModel != null && !objectModel.multiple) {
                 return DeleteResponse.methodNotAllowed();
             }
@@ -214,7 +214,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     public synchronized final ExecuteResponse execute(ExtendedIdentity identity, ExecuteRequest request) {
         LwM2mPath path = request.getPath();
 
-        if (identity.isBootstrap()) {
+        if (identity.isLwm2mBootstrapServer()) {
             // execute is not supported for bootstrap
             return ExecuteResponse.methodNotAllowed();
         }
@@ -253,7 +253,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     @Override
     public synchronized DiscoverResponse discover(ExtendedIdentity identity, DiscoverRequest request) {
 
-        if (identity.isBootstrap()) {
+        if (identity.isLwm2mBootstrapServer()) {
             // discover is not supported for bootstrap
             return DiscoverResponse.methodNotAllowed();
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -13,14 +13,14 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - deny delete of resource
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity to 
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity to 
  *                                                     protect the security object
  *******************************************************************************/
 package org.eclipse.leshan.client.resource;
 
 import org.eclipse.leshan.LinkObject;
 import org.eclipse.leshan.LwM2mId;
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.util.LinkFormatHelper;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
@@ -66,7 +66,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized final CreateResponse create(ExtendedIdentity identity, CreateRequest request) {
+    public synchronized final CreateResponse create(ServerIdentity identity, CreateRequest request) {
         // we can not create new instance on single object
 
         if (!identity.isSystem()) {
@@ -90,7 +90,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized final ReadResponse read(ExtendedIdentity identity, ReadRequest request) {
+    public synchronized final ReadResponse read(ServerIdentity identity, ReadRequest request) {
         LwM2mPath path = request.getPath();
 
         if (identity.isLwm2mBootstrapServer()) {
@@ -118,13 +118,13 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
         // TODO we could do a validation of response.getContent by comparing with the spec.
     }
 
-    protected ReadResponse doRead(ReadRequest request, ExtendedIdentity identity) {
+    protected ReadResponse doRead(ReadRequest request, ServerIdentity identity) {
         // This should be a not implemented error, but this is not defined in the spec.
         return ReadResponse.internalServerError("not implemented");
     }
 
     @Override
-    public synchronized final WriteResponse write(ExtendedIdentity identity, WriteRequest request) {
+    public synchronized final WriteResponse write(ServerIdentity identity, WriteRequest request) {
         LwM2mPath path = request.getPath();
 
         if (identity.isLwm2mBootstrapServer()) {
@@ -157,7 +157,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized final BootstrapWriteResponse write(ExtendedIdentity identity, BootstrapWriteRequest request) {
+    public synchronized final BootstrapWriteResponse write(ServerIdentity identity, BootstrapWriteRequest request) {
         LwM2mPath path = request.getPath();
 
         if (!identity.isLwm2mBootstrapServer()) {
@@ -184,7 +184,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized final DeleteResponse delete(ExtendedIdentity identity, DeleteRequest request) {
+    public synchronized final DeleteResponse delete(ServerIdentity identity, DeleteRequest request) {
         if (!identity.isLwm2mBootstrapServer() && !identity.isSystem()) {
 
             if (id == LwM2mId.SECURITY) {
@@ -211,7 +211,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized final ExecuteResponse execute(ExtendedIdentity identity, ExecuteRequest request) {
+    public synchronized final ExecuteResponse execute(ServerIdentity identity, ExecuteRequest request) {
         LwM2mPath path = request.getPath();
 
         if (identity.isLwm2mBootstrapServer()) {
@@ -243,7 +243,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized WriteAttributesResponse writeAttributes(ExtendedIdentity identity,
+    public synchronized WriteAttributesResponse writeAttributes(ServerIdentity identity,
             WriteAttributesRequest request) {
         // TODO should be implemented here to be available for all object enabler
         // This should be a not implemented error, but this is not defined in the spec.
@@ -251,7 +251,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized DiscoverResponse discover(ExtendedIdentity identity, DiscoverRequest request) {
+    public synchronized DiscoverResponse discover(ServerIdentity identity, DiscoverRequest request) {
 
         if (identity.isLwm2mBootstrapServer()) {
             // discover is not supported for bootstrap
@@ -296,7 +296,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized ObserveResponse observe(ExtendedIdentity identity, ObserveRequest request) {
+    public synchronized ObserveResponse observe(ServerIdentity identity, ObserveRequest request) {
         ReadResponse readResponse = this.read(identity, new ReadRequest(request.getPath().toString()));
         return new ObserveResponse(readResponse.getCode(), readResponse.getContent(), null,
                 readResponse.getErrorMessage());

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
@@ -12,18 +12,19 @@
  *
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.resource;
 
 import java.util.List;
 
+import org.eclipse.leshan.client.request.ExtendedIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.CreateRequest;
 import org.eclipse.leshan.core.request.DeleteRequest;
 import org.eclipse.leshan.core.request.DiscoverRequest;
 import org.eclipse.leshan.core.request.ExecuteRequest;
-import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.request.ObserveRequest;
 import org.eclipse.leshan.core.request.ReadRequest;
 import org.eclipse.leshan.core.request.WriteAttributesRequest;
@@ -46,23 +47,23 @@ public interface LwM2mObjectEnabler {
 
     List<Integer> getAvailableInstanceIds();
 
-    CreateResponse create(Identity identity, CreateRequest request);
+    CreateResponse create(ExtendedIdentity identity, CreateRequest request);
 
-    ReadResponse read(Identity identity, ReadRequest request);
+    ReadResponse read(ExtendedIdentity identity, ReadRequest request);
 
-    WriteResponse write(Identity identity, WriteRequest request);
+    WriteResponse write(ExtendedIdentity identity, WriteRequest request);
 
-    BootstrapWriteResponse write(Identity identity, BootstrapWriteRequest request);
+    BootstrapWriteResponse write(ExtendedIdentity identity, BootstrapWriteRequest request);
 
-    DeleteResponse delete(Identity identity, DeleteRequest request);
+    DeleteResponse delete(ExtendedIdentity identity, DeleteRequest request);
 
-    ExecuteResponse execute(Identity identity, ExecuteRequest request);
+    ExecuteResponse execute(ExtendedIdentity identity, ExecuteRequest request);
 
-    WriteAttributesResponse writeAttributes(Identity identity, WriteAttributesRequest request);
+    WriteAttributesResponse writeAttributes(ExtendedIdentity identity, WriteAttributesRequest request);
 
-    DiscoverResponse discover(Identity identity, DiscoverRequest request);
+    DiscoverResponse discover(ExtendedIdentity identity, DiscoverRequest request);
 
-    ObserveResponse observe(Identity identity, ObserveRequest request);
+    ObserveResponse observe(ExtendedIdentity identity, ObserveRequest request);
 
     void setNotifySender(NotifySender sender);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
@@ -12,13 +12,13 @@
  *
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.resource;
 
 import java.util.List;
 
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.CreateRequest;
@@ -47,23 +47,23 @@ public interface LwM2mObjectEnabler {
 
     List<Integer> getAvailableInstanceIds();
 
-    CreateResponse create(ExtendedIdentity identity, CreateRequest request);
+    CreateResponse create(ServerIdentity identity, CreateRequest request);
 
-    ReadResponse read(ExtendedIdentity identity, ReadRequest request);
+    ReadResponse read(ServerIdentity identity, ReadRequest request);
 
-    WriteResponse write(ExtendedIdentity identity, WriteRequest request);
+    WriteResponse write(ServerIdentity identity, WriteRequest request);
 
-    BootstrapWriteResponse write(ExtendedIdentity identity, BootstrapWriteRequest request);
+    BootstrapWriteResponse write(ServerIdentity identity, BootstrapWriteRequest request);
 
-    DeleteResponse delete(ExtendedIdentity identity, DeleteRequest request);
+    DeleteResponse delete(ServerIdentity identity, DeleteRequest request);
 
-    ExecuteResponse execute(ExtendedIdentity identity, ExecuteRequest request);
+    ExecuteResponse execute(ServerIdentity identity, ExecuteRequest request);
 
-    WriteAttributesResponse writeAttributes(ExtendedIdentity identity, WriteAttributesRequest request);
+    WriteAttributesResponse writeAttributes(ServerIdentity identity, WriteAttributesRequest request);
 
-    DiscoverResponse discover(ExtendedIdentity identity, DiscoverRequest request);
+    DiscoverResponse discover(ServerIdentity identity, DiscoverRequest request);
 
-    ObserveResponse observe(ExtendedIdentity identity, ObserveRequest request);
+    ObserveResponse observe(ServerIdentity identity, ObserveRequest request);
 
     void setNotifySender(NotifySender sender);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -12,6 +12,7 @@
  *
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.resource;
 
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.leshan.ResponseCode;
+import org.eclipse.leshan.client.request.ExtendedIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mObject;
@@ -33,7 +35,6 @@ import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.CreateRequest;
 import org.eclipse.leshan.core.request.DeleteRequest;
 import org.eclipse.leshan.core.request.ExecuteRequest;
-import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.request.ReadRequest;
 import org.eclipse.leshan.core.request.WriteRequest;
 import org.eclipse.leshan.core.request.WriteRequest.Mode;
@@ -103,7 +104,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
     }
 
     @Override
-    protected ReadResponse doRead(ReadRequest request, Identity identity) {
+    protected ReadResponse doRead(ReadRequest request, ExtendedIdentity identity) {
         LwM2mPath path = request.getPath();
 
         // Manage Object case
@@ -128,11 +129,11 @@ public class ObjectEnabler extends BaseObjectEnabler {
         return instance.read(path.getResourceId());
     }
 
-    LwM2mObjectInstance getLwM2mObjectInstance(int instanceid, LwM2mInstanceEnabler instance, Identity identity) {
+    LwM2mObjectInstance getLwM2mObjectInstance(int instanceid, LwM2mInstanceEnabler instance, ExtendedIdentity identity) {
         List<LwM2mResource> resources = new ArrayList<>();
         for (ResourceModel resourceModel : getObjectModel().resources.values()) {
             // if internal request (null identity) or readable
-            if (identity == null || resourceModel.operations.isReadable()) {
+            if (identity.isSystem() || resourceModel.operations.isReadable()) {
                 ReadResponse response = instance.read(resourceModel.id);
                 if (response.getCode() == ResponseCode.CONTENT && response.getContent() instanceof LwM2mResource)
                     resources.add((LwM2mResource) response.getContent());

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -12,7 +12,7 @@
  *
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.resource;
 
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.leshan.ResponseCode;
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mObject;
@@ -104,7 +104,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
     }
 
     @Override
-    protected ReadResponse doRead(ReadRequest request, ExtendedIdentity identity) {
+    protected ReadResponse doRead(ReadRequest request, ServerIdentity identity) {
         LwM2mPath path = request.getPath();
 
         // Manage Object case
@@ -129,10 +129,10 @@ public class ObjectEnabler extends BaseObjectEnabler {
         return instance.read(path.getResourceId());
     }
 
-    LwM2mObjectInstance getLwM2mObjectInstance(int instanceid, LwM2mInstanceEnabler instance, ExtendedIdentity identity) {
+    LwM2mObjectInstance getLwM2mObjectInstance(int instanceid, LwM2mInstanceEnabler instance, ServerIdentity identity) {
         List<LwM2mResource> resources = new ArrayList<>();
         for (ResourceModel resourceModel : getObjectModel().resources.values()) {
-            // if internal request (null identity) or readable
+            // check, if internal request (SYSTEM) or readable
             if (identity.isSystem() || resourceModel.operations.isReadable()) {
                 ReadResponse response = instance.read(resourceModel.id);
                 if (response.getCode() == ResponseCode.CONTENT && response.getContent() instanceof LwM2mResource)

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
@@ -12,7 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.leshan.client.request.ExtendedIdentity;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
@@ -50,7 +50,7 @@ public class BootstrapHandler {
         objects = objectEnablers;
     }
 
-    public synchronized BootstrapFinishResponse finished(ExtendedIdentity identity,
+    public synchronized BootstrapFinishResponse finished(ServerIdentity identity,
             BootstrapFinishRequest finishedRequest) {
         if (bootstrapping) {
             // only if the request is from the bootstrap server
@@ -66,7 +66,7 @@ public class BootstrapHandler {
         }
     }
 
-    public synchronized BootstrapDeleteResponse delete(ExtendedIdentity identity, BootstrapDeleteRequest deleteRequest) {
+    public synchronized BootstrapDeleteResponse delete(ServerIdentity identity, BootstrapDeleteRequest deleteRequest) {
         if (bootstrapping) {
             // Only if the request is from the bootstrap server
             if (!isBootstrapServer(identity)) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity
  *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
@@ -24,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.leshan.client.request.ExtendedIdentity;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
@@ -48,7 +50,8 @@ public class BootstrapHandler {
         objects = objectEnablers;
     }
 
-    public synchronized BootstrapFinishResponse finished(Identity identity, BootstrapFinishRequest finishedRequest) {
+    public synchronized BootstrapFinishResponse finished(ExtendedIdentity identity,
+            BootstrapFinishRequest finishedRequest) {
         if (bootstrapping) {
             // only if the request is from the bootstrap server
             if (!isBootstrapServer(identity)) {
@@ -63,7 +66,7 @@ public class BootstrapHandler {
         }
     }
 
-    public synchronized BootstrapDeleteResponse delete(Identity identity, BootstrapDeleteRequest deleteRequest) {
+    public synchronized BootstrapDeleteResponse delete(ExtendedIdentity identity, BootstrapDeleteRequest deleteRequest) {
         if (bootstrapping) {
             // Only if the request is from the bootstrap server
             if (!isBootstrapServer(identity)) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity.SYSTEM
  *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
@@ -24,6 +25,7 @@ import static org.eclipse.leshan.LwM2mId.SERVER;
 import static org.eclipse.leshan.LwM2mId.SRV_BINDING;
 import static org.eclipse.leshan.LwM2mId.SRV_LIFETIME;
 import static org.eclipse.leshan.LwM2mId.SRV_SERVER_ID;
+import static org.eclipse.leshan.client.request.ExtendedIdentity.SYSTEM;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -51,8 +53,8 @@ public class ServersInfoExtractor {
             return null;
 
         ServersInfo infos = new ServersInfo();
-        LwM2mObject securities = (LwM2mObject) securityEnabler.read(null, new ReadRequest(SECURITY)).getContent();
-        LwM2mObject servers = (LwM2mObject) serverEnabler.read(null, new ReadRequest(SERVER)).getContent();
+        LwM2mObject securities = (LwM2mObject) securityEnabler.read(SYSTEM, new ReadRequest(SECURITY)).getContent();
+        LwM2mObject servers = (LwM2mObject) serverEnabler.read(SYSTEM, new ReadRequest(SERVER)).getContent();
 
         for (LwM2mObjectInstance security : securities.getInstances().values()) {
             try {
@@ -88,6 +90,10 @@ public class ServersInfoExtractor {
                 }
             } catch (URISyntaxException e) {
                 LOG.error(String.format("Invalid URI %s", (String) security.getResource(SEC_SERVER_URI).getValue()), e);
+            } catch (Throwable e) {
+                LOG.error("Error", e);
+                e.printStackTrace();
+                throw e;
             }
         }
         return infos;

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -12,7 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Achim Kraus (Bosch Software Innovations GmbH) - use ExtendedIdentity.SYSTEM
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity.SYSTEM
  *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
@@ -25,7 +25,7 @@ import static org.eclipse.leshan.LwM2mId.SERVER;
 import static org.eclipse.leshan.LwM2mId.SRV_BINDING;
 import static org.eclipse.leshan.LwM2mId.SRV_LIFETIME;
 import static org.eclipse.leshan.LwM2mId.SRV_SERVER_ID;
-import static org.eclipse.leshan.client.request.ExtendedIdentity.SYSTEM;
+import static org.eclipse.leshan.client.request.ServerIdentity.SYSTEM;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -90,10 +90,6 @@ public class ServersInfoExtractor {
                 }
             } catch (URISyntaxException e) {
                 LOG.error(String.format("Invalid URI %s", (String) security.getResource(SEC_SERVER_URI).getValue()), e);
-            } catch (Throwable e) {
-                LOG.error("Error", e);
-                e.printStackTrace();
-                throw e;
             }
         }
         return infos;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - add protected constructor for sub-classing
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
@@ -36,6 +37,13 @@ public class Identity {
         this.pskIdentity = pskIdentity;
         this.rawPublicKey = rawPublicKey;
         this.x509CommonName = x509CommonName;
+    }
+
+    protected Identity(Identity identity) {
+        this.peerAddress = identity.peerAddress;
+        this.pskIdentity = identity.pskIdentity;
+        this.rawPublicKey = identity.rawPublicKey;
+        this.x509CommonName = identity.x509CommonName;
     }
 
     public InetSocketAddress getPeerAddress() {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/CreateTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/CreateTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - add test for create security object
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -162,4 +163,14 @@ public class CreateTest {
         // verify result
         assertEquals(ResponseCode.METHOD_NOT_ALLOWED, response.getCode());
     }
+
+    @Test
+    public void cannot_create_instance_of_security_object() throws InterruptedException {
+        CreateResponse response = helper.server.send(helper.getClient(), new CreateRequest(0,
+                new LwM2mResource[] { LwM2mSingleResource.newStringResource(0, "new.dest") }));
+
+        // verify result
+        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
+    }
+
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Zebra Technologies - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for deleting a resource
+ *     Achim Kraus (Bosch Software Innovations GmbH) - add test for delete security object
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -98,4 +99,13 @@ public class DeleteTest {
         // verify result
         assertEquals(ResponseCode.METHOD_NOT_ALLOWED, response.getCode());
     }
+
+    @Test
+    public void cannot_delete_security_object_instance() throws InterruptedException {
+        DeleteResponse response = helper.server.send(helper.getClient(), new DeleteRequest(0, 0));
+
+        // verify result
+        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
+    }
+
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Zebra Technologies - initial API and implementation
  *     Kiran Pradeep - add more test cases
+ *     Achim Kraus (Bosch Software Innovations GmbH) - add test for execute security object
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -79,6 +80,14 @@ public class ExecuteTest {
         final int nonExistingObjectId = 9999;
         ExecuteResponse response = helper.server
                 .send(helper.getClient(), new ExecuteRequest(nonExistingObjectId, 0, 0));
+
+        // verify result
+        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
+    }
+
+    @Test
+    public void cannot_execute_security_object() throws InterruptedException {
+        ExecuteResponse response = helper.server.send(helper.getClient(), new ExecuteRequest(0, 0, 0));
 
         // verify result
         assertEquals(ResponseCode.NOT_FOUND, response.getCode());

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - add test for read security object
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -134,6 +135,15 @@ public class ReadTest {
     public void cannot_read_non_existent_resource() throws InterruptedException {
         // read device 50 resource
         ReadResponse response = helper.server.send(helper.getClient(), new ReadRequest(3, 0, 50));
+
+        // verify result
+        assertEquals(NOT_FOUND, response.getCode());
+    }
+
+    @Test
+    public void cannot_read_security_resource() throws InterruptedException {
+        // read device 50 resource
+        ReadResponse response = helper.server.send(helper.getClient(), new ReadRequest(0, 0, 0));
 
         // verify result
         assertEquals(NOT_FOUND, response.getCode());

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - add test for write security object
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -91,6 +92,16 @@ public class WriteTest {
 
         // verify result
         assertEquals(ResponseCode.METHOD_NOT_ALLOWED, response.getCode());
+    }
+
+    @Test
+    public void cannot_write_security_resource() throws InterruptedException {
+        // try to write unwritable resource like manufacturer on device
+        final String uri = "new.dest.server";
+        WriteResponse response = helper.server.send(helper.getClient(), new WriteRequest(Mode.REPLACE, 0, 0, 0, uri));
+
+        // verify result
+        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
     }
 
     @Test


### PR DESCRIPTION
Protect security object from access of DM server.
Protection is implemented in CoAP method mapping to allow the internal use of read/write operations as in ServersInfoExtractor.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>