### PR TITLE
(NOT TO BE MERGED) Introduce cancel request for client side.

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/LwM2mClientRequestSender.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/LwM2mClientRequestSender.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - add RequestCanceler
  *******************************************************************************/
 package org.eclipse.leshan.client.request;
 
@@ -36,7 +37,7 @@ public interface LwM2mClientRequestSender {
     /**
      * Send a Lightweight M2M request asynchronously.
      */
-    <T extends LwM2mResponse> void send(final InetSocketAddress server, final boolean secure,
+    <T extends LwM2mResponse> RequestCanceler send(final InetSocketAddress server, final boolean secure,
             final UplinkRequest<T> request, final ResponseCallback<T> responseCallback,
             final ErrorCallback errorCallback);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/RequestCanceler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/request/RequestCanceler.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial version
+ *******************************************************************************/
+
+package org.eclipse.leshan.client.request;
+
+/**
+ * Provide cancel functionality for asynchronously sent requests.
+ * {@link LwM2mClientRequestSender#send(java.net.InetSocketAddress, boolean, org.eclipse.leshan.core.request.UplinkRequest, org.eclipse.leshan.core.response.ResponseCallback, org.eclipse.leshan.core.response.ErrorCallback)}
+ * .
+ */
+public interface RequestCanceler {
+    /**
+     * Cancel pending request.
+     */
+    void cancel();
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/exception/RequestCanceledException.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/exception/RequestCanceledException.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - cloned from RequestFailedException
+ *******************************************************************************/
+package org.eclipse.leshan.core.request.exception;
+
+/**
+ * Exception for canceled requests.
+ */
+public class RequestCanceledException extends RequestFailedException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RequestCanceledException() {
+        super();
+    }
+
+    public RequestCanceledException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
PLEASE DO NOT MERGE!

This should give a first idea, how "cancel request" could be introduced into the "core" (here client side). This "idea" would make it possible, to move parts of "cancel on deregistration" into the core (if that is wanted).  

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>