### PR TITLE
Delete security object on bootstrap completion

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
@@ -83,7 +83,7 @@ public class BootstrapHandler {
             // Delete all security instance (except bootstrap one)
             // TODO do not delete boostrap server (see 5.2.5.2 Bootstrap Delete)
             LwM2mObjectEnabler securityObject = objects.get(SECURITY);
-            for (Integer instanceId : serverObject.getAvailableInstanceIds()) {
+            for (Integer instanceId : securityObject.getAvailableInstanceIds()) {
                 securityObject.delete(identity, new DeleteRequest(SECURITY, instanceId));
             }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/BootstrapHandler.java
@@ -84,7 +84,7 @@ public class BootstrapHandler {
             // TODO do not delete boostrap server (see 5.2.5.2 Bootstrap Delete)
             LwM2mObjectEnabler securityObject = objects.get(SECURITY);
             for (Integer instanceId : serverObject.getAvailableInstanceIds()) {
-                securityObject.delete(identity, new DeleteRequest(SERVER, instanceId));
+                securityObject.delete(identity, new DeleteRequest(SECURITY, instanceId));
             }
 
             return BootstrapDeleteResponse.success();


### PR DESCRIPTION
Fix for issue #91. Security object was not getting deleted on bootstrap completion.
Signed-off-by: Kiran Pradeep <kiran.happy@gmail.com>