### PR TITLE
Use concurrent collections instead of  synchronized methods.

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/Callback.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/Callback.java
@@ -29,6 +29,7 @@ public class Callback<T extends LwM2mResponse> implements ResponseCallback<T>, E
     private final CountDownLatch latch;
     private final AtomicBoolean called;
     private T response;
+    private Exception exception;
 
     public Callback() {
         called = new AtomicBoolean(false);
@@ -44,6 +45,7 @@ public class Callback<T extends LwM2mResponse> implements ResponseCallback<T>, E
 
     @Override
     public void onError(Exception e) {
+        exception = e;
         called.set(true);
         latch.countDown();
     }
@@ -52,8 +54,8 @@ public class Callback<T extends LwM2mResponse> implements ResponseCallback<T>, E
         return called;
     }
 
-    public void waitForResponse(long timeout) throws InterruptedException {
-        latch.await(timeout, TimeUnit.MILLISECONDS);
+    public boolean waitForResponse(long timeout) throws InterruptedException {
+        return latch.await(timeout, TimeUnit.MILLISECONDS);
     }
 
     public ResponseCode getResponseCode() {
@@ -66,5 +68,9 @@ public class Callback<T extends LwM2mResponse> implements ResponseCallback<T>, E
 
     public T getResponse() {
         return response;
+    }
+
+    public Exception getException() {
+        return exception;
     }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
@@ -20,7 +20,9 @@ import static org.eclipse.leshan.integration.tests.IntegrationTestHelper.ENDPOIN
 import static org.eclipse.leshan.integration.tests.IntegrationTestHelper.LIFETIME;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
@@ -36,7 +38,9 @@ import org.eclipse.leshan.client.californium.impl.CaliforniumLwM2mClientRequestS
 import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectEnabler;
+import org.eclipse.leshan.core.request.ReadRequest;
 import org.eclipse.leshan.core.request.RegisterRequest;
+import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.server.client.Client;
 import org.eclipse.leshan.server.security.NonUniqueSecurityInfoException;
 import org.junit.After;
@@ -83,6 +87,38 @@ public class RegistrationTest {
         helper.client.stop(true);
         helper.waitForDeregistration(1);
         assertTrue(helper.server.getClientRegistry().allClients().isEmpty());
+    }
+
+    @Test
+    public void deregister_cancel_pending_request() throws InterruptedException {
+        // Check registration
+        assertTrue(helper.server.getClientRegistry().allClients().isEmpty());
+
+        helper.client.start();
+        helper.waitForRegistration(1);
+
+        assertEquals(1, helper.server.getClientRegistry().allClients().size());
+        Client client = helper.server.getClientRegistry().get(ENDPOINT_IDENTIFIER);
+        assertNotNull(client);
+        assertArrayEquals(LinkObject.parse("</>;rt=\"oma.lwm2m\",</1/0>,</2>,</3/0>".getBytes()),
+                client.getObjectLinks());
+
+        // Stop client with out de-registration
+        helper.client.stop(false);
+
+        // Send a read which should be retransmitted.
+        Callback<ReadResponse> callback = new Callback<ReadResponse>();
+        helper.server.send(client, new ReadRequest(3, 0, 1), callback, callback);
+
+        // Restart client (de-registration/re-registration)
+        helper.client.start();
+
+        // Check the request was cancelled.
+        boolean timedout = !callback.waitForResponse(1000);
+        assertFalse("Response or Error expected", timedout);
+        assertTrue("Response or Error expected", callback.isCalled().get());
+        assertNull("No response expected", callback.getResponse());
+        assertNotNull("Exception expected", callback.getException());
     }
 
     @Test

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
@@ -29,6 +29,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.californium.core.network.Endpoint;
@@ -119,6 +120,47 @@ public class RegistrationTest {
         assertTrue("Response or Error expected", callback.isCalled().get());
         assertNull("No response expected", callback.getResponse());
         assertNotNull("Exception expected", callback.getException());
+    }
+
+    @Test
+    public void deregister_cancel_multiple_pending_request() throws InterruptedException {
+        // Check registration
+        assertTrue(helper.server.getClientRegistry().allClients().isEmpty());
+
+        helper.client.start();
+        helper.waitForRegistration(1);
+
+        assertEquals(1, helper.server.getClientRegistry().allClients().size());
+        Client client = helper.server.getClientRegistry().get(ENDPOINT_IDENTIFIER);
+        assertNotNull(client);
+        assertArrayEquals(LinkObject.parse("</>;rt=\"oma.lwm2m\",</1/0>,</2>,</3/0>".getBytes()),
+                client.getObjectLinks());
+
+        // Stop client with out de-registration
+        helper.client.stop(false);
+
+        // Send multiple reads which should be retransmitted.
+        List<Callback<ReadResponse>> callbacks = new ArrayList<Callback<ReadResponse>>();
+
+        for (int index = 0; index < 4; ++index) {
+            Callback<ReadResponse> callback = new Callback<ReadResponse>();
+            helper.server.send(client, new ReadRequest(3, 0, 1), callback, callback);
+            callbacks.add(callback);
+        }
+
+        // Restart client (de-registration/re-registration)
+        helper.client.start();
+
+        // Check the request was cancelled.
+        int index = 0;
+        for (Callback<ReadResponse> callback : callbacks) {
+            boolean timedout = !callback.waitForResponse(1000);
+            assertFalse("Response or Error expected, no timeout, call " + index, timedout);
+            assertTrue("Response or Error expected, call " + index, callback.isCalled().get());
+            assertNull("No response expected, call " + index, callback.getResponse());
+            assertNotNull("Exception expected, call " + index, callback.getException());
+            ++index;
+        }
     }
 
     @Test

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -128,6 +128,7 @@ public class LeshanServer implements LwM2mServer {
             @Override
             public void unregistered(final Client client) {
                 LeshanServer.this.observationRegistry.cancelObservations(client);
+                requestSender.cancelPendingRequests(client.getRegistrationId());
             }
 
             @Override


### PR DESCRIPTION
Use concurrent collections instead of  synchronized methods.
Add test for cancel multiple requests.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>