### PR TITLE
Fix bootstrap write server id.

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
@@ -81,6 +81,13 @@ public class Server extends BaseInstanceEnabler {
 
         switch (resourceid) {
 
+        case 0:
+            if (value.getType() != Type.INTEGER) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            shortServerId = ((Long) value.getValue()).intValue();
+            return WriteResponse.success();
+
         case 1:
             if (value.getType() != Type.INTEGER) {
                 return WriteResponse.badRequest("invalid type");

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -185,37 +185,26 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
 
         // TODO we could do a validation of request.getNode() by comparing with resourceSpec information
 
-        return doWrite(request);
+        return doWrite(request, identity);
     }
 
-    protected WriteResponse doWrite(WriteRequest request) {
+    protected WriteResponse doWrite(WriteRequest request, ServerIdentity identity) {
         // This should be a not implemented error, but this is not defined in the spec.
         return WriteResponse.internalServerError("not implemented");
     }
 
     @Override
     public synchronized final BootstrapWriteResponse write(ServerIdentity identity, BootstrapWriteRequest request) {
-        LwM2mPath path = request.getPath();
 
         // We should not get a bootstrapWriteRequest from a LWM2M server
         if (!identity.isLwm2mBootstrapServer()) {
             return BootstrapWriteResponse.internalServerError("bootstrap write request from LWM2M server");
         }
 
-        // check if the resource is writable
-        if (path.isResource()) {
-            ResourceModel resourceModel = objectModel.resources.get(path.getResourceId());
-            if (resourceModel != null && !resourceModel.operations.isWritable()) {
-                return BootstrapWriteResponse.badRequest(null);
-            }
-        }
-
-        // TODO we could do a validation of request.getNode() by comparing with resourceSpec information
-
-        return doWrite(request);
+        return doWrite(request, identity);
     }
 
-    protected BootstrapWriteResponse doWrite(BootstrapWriteRequest request) {
+    protected BootstrapWriteResponse doWrite(BootstrapWriteRequest request, ServerIdentity identity) {
         // This should be a not implemented error, but this is not defined in the spec.
         return BootstrapWriteResponse.internalServerError("not implemented");
     }
@@ -283,8 +272,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public synchronized WriteAttributesResponse writeAttributes(ServerIdentity identity,
-            WriteAttributesRequest request) {
+    public synchronized WriteAttributesResponse writeAttributes(ServerIdentity identity, WriteAttributesRequest request) {
         // TODO should be implemented here to be available for all object enabler
         // This should be a not implemented error, but this is not defined in the spec.
         return WriteAttributesResponse.internalServerError("not implemented");


### PR DESCRIPTION
Fix writing the `short server id` in the LWM2M Server.

Currently no junit test could be provided, because the used demo bootstrap server will first erase all instances and so create is instead of replace.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>