### PR TITLE
Check BS authentication before computing BS config

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
@@ -130,6 +130,15 @@ public class BootstrapResource extends CoapResource {
         }
         final String endpoint = endpointTmp;
 
+        // Check security of the endpoint
+        Identity clientIdentity = extractIdentity(exchange);
+
+        if (!bsAuthService.authenticate(endpoint, clientIdentity)) {
+            exchange.respond(ResponseCode.UNAUTHORIZED);
+            return;
+        }
+
+        // Get the desired bootstrap config for the endpoint
         final BootstrapConfig cfg = bsStore.getBootstrap(endpoint);
 
         if (cfg == null) {
@@ -138,14 +147,6 @@ public class BootstrapResource extends CoapResource {
             return;
         }
         exchange.respond(ResponseCode.CHANGED);
-
-        // Check security of the endpoint
-        Identity clientIdentity = extractIdentity(exchange);
-
-        if (!bsAuthService.authenticate(endpoint, clientIdentity)) {
-            exchange.respond(ResponseCode.UNAUTHORIZED);
-            return;
-        }
 
         // now push the config
 
@@ -161,7 +162,7 @@ public class BootstrapResource extends CoapResource {
                 deleteAll.setDestination(exchange.getSourceAddress());
                 deleteAll.setDestinationPort(exchange.getSourcePort());
 
-                deleteAll.addMessageObserver( new MessageObserver() {
+                deleteAll.addMessageObserver(new MessageObserver() {
 
                     @Override
                     public void onTimeout() {


### PR DESCRIPTION
Currently, BS configuration to send to a device is
computed before checking that the BS credentials
sent by the device are valid.

When rotating BS credentials, a server might generate
new credentials as a result of checking credentials.

Changing the order or the calls makes it possible
to send newly generated BS credentials as soon as
they are generated.

Signed-off-by: Pierre-Henri Trivier <phtrivier@sierrawireless.com>