### PR TITLE
Introduce server extensions.

### DIFF
--- a/leshan-server-demo/clientsetups.json
+++ b/leshan-server-demo/clientsetups.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "ObserveTime",
+    "className": "org.eclipse.leshan.server.demo.extensions.clientsetup.GenericClientSetup",
+    "endpointName": "simpleclient",
+    "observeUris": [
+      "/3/0/13"
+    ]
+  },
+  {
+    "name": "Generic",
+    "className": "org.eclipse.leshan.server.demo.extensions.clientsetup.GenericClientSetup",
+    "instanceUri": "/3/0",
+    "observeUris": [
+      "*"
+    ]
+  }
+]

--- a/leshan-server-demo/extensions.json
+++ b/leshan-server-demo/extensions.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "FileResource",
+    "className": "org.eclipse.leshan.server.demo.extensions.FileResourceExtension",
+    "configuration": {
+      "ROOT": "files",
+      "MAX_FILE_LENGTH": "2000000"
+    }
+  },
+  {
+    "tags" : [
+      "TRACE"
+    ],
+    "name": "MessageTracer",
+    "className": "org.eclipse.leshan.server.demo.extensions.MessageTracerExtension"
+  },
+  {
+    "name": "ClientSetup",
+    "className": "org.eclipse.leshan.server.demo.extensions.clientsetup.ClientSetupExtension",
+    "configuration": {
+      "FILE": "clientsetups.json",
+      "DELAY_IN_MS": "3000"
+    }
+  },
+  {
+    "tags" : [
+      "ROBUSTNESS_TEST"
+    ],
+    "name": "MessageDelayer",
+    "className": "org.eclipse.leshan.server.demo.extensions.MessageDelayerExtension",
+    "configuration": {
+      "MAX_DELAY_IN_MS": "5000",
+      "MAX_DELAYED_MESSAGES": "2000",
+      "MAX_UNDELAYED_MESSAGES": "2000"
+    }
+  },
+  {
+    "tags" : [
+      "ROBUSTNESS_TEST"
+    ],
+    "name": "MultiRequests",
+    "className": "org.eclipse.leshan.server.demo.extensions.MultiRequestExtension",
+    "configuration": {
+      "MULTI_REQUESTS": "3",
+      "NORMAL_OPERATION": "4"
+    }
+  },
+  {
+    "tags" : [
+      "ROBUSTNESS_TEST"
+    ],
+    "name": "Toggle",
+    "className": "org.eclipse.leshan.server.demo.extensions.ToggleExtension",
+    "configuration": {
+      "START_ENABLED": "false",
+      "ENABLED_TIME_IN_S": "600",
+      "DISABLED_TIME_IN_S": "600",
+      "MessageDelayer": "TOGGLE",
+      "MultiRequests": "TOGGLE"
+    }
+  }
+]

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/ExtensionConfig.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/ExtensionConfig.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension configuration data. Intended to be read from JSON format.
+ */
+@SuppressWarnings("serial")
+public class ExtensionConfig implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(ExtensionConfig.class);
+
+    /**
+     * Name of extension.
+     */
+    public String name;
+    /**
+     * Class name of extension class. Class must implement {@link LeshanServerExtension}
+     */
+    public String className;
+    /**
+     * Auto start indicator. Default: true
+     */
+    public Boolean autoStart;
+    /**
+     * Tags for optional loading extension. If used, the extension is only started, if one tag is contained in the
+     * active tags passed in by arguments. If empty, the extension is always started.
+     * 
+     * @see #isActive(String[])
+     */
+    public Set<String> tags = new HashSet<>();
+    /**
+     * Configuration properties passed in to extension. See special extension documentation for values.
+     * 
+     * @see #get(String, String)
+     * @see #get(String, Boolean)
+     * @see #get(String, Integer)
+     * @see #get(String, Long)
+     */
+    public Map<String, String> configuration = new HashMap<>();
+
+    /**
+     * Get configuration string property for provided name.
+     * 
+     * @param key property name
+     * @param def default value
+     * @return configured value.
+     */
+    public String get(String key, String def) {
+        String value = configuration.get(key);
+        if (null != value && !value.isEmpty()) {
+            return value;
+        }
+        return def;
+    }
+
+    /**
+     * Get configuration long property for provided name.
+     * 
+     * @param key property name
+     * @param def default value
+     * @return configured value.
+     */
+    public Long get(String key, Long def) {
+        String value = configuration.get(key);
+        if (null != value && !value.isEmpty()) {
+            try {
+                return Long.decode(value);
+            } catch (NumberFormatException ex) {
+                LOG.error("Error decoding '" + key + "' := '" + value + "'", ex);
+            }
+        }
+        return def;
+    }
+
+    /**
+     * Get configuration int property for provided name.
+     * 
+     * @param key property name
+     * @param def default value
+     * @return configured value.
+     */
+    public Integer get(String key, Integer def) {
+        String value = configuration.get(key);
+        if (null != value && !value.isEmpty()) {
+            try {
+                return Integer.decode(value);
+            } catch (NumberFormatException ex) {
+                LOG.error("Error decoding '" + key + "' := '" + value + "'", ex);
+            }
+        }
+        return def;
+    }
+
+    /**
+     * Get configuration boolean property for provided name.
+     * 
+     * @param key property name
+     * @param def default value
+     * @return configured value.
+     */
+    public Boolean get(String key, Boolean def) {
+        String value = configuration.get(key);
+        if (null != value && !value.isEmpty()) {
+            try {
+                return Boolean.valueOf(value);
+            } catch (NumberFormatException ex) {
+                LOG.error("Error decoding '" + key + "' := '" + value + "'", ex);
+            }
+        }
+        return def;
+    }
+
+    /**
+     * Check, if extension is active according the provided active tags.
+     * 
+     * If {@link #tags} are empty, the extension is always started. If {@link #tags} are configured, the extension is
+     * only started, if one tag is contained in the provided active tags.
+     * 
+     * @param activeTags active tags. May be null or of length 0, if not provided by the environment.
+     * @return true, if extension is active, false, otherwise.
+     */
+    public boolean isActive(String[] activeTags) {
+        if (tags.isEmpty())
+            return true;
+        if (null != activeTags) {
+            for (String tag : activeTags) {
+                if (tags.contains(tag))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check, if the value is provided and not empty.
+     * 
+     * @param value value to be checked.
+     * @return true, if value is provided (not null) and not empty, false, otherwise.
+     */
+    public static boolean isDefined(String value) {
+        return null != value && !value.isEmpty();
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/FileResourceExtension.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/FileResourceExtension.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple file resource.
+ * 
+ * Enables the LWM2M server to provide files to clients via COAP.
+ * 
+ * Usage: "coap://host/file/filename" (or "coaps://")
+ * 
+ * where "file" is the COAP name of this resource, and filename is the filename of the file in the file-root directory.
+ */
+public class FileResourceExtension extends CoapResource implements LeshanServerExtension {
+
+    /**
+     * Configuration key for files root directory.
+     * 
+     * @see #dataRoot
+     */
+    public static final String CONFIG_ROOT = "ROOT";
+    /**
+     * Configuration key for maximum file length.
+     * 
+     * @see #maxFileLength
+     */
+    public static final String CONFIG_MAX_FILE_LENGTH = "MAX_FILE_LENGTH";
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileResourceExtension.class);
+    /**
+     * Default value for files root directory.
+     * 
+     * @see #dataRoot
+     */
+    private static final String DEFAULT_ROOT = "files";
+    /**
+     * Default value for maximum file length.
+     * 
+     * @see #maxFileLength
+     */
+    private static final long DEFAULT_MAX_FILE_LENGTH = 1000000;
+
+    private volatile boolean enabled;
+    /**
+     * Maximum file length.
+     */
+    private volatile long maxFileLength = DEFAULT_MAX_FILE_LENGTH;
+    /**
+     * Files root directory.
+     */
+    private volatile File dataRoot = new File(DEFAULT_ROOT);
+
+    public FileResourceExtension() {
+        super("file");
+    }
+
+    /*
+     * Override the default behavior so that requests to sub resources (typically /file/{file-name}) are handled by
+     * /file resource.
+     */
+    @Override
+    public Resource getChild(String name) {
+        return this;
+    }
+
+    @Override
+    public void handleRequest(Exchange exchange) {
+        try {
+            super.handleRequest(exchange);
+        } catch (Exception e) {
+            LOG.error("Exception while handling a request on the /bs resource", e);
+            exchange.sendResponse(new Response(CoAP.ResponseCode.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    @Override
+    public void handleGET(final CoapExchange exchange) {
+        Request request = exchange.advanced().getRequest();
+        LOG.debug("Get received : {}", request);
+
+        if (!enabled || null == dataRoot)
+            exchange.respond(CoAP.ResponseCode.NOT_FOUND);
+
+        String myURI = getURI() + "/";
+        String path = "/" + request.getOptions().getUriPathString();
+        if (!path.startsWith(myURI)) {
+            LOG.warn("Request {} doesn't match {}!", path, myURI);
+            exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+            return;
+        }
+        path = path.substring(myURI.length());
+        LOG.info("Send file {}", path);
+        File file = new File(dataRoot, path);
+        if (!file.exists() || !file.isFile()) {
+            LOG.warn("File {} doesn't exist!", file.getAbsolutePath());
+            exchange.respond(CoAP.ResponseCode.NOT_FOUND);
+            return;
+        }
+        if (!file.canRead()) {
+            LOG.warn("File {} is not readable!", file.getAbsolutePath());
+            exchange.respond(CoAP.ResponseCode.UNAUTHORIZED);
+            return;
+        }
+        long length = file.length();
+        if (length > maxFileLength) {
+            LOG.warn("File {} is too large {} (max.: {})!", file.getAbsolutePath(), length, maxFileLength);
+            exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+            return;
+        }
+        try {
+            byte[] content = new byte[(int) length];
+            try (InputStream in = new FileInputStream(file)) {
+                int r = in.read(content);
+                if (length == r) {
+                    Response response = new Response(CoAP.ResponseCode.CONTENT);
+                    response.setPayload(content);
+                    response.getOptions().setSize2((int) length);
+                    exchange.respond(response);
+                } else {
+                    LOG.warn("File {} could not be read in!", file.getAbsolutePath());
+                    exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+                }
+            } catch (IOException ex) {
+                LOG.warn("File {} : {}", file.getAbsolutePath(), ex);
+                exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+            }
+        } catch (OutOfMemoryError error) {
+            LOG.warn("Out of Memory Error {}!", length);
+            exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public void setup(LeshanServer lwServer, ExtensionConfig configuration, LeshanServerExtensionsManager manager) {
+        String root = configuration.get(CONFIG_ROOT, DEFAULT_ROOT);
+        maxFileLength = configuration.get(CONFIG_MAX_FILE_LENGTH, DEFAULT_MAX_FILE_LENGTH);
+        dataRoot = new File(root);
+        lwServer.getCoapServer().add(this);
+        LOG.info("file resources rootdir: " + dataRoot.getAbsolutePath() + ", max. bytes: " + maxFileLength);
+    }
+
+    @Override
+    public void start() {
+        enabled = true;
+        LOG.info("Extension file resources enabled");
+    }
+
+    @Override
+    public void stop() {
+        enabled = false;
+        LOG.info("Extension file resources disabled");
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/LeshanServerExtension.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/LeshanServerExtension.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+
+/**
+ * Interface for dynamic server extensions. A server extension must implement this interface.
+ */
+public interface LeshanServerExtension {
+    /**
+     * Setup server extension.
+     * 
+     * @param lwServer LWM2M server
+     * @param configuration configuration parameters for extension
+     * @param manager extensions manager
+     */
+    void setup(LeshanServer lwServer, ExtensionConfig configuration, LeshanServerExtensionsManager manager);
+
+    /**
+     * Start extension. Called after the LWM2M server is started.
+     */
+    void start();
+
+    /**
+     * Stop extension.
+     */
+    void stop();
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/LeshanServerExtensionsManager.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/LeshanServerExtensionsManager.java
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * Leshan Server Extensions Manager. Load and maintain server extension.
+ */
+
+public class LeshanServerExtensionsManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LeshanServerExtensionsManager.class);
+
+    /**
+     * Set of auto-starting extensions.
+     * 
+     * @see ExtensionConfig#autoStart
+     */
+    private final Set<String> autoStarting = new ConcurrentHashSet<String>();
+    /**
+     * Map of {@link ExtensionConfig#name} to {@link LeshanServerExtension}.
+     */
+    private final Map<String, LeshanServerExtension> extensions = new ConcurrentHashMap<String, LeshanServerExtension>();
+
+    /**
+     * Load extension for json file according the provided tags.
+     * 
+     * @param lwServer LWM2M server
+     * @param extensions name of the JSON extensions file
+     * @param extensionTags ";" separated list of active tags. May be null.
+     * @return Set of extension names.
+     */
+    public Set<String> loadExtensions(LeshanServer lwServer, String extensions, String extensionTags) {
+        if (null != extensions) {
+            try (Reader reader = new InputStreamReader(new FileInputStream(extensions))) {
+                ExtensionConfig[] configurations = new Gson().fromJson(reader, ExtensionConfig[].class);
+                String[] activeTags = null;
+                if (null != extensionTags) {
+                    activeTags = extensionTags.split(",");
+                    for (int index = 0; activeTags.length > index; ++index) {
+                        activeTags[index] = activeTags[index].trim();
+                    }
+                }
+                for (ExtensionConfig configuration : configurations) {
+                    if (!configuration.isActive(activeTags))
+                        continue;
+                    String name = configuration.name;
+                    String className = configuration.className;
+                    if (!ExtensionConfig.isDefined(name)) {
+                        LOG.error("Extension missing name!");
+                        continue;
+                    }
+                    if (!ExtensionConfig.isDefined(className)) {
+                        LOG.error("Extension {} missing class name!", name);
+                        continue;
+                    }
+                    if (this.extensions.containsKey(name)) {
+                        LOG.error("Extension {} already loaded.", name);
+                        continue;
+                    }
+                    try {
+                        Class<?> extensionClass = Class.forName(className);
+                        Object extensionInstance = extensionClass.newInstance();
+                        if (extensionInstance instanceof LeshanServerExtension) {
+                            LeshanServerExtension serverExtension = (LeshanServerExtension) extensionInstance;
+                            if (serverExtension instanceof Tagging) {
+                                // store/apply active tags also for sub extensions.
+                                ((Tagging) serverExtension).setActiveTags(activeTags);
+                            }
+                            serverExtension.setup(lwServer, configuration, this);
+                            this.extensions.put(name, serverExtension);
+                            if (null == configuration.autoStart || configuration.autoStart) {
+                                LOG.info("Server extension {} loaded (auto starting).", name);
+                                autoStarting.add(name);
+                            } else {
+                                LOG.info("Server extension {} loaded.", name);
+                            }
+                        } else {
+                            LOG.error("Wrong extension class {}, doesn't extend LeshanServerExtension.", className);
+                        }
+                    } catch (ClassNotFoundException e) {
+                        LOG.error("Missing extension class {}.", className);
+                    } catch (InstantiationException e) {
+                        LOG.error("Error creating instance of extension class {}.", className);
+                        LOG.error("Error:", e);
+                    } catch (IllegalAccessException e) {
+                        LOG.error("Error creating instance of extension class {}.", className);
+                        LOG.error("Error:", e);
+                    }
+                }
+            } catch (FileNotFoundException e1) {
+                LOG.error("File not found {}.", extensions);
+            } catch (IOException e1) {
+                LOG.error("File I/O error.", e1);
+            }
+        }
+
+        return this.extensions.keySet();
+    }
+
+    /**
+     * Get set of extension names.
+     * 
+     * @return set of extension names
+     */
+    public Set<String> getExtensions() {
+        return this.extensions.keySet();
+    }
+
+    /**
+     * Start auto starting extensions.
+     * 
+     * @see #autoStarting
+     * @see ExtensionConfig#autoStart
+     */
+    public void startAutoStarting() {
+        for (String extension : autoStarting) {
+            start(extension);
+        }
+    }
+
+    /**
+     * Stop auto starting extensions.
+     * 
+     * @see #autoStarting
+     * @see ExtensionConfig#autoStart
+     */
+    public void stopAutoStarting() {
+        for (String extension : autoStarting) {
+            stop(extension);
+        }
+    }
+
+    /**
+     * Check, if extension is auto starting.
+     * 
+     * @param extension name of extension
+     * @see #autoStarting
+     * @see ExtensionConfig#autoStart
+     */
+    public boolean isAutoStarting(String extension) {
+        return autoStarting.contains(extension);
+    }
+
+    /**
+     * Remove extension from auto starting.
+     * 
+     * @param extension name of extension
+     * @see #autoStarting
+     * @see ExtensionConfig#autoStart
+     */
+    public void removeAutoStarting(String extension) {
+        if (autoStarting.remove(extension)) {
+            LOG.info("Server extension {} removed from auto start.", extension);
+        }
+    }
+
+    /**
+     * Check, if extension is available.
+     * 
+     * @param extension name of extension
+     * @see #extensions
+     */
+    public boolean hasExtension(String extension) {
+        return extensions.containsKey(extension);
+    }
+
+    /**
+     * Start extension.
+     * 
+     * @param extension name of extension
+     * @see #extensions
+     */
+    public void start(String extension) {
+        LeshanServerExtension handler = extensions.get(extension);
+        if (null != handler) {
+            handler.start();
+        }
+    }
+
+    /**
+     * Stop extension.
+     * 
+     * @param extension name of extension
+     * @see #extensions
+     */
+    public void stop(String extension) {
+        LeshanServerExtension handler = extensions.get(extension);
+        if (null != handler) {
+            handler.stop();
+        }
+    }
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/LeshanServerExtensionsManager.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/LeshanServerExtensionsManager.java
@@ -55,7 +55,7 @@ public class LeshanServerExtensionsManager {
      * 
      * @param lwServer LWM2M server
      * @param extensions name of the JSON extensions file
-     * @param extensionTags ";" separated list of active tags. May be null.
+     * @param extensionTags "," separated list of active tags. May be null.
      * @return Set of extension names.
      */
     public Set<String> loadExtensions(LeshanServer lwServer, String extensions, String extensionTags) {

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/MessageDelayerExtension.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/MessageDelayerExtension.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import java.util.Random;
+
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message delayer extensions. Delays processing of messages to simulate processing under stress condition. Used for
+ * robustness test of clients. The extension toggles between delayed and undelayed processing to see, if the client is
+ * able to work under "normal" condition when it was "stressed before.
+ */
+public class MessageDelayerExtension implements MessageInterceptor, LeshanServerExtension {
+    /**
+     * Configuration key for maximum number of undelayed processed messages.
+     */
+    public static final String CONFIG_MAX_UNDELAYED = "MAX_UNDELAYED_MESSAGES";
+    /**
+     * Configuration key for maximum number of delayed processed messages.
+     */
+    public static final String CONFIG_MAX_DELAYED = "MAX_DELAYED_MESSAGES";
+    /**
+     * Configuration key for maximum delay in milliseconds.
+     */
+    public static final String CONFIG_MAX_DELAY_IN_MS = "MAX_DELAY_IN_MS";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MessageDelayerExtension.class);
+
+    /**
+     * Default value for maximum number of undelayed processed messages.
+     */
+    static private final int DEF_MAX_UNDELAYED_MESSAGES = 2000;
+    /**
+     * Default value for maximum number of delayed processed messages.
+     */
+    static private final int DEF_MAX_DELAYED_MESSAGES = 4000;
+    /**
+     * Default value for maximum delay in milliseconds.
+     */
+    static private final int DEF_MAX_DELAY_IN_MS = 4000;
+
+    private final Random rand = new Random();
+    private volatile boolean enabled;
+
+    /**
+     * Maximum number of undelayed processed messages.
+     */
+    private int maxUndelayedMessage = DEF_MAX_UNDELAYED_MESSAGES;
+    /**
+     * Maximum number of delayed processed messages.
+     */
+    private int maxDelayedMessage = DEF_MAX_DELAYED_MESSAGES;
+    /**
+     * Maximum delay in milliseconds.
+     */
+    private int maxDelayInMs = DEF_MAX_DELAY_IN_MS;
+
+    /**
+     * Number of undelayed messages for this run.
+     */
+    private int start;
+    /**
+     * Number of messages to stop delayed processing for this run.
+     */
+    private int stop;
+    /**
+     * Number of messages in this run.
+     */
+    private int counter;
+
+    public MessageDelayerExtension() {
+    }
+
+    @Override
+    public void setup(LeshanServer lwServer, ExtensionConfig configuration, LeshanServerExtensionsManager manager) {
+        int maxUndelayedMessage = configuration.get(CONFIG_MAX_UNDELAYED, DEF_MAX_UNDELAYED_MESSAGES);
+        int maxDelayedMessage = configuration.get(CONFIG_MAX_DELAYED, DEF_MAX_DELAYED_MESSAGES);
+        int maxDelayInMs = configuration.get(CONFIG_MAX_DELAY_IN_MS, DEF_MAX_DELAY_IN_MS);
+        synchronized (this) {
+            this.maxUndelayedMessage = maxUndelayedMessage;
+            this.maxDelayedMessage = maxDelayedMessage;
+            this.maxDelayInMs = maxDelayInMs;
+            this.start = 0;
+            this.stop = rand.nextInt(maxDelayedMessage);
+            this.counter = 1;
+        }
+        for (Endpoint endpoint : lwServer.getCoapServer().getEndpoints()) {
+            endpoint.addInterceptor(this);
+        }
+        LOG.info("delayInMs message processing " + maxDelayInMs + "[ms] [" + maxUndelayedMessage + " - "
+                + maxDelayedMessage + "]");
+    }
+
+    @Override
+    public void start() {
+        enabled = true;
+        LOG.info("Extension message delayer enabled");
+    }
+
+    @Override
+    public void stop() {
+        enabled = false;
+        LOG.info("Extension message delayer disabled");
+    }
+
+    @Override
+    public void sendRequest(Request request) {
+    }
+
+    @Override
+    public void sendResponse(Response response) {
+    }
+
+    @Override
+    public void sendEmptyMessage(EmptyMessage message) {
+    }
+
+    @Override
+    public void receiveRequest(Request request) {
+        randomDelay();
+    }
+
+    @Override
+    public void receiveResponse(Response response) {
+        randomDelay();
+    }
+
+    @Override
+    public void receiveEmptyMessage(EmptyMessage message) {
+        randomDelay();
+    }
+
+    /**
+     * Randomly delay message processing. Delay message processing randomly, if {@link #enabled} and {@link #counter} is
+     * between {@link #start} and {@link #stop}. Restarts, if {@link #counter} reaches {@link #stop} with new random
+     * values for {@link #start} and {@link #stop} according the maximum values
+     */
+    private void randomDelay() {
+        if (!enabled)
+            return;
+
+        int delay = 0;
+        int counter;
+        int start;
+        int stop;
+        synchronized (this) {
+            if (this.stop <= this.counter) {
+                this.counter = 0;
+            }
+            if (0 == this.counter) {
+                this.start = rand.nextInt(maxUndelayedMessage);
+                this.stop = this.start + rand.nextInt(maxDelayedMessage);
+            }
+            counter = ++this.counter;
+            start = this.start;
+            stop = this.stop;
+            if (start < counter) {
+                delay = rand.nextInt(maxDelayInMs);
+            }
+        }
+
+        if (start < counter) {
+            if (0 < delay) {
+                try {
+                    LOG.info("delayInMs message processing " + delay + "ms " + counter + " to [" + start + " - " + stop
+                            + "]");
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                }
+            } else {
+                LOG.info("undelayed message processing " + counter + " to [" + start + " - " + stop + "]");
+            }
+        } else {
+            LOG.info("direct message processing " + counter + " to [" + start + " - " + stop + "]");
+        }
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/MessageTracerExtension.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/MessageTracerExtension.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import org.eclipse.californium.core.CaliforniumLogger;
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.interceptors.MessageTracer;
+import org.eclipse.californium.scandium.ScandiumLogger;
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MessageTracerExtension extends MessageTracer implements LeshanServerExtension {
+    private static final Logger LOG = LoggerFactory.getLogger(MessageTracerExtension.class);
+    private volatile boolean enabled;
+
+    @Override
+    public void setup(LeshanServer lwServer, ExtensionConfig configuration, LeshanServerExtensionsManager manager) {
+        ScandiumLogger.initialize();
+        CaliforniumLogger.initialize();
+        for (Endpoint endpoint : lwServer.getCoapServer().getEndpoints()) {
+            endpoint.addInterceptor(this);
+        }
+    }
+
+    @Override
+    public void start() {
+        enabled = true;
+        LOG.info("Extension message tracer enabled");
+    }
+
+    @Override
+    public void stop() {
+        enabled = false;
+        LOG.info("Extension message tracer disabled");
+    }
+
+    @Override
+    public void sendRequest(Request request) {
+        if (enabled) {
+            super.sendRequest(request);
+        }
+    }
+
+    @Override
+    public void sendResponse(Response response) {
+        if (enabled) {
+            super.sendResponse(response);
+        }
+    }
+
+    @Override
+    public void sendEmptyMessage(EmptyMessage message) {
+        if (enabled) {
+            super.sendEmptyMessage(message);
+        }
+    }
+
+    @Override
+    public void receiveRequest(Request request) {
+        if (enabled) {
+            super.receiveRequest(request);
+        }
+    }
+
+    @Override
+    public void receiveResponse(Response response) {
+        if (enabled) {
+            super.receiveResponse(response);
+        }
+    }
+
+    @Override
+    public void receiveEmptyMessage(EmptyMessage message) {
+        if (enabled) {
+            super.receiveEmptyMessage(message);
+        }
+    }
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/MultiRequestExtension.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/MultiRequestExtension.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.leshan.core.request.ReadRequest;
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.ReadResponse;
+import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientRegistryListener;
+import org.eclipse.leshan.server.client.ClientUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Multiple requests extensions. Send multiple request during registration without waiting for responses. Violates
+ * N-START 1 (depends on congestion control in COAP layer). Used for robustness test of clients. The extension toggles
+ * between normal registrations and registrations with multiple requests to see, if the client is able to work under
+ * "normal" condition when it was "stressed before.
+ */
+public class MultiRequestExtension implements ClientRegistryListener, LeshanServerExtension {
+    /**
+     * Configuration key for number of multiple requests.
+     * 
+     * @see #multiRequests
+     */
+    public static final String CONFIG_MULTI_REQUESTS = "MULTI_REQUESTS";
+    /**
+     * Configuration key for number of registrations processed without multiple requests.
+     * 
+     * @see #normalOperation
+     */
+    public static final String CONFIG_NORMAL_OPERATION = "NORMAL_OPERATION";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MultiRequestExtension.class);
+
+    /**
+     * Default value for number of multiple requests.
+     * 
+     * @see #multiRequests
+     */
+    private static final int DEFAULT_MULTI_REQUESTS = 3;
+    /**
+     * Default value for number of registrations processed without multiple requests.
+     * 
+     * @see #normalOperation
+     */
+    private static final int DEFAULT_NORMAL_OPERATION = 4;
+
+    /**
+     * Counter of registrations.
+     */
+    private final AtomicInteger counter = new AtomicInteger();
+    private volatile boolean enabled;
+    private volatile LeshanServer server;
+    /**
+     * Number of multiple request send during registration.
+     */
+    private volatile int multiRequests = DEFAULT_MULTI_REQUESTS;
+    /**
+     * Number of normal processed registrations.
+     */
+    private volatile int normalOperation = DEFAULT_NORMAL_OPERATION;
+
+    public MultiRequestExtension() {
+    }
+
+    @Override
+    public void setup(LeshanServer lwServer, ExtensionConfig configuration, LeshanServerExtensionsManager manager) {
+        server = lwServer;
+        multiRequests = configuration.get(CONFIG_MULTI_REQUESTS, DEFAULT_MULTI_REQUESTS);
+        normalOperation = configuration.get(CONFIG_NORMAL_OPERATION, DEFAULT_NORMAL_OPERATION);
+        LOG.info("Multi requests: " + multiRequests + ", normal operation: " + normalOperation);
+    }
+
+    @Override
+    public void start() {
+        enabled = true;
+        LOG.info("Extension multi requests enabled");
+    }
+
+    @Override
+    public void stop() {
+        enabled = false;
+        LOG.info("Extension multi requests disabled");
+    }
+
+    @Override
+    public void registered(final Client client) {
+        multipleRequests(client);
+    }
+
+    @Override
+    public void updated(ClientUpdate update, Client clientUpdated) {
+        multipleRequests(clientUpdated);
+    }
+
+    @Override
+    public void unregistered(Client client) {
+    }
+
+    /**
+     * Send multiple request. Send multiple request, if enabled and not processing a normal registration.
+     * 
+     * @param client registering client
+     */
+    private void multipleRequests(final Client client) {
+        if (!enabled)
+            return;
+        int count = counter.incrementAndGet();
+        if (1 == count) {
+            try {
+                LOG.info("double request for " + client.getEndpoint());
+                server.send(client, new ReadRequest(3, 0), responseCallback, errorCallback);
+                if (1 < multiRequests) {
+                    for (int i = 1; i < multiRequests; ++i) {
+                        server.send(client, new ReadRequest(3, 0, 13), responseCallback, errorCallback);
+                    }
+                }
+                Thread.sleep(500);
+            } catch (Throwable ex) {
+                LOG.error("error during double request for " + client.getEndpoint(), ex);
+            }
+        } else if (normalOperation == count) {
+            counter.set(0);
+        }
+    }
+
+    private final ResponseCallback<ReadResponse> responseCallback = new ResponseCallback<ReadResponse>() {
+        @Override
+        public void onResponse(ReadResponse response) {
+        }
+    };
+
+    private final ErrorCallback errorCallback = new ErrorCallback() {
+        @Override
+        public void onError(Exception e) {
+        }
+    };
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/Tagging.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/Tagging.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+/**
+ * Interface for dynamic server extensions.
+ */
+public interface Tagging {
+    /**
+     * Set active tags.
+     * 
+     * @param activeTags active tags
+     */
+    void setActiveTags(String[] activeTags);
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/ToggleExtension.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/ToggleExtension.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension to toggle other extensions. The extension, which should be toggled by this extension are configured in
+ * {@link ExtensionConfig#configuration} with the extension name as key and {@link #CONFIG_EXTENSION_VALUE} as value.
+ * 
+ * <pre>
+ *   "configuration": {
+ *     "START_ENABLED": "false",
+ *     "ENABLED_TIME_IN_S": "600",
+ *     "DISABLED_TIME_IN_S": "600",
+ *     "MessageDelayer": "TOGGLE",
+ *     "MultiRequests": "TOGGLE"
+ *   }
+ * </pre>
+ */
+public class ToggleExtension implements LeshanServerExtension {
+    /**
+     * Configuration key for starting mode. If true, the extension starts with the toggled extensions enabled, if false,
+     * with the toggled extensions disabled.
+     */
+    public static final String CONFIG_START_ENABLED = "START_ENABLED";
+    /**
+     * Configuration key for enabled time in seconds.
+     */
+    public static final String CONFIG_ENABLED_TIME_IN_S = "ENABLED_TIME_IN_S";
+    /**
+     * Configuration key for disabled time in seconds.
+     */
+    public static final String CONFIG_DISABLED_TIME_IN_S = "DISABLED_TIME_IN_S";
+    /**
+     * Configuration value to mark keys as name of toggling extensions.
+     */
+    public static final String CONFIG_EXTENSION_VALUE = "TOGGLE";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ToggleExtension.class);
+
+    /**
+     * Default starting mode.
+     */
+    private static final boolean DEFAULT_START_ENABLED = false;
+    /**
+     * Default value of enabled time in seconds.
+     */
+    private static final int DEFAULT_ENABLED_TIME_IN_S = 60 * 10;
+    /**
+     * Default value of disabled time in seconds.
+     */
+    private static final int DEFAULT_DISABLED_TIME_IN_S = 60 * 20;
+
+    private boolean enabled;
+
+    private void apply(LeshanServerExtensionsManager manager, Set<String> extensions, boolean mode) {
+        for (String extension : extensions) {
+            if (mode) {
+                manager.start(extension);
+            } else {
+                manager.stop(extension);
+            }
+        }
+    }
+
+    private void loop(ExtensionConfig configuration, LeshanServerExtensionsManager manager) {
+        Set<String> extensions = new HashSet<>();
+        Set<String> exclude = new HashSet<>();
+        exclude.add(CONFIG_START_ENABLED);
+        exclude.add(CONFIG_ENABLED_TIME_IN_S);
+        exclude.add(CONFIG_DISABLED_TIME_IN_S);
+        exclude.add(configuration.name);
+        final boolean startEnabled = configuration.get(CONFIG_START_ENABLED, DEFAULT_START_ENABLED);
+        final int enabledTime = configuration.get(CONFIG_ENABLED_TIME_IN_S, DEFAULT_ENABLED_TIME_IN_S);
+        final int disabledTime = configuration.get(CONFIG_DISABLED_TIME_IN_S, DEFAULT_DISABLED_TIME_IN_S);
+        boolean enableMode = startEnabled;
+        boolean disabled = true;
+
+        for (Map.Entry<String, String> config : configuration.configuration.entrySet()) {
+            String extension = config.getKey();
+            if (exclude.contains(extension))
+                continue;
+            if (CONFIG_EXTENSION_VALUE.equals(config.getValue())) {
+                if (!manager.hasExtension(extension)) {
+                    LOG.warn("Extension {} not available!", extension);
+                    continue;
+                }
+                LOG.info("Extension {} add to toggles", extension);
+                extensions.add(extension);
+                manager.removeAutoStarting(extension);
+            }
+        }
+        if (startEnabled) {
+            LOG.info("Toggles extension starting with enable time {}[s] followed by disabletime {}[s]", enabledTime,
+                    disabledTime);
+        } else {
+            LOG.info("Toggles extension starting with disable time {}[s] followed by enable time {}[s]", disabledTime,
+                    enabledTime);
+        }
+        long nano = System.nanoTime();
+        while (true) {
+            boolean enable;
+            synchronized (this) {
+                try {
+                    wait(5000);
+                } catch (InterruptedException e) {
+                }
+                enable = enabled;
+            }
+            if (enable) {
+                if (disabled) {
+                    nano = System.nanoTime();
+                    enableMode = startEnabled;
+                    disabled = false;
+                }
+                if (nano <= System.nanoTime()) {
+                    if (enableMode) {
+                        LOG.info("Toggles extension starts enable for {}[s]", enabledTime);
+                    } else {
+                        LOG.info("Toggles extension starts disable for {}[s]", disabledTime);
+                    }
+                    apply(manager, extensions, enableMode);
+                    int time = enableMode ? enabledTime : disabledTime;
+                    nano = System.nanoTime() + TimeUnit.NANOSECONDS.convert(time, TimeUnit.SECONDS);
+                    enableMode = !enableMode;
+                }
+            } else if (!disabled) {
+                apply(manager, extensions, false);
+                disabled = true;
+            }
+        }
+    }
+
+    @Override
+    public void setup(LeshanServer lwServer, final ExtensionConfig configuration,
+            final LeshanServerExtensionsManager manager) {
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                loop(configuration, manager);
+            }
+        }, "Toggle");
+        thread.start();
+    }
+
+    @Override
+    public void start() {
+        synchronized (this) {
+            enabled = true;
+            notify();
+        }
+        LOG.info("Extension toggles enabled");
+    }
+
+    @Override
+    public void stop() {
+        synchronized (this) {
+            enabled = false;
+            notify();
+        }
+        LOG.info("Extension toggles disabled");
+    }
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/BaseClientSetup.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/BaseClientSetup.java
@@ -45,6 +45,11 @@ public abstract class BaseClientSetup {
     private static final Logger LOG = LoggerFactory.getLogger(BaseClientSetup.class);
 
     /**
+     * LWM2M path of security object.
+     */
+    private static final String LWM2M_SECURITY_OBJECT = "/0/";
+
+    /**
      * State to initialize client setup.
      */
     protected final static int STATE_INIT = 0;
@@ -136,7 +141,7 @@ public abstract class BaseClientSetup {
                     if (1 == configuration.observeUris.size()) {
                         for (LinkObject link : client.getObjectLinks()) {
                             String url = link.getUrl();
-                            if (!url.equals(rootPath)) {
+                            if (!url.equals(rootPath) && !url.startsWith(LWM2M_SECURITY_OBJECT)) {
                                 LOG.info("Client {} add * observe {}", endpoint, url);
                                 observes.add(new ObserveRequest(url));
                             }
@@ -230,7 +235,8 @@ public abstract class BaseClientSetup {
     public abstract boolean process(LeshanServer server, Client client, int stateIndex) throws InterruptedException;
 
     /**
-     * Check, if the registration of the client contains the provided LWM2M object instance.
+     * Check, if the registration of the client contains the provided LWM2M object instance. Instances of the
+     * {@link #LWM2M_SECURITY_OBJECT} will always be excluded.
      * 
      * @param client client of the registration.
      * @param path path to be checked. Paths to resources are truncated to their instance (e.g. "/3/0/13" will be
@@ -242,6 +248,8 @@ public abstract class BaseClientSetup {
             LOG.warn("Instance {}?", path);
             return false;
         }
+        if (path.startsWith(LWM2M_SECURITY_OBJECT))
+            return false;
         String[] resPath = path.split("/", 4);
         if (4 == resPath.length) {
             path = "/" + resPath[1] + "/" + resPath[2];

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/BaseClientSetup.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/BaseClientSetup.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions.clientsetup;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.LinkObject;
+import org.eclipse.leshan.ResponseCode;
+import org.eclipse.leshan.core.request.ObserveRequest;
+import org.eclipse.leshan.core.request.WriteRequest;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.core.response.WriteResponse;
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.client.Client;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base client setup. Adjust device current time and enables observes. The setup is executed after the registration and
+ * a configured {@link ClientSetupConfig#delayInMs}. It uses the {@link #state} to determine the next setup task and
+ * increments it. The setup is intended to always start with adjusting the device current time at {@link #state}
+ * {@link #STATE_START}, if enabled in configuration {@link ClientSetupConfig#syncTime}. The next steps may be
+ * customized by setting {@link #stateStartObserve} to a custom value and implement a
+ * {@link #process(LeshanServer, Client, int)} in a derived class. After that, the provided {@link #observes} are
+ * enabled and finally {@link #process(LeshanServer, Client, int)} is called until it returns that setup has finished
+ * with true.
+ */
+public abstract class BaseClientSetup {
+    private static final Logger LOG = LoggerFactory.getLogger(BaseClientSetup.class);
+
+    /**
+     * State to initialize client setup.
+     */
+    protected final static int STATE_INIT = 0;
+    /**
+     * State for waiting for setup. Delay after registration.
+     */
+    protected final static int STATE_DELAY = 1;
+    /**
+     * State for starting initialization.
+     */
+    protected final static int STATE_START = 2;
+
+    /**
+     * Endpoint name of client.
+     */
+    private volatile String endpoint;
+    /**
+     * Configuration for client setup.
+     */
+    protected volatile ClientSetupConfig configuration;
+    /**
+     * State for starting observers during initialization.
+     */
+    protected volatile int stateStartObserve = STATE_START + 1;
+    /**
+     * System time in nanos to start initialization.
+     * 
+     * @see ClientSetupConfig#delayInMs
+     */
+    private long nanos;
+    /**
+     * Observes to be established during setup.
+     */
+    private ObserveRequest[] observes;
+    /**
+     * Current setup state.
+     * 
+     * @see #process(LeshanServer, Client)
+     */
+    private volatile int state = STATE_INIT;
+
+    /**
+     * Create a client setup.
+     */
+    public BaseClientSetup() {
+    }
+
+    /**
+     * Set configuration for client setup.
+     * 
+     * @param client client to be setup
+     * @param configuration configuration for setup
+     */
+    public void setConfiguration(Client client, ClientSetupConfig configuration) {
+        this.endpoint = client.getEndpoint();
+        this.configuration = configuration;
+    }
+
+    /**
+     * Set observes. May be used from derived classes to overwrite the configured observes
+     * {@link ClientSetupConfig#observeUris}. Intended to be called in the context of
+     * {@link #process(LeshanServer, Client)}.
+     * 
+     * @param stateStartObserve state to start enabling observes.
+     * @param observes observes to be enabled during setup. May be null, when configured observes should be used.
+     */
+    protected void enableObserves(int stateStartObserve, ObserveRequest[] observes) {
+        this.stateStartObserve = stateStartObserve;
+        if (null != observes) {
+            this.observes = observes;
+        }
+    }
+
+    /**
+     * Apply configuration for client setup. Intended to be called in the context of
+     * {@link #process(LeshanServer, Client)}.
+     * 
+     * @param client client to be setup
+     * @return state number after enabling observations. Used for setup tasks after observes are enabled.
+     * @see #STATE_INIT
+     */
+    public int applyConfiguration(Client client) {
+        this.nanos = System.nanoTime() + TimeUnit.NANOSECONDS.convert(configuration.delayInMs, TimeUnit.MILLISECONDS);
+        String rootPath = client.getRootPath();
+        if (null == this.observes) {
+            List<ObserveRequest> observes = new ArrayList<ObserveRequest>(configuration.observeUris.size());
+            for (String uri : configuration.observeUris) {
+                if (uri.equals("*")) {
+                    if (1 == configuration.observeUris.size()) {
+                        for (LinkObject link : client.getObjectLinks()) {
+                            String url = link.getUrl();
+                            if (!url.equals(rootPath)) {
+                                LOG.info("Client {} add * observe {}", endpoint, url);
+                                observes.add(new ObserveRequest(url));
+                            }
+                        }
+                    }
+                } else {
+                    if (!uri.startsWith("/")) {
+                        LOG.warn("Client setup {} add observe {}?", configuration.name, uri);
+                    } else if (hasAvailableInstances(client, uri)) {
+                        observes.add(new ObserveRequest(uri));
+                        LOG.info("Client {} add observe {}", endpoint, uri);
+                    }
+                }
+            }
+            this.observes = observes.toArray(new ObserveRequest[observes.size()]);
+        }
+        return stateStartObserve + this.observes.length;
+    }
+
+    /**
+     * Get endpoint name of client.
+     * 
+     * @return endpoint name of client
+     */
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    /**
+     * Process client setup. Setup device current time and enables observes. Calls
+     * {@link #process(LeshanServer, Client, int)} setup customization.
+     * 
+     * @param server LWM2M server to send request.
+     * @param client client to be setup.
+     * @return true, if setup finished, false, otherwise.
+     */
+    public boolean process(LeshanServer server, Client client) {
+        boolean done = false;
+        if (STATE_INIT == state) {
+            applyConfiguration(client);
+            ++state;
+        }
+        if (System.nanoTime() > nanos) {
+            while (true) {
+                ++state;
+                try {
+                    if (STATE_START == state) {
+                        LOG.error("start initialization for " + getEndpoint());
+                        if (null != configuration && configuration.syncTime) {
+                            Date now = new Date();
+                            LOG.info("set client time for " + getEndpoint() + " " + now);
+                            WriteResponse response = server.send(client, new WriteRequest(3, 0, 13, now));
+                            if (null == response || response.getCode() != ResponseCode.CHANGED) {
+                                LOG.error("error set time for " + getEndpoint());
+                            }
+                        }
+                    } else if (null != observes && stateStartObserve <= state
+                            && observes.length > state - stateStartObserve) {
+                        ObserveRequest request = observes[state - stateStartObserve];
+                        if (null != request && hasAvailableInstances(client, request.getPath().toString())) {
+                            ObserveResponse response = server.send(client, request);
+                            if (null == response || response.getCode() != ResponseCode.CONTENT) {
+                                LOG.error("error enable observer for " + getEndpoint() + " object " + request.getPath());
+                            }
+                        } else
+                            continue;
+                    } else {
+                        done = process(server, client, state);
+                        if (done)
+                            LOG.info("finished initialization for " + getEndpoint());
+                    }
+                } catch (Throwable ex) {
+                    LOG.error("error during initialization for " + getEndpoint(), ex);
+                }
+                break;
+            }
+        }
+
+        return done;
+    }
+
+    /**
+     * Process client setup state. Only called for states other then {@link #STATE_START} and states enabling observes (
+     * {@link #stateStartObserve} to {@link #stateStartObserve} + {@link #observes}.length).
+     * 
+     * @param server LWM2M server to send request.
+     * @param client client to be setup.
+     * @param state state of setup.
+     * @return true, if setup finished, false, otherwise.
+     */
+    public abstract boolean process(LeshanServer server, Client client, int stateIndex) throws InterruptedException;
+
+    /**
+     * Check, if the registration of the client contains the provided LWM2M object instance.
+     * 
+     * @param client client of the registration.
+     * @param path path to be checked. Paths to resources are truncated to their instance (e.g. "/3/0/13" will be
+     *        "/3/0")
+     * @return true, if contained in registration, false, otherwise.
+     */
+    public static boolean hasAvailableInstances(Client client, String path) {
+        if (!path.startsWith("/")) {
+            LOG.warn("Instance {}?", path);
+            return false;
+        }
+        String[] resPath = path.split("/", 4);
+        if (4 == resPath.length) {
+            path = "/" + resPath[1] + "/" + resPath[2];
+        }
+        int len = path.length();
+        for (LinkObject link : client.getObjectLinks()) {
+            String url = link.getUrl();
+            if (url.startsWith(path)) {
+                if (url.length() > len) {
+                    return url.charAt(len) == '/';
+                } else {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/ClientRegistry.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/ClientRegistry.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions.clientsetup;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientRegistryListener;
+import org.eclipse.leshan.server.client.ClientUpdate;
+import org.eclipse.leshan.server.demo.extensions.ExtensionConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client registry to setup clients.
+ */
+public class ClientRegistry implements ClientRegistryListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClientRegistry.class);
+
+    /**
+     * Map of client setups.
+     */
+    private final ConcurrentHashMap<String, BaseClientSetup> clients = new ConcurrentHashMap<String, BaseClientSetup>();
+    /**
+     * Client setup configurations. Read from {@link ClientSetupExtension#CONFIG_FILE}.
+     */
+    private final ClientSetupConfig[] configurations;
+
+    private volatile boolean enabled;
+
+    /**
+     * Create client registry to setup client.
+     * 
+     * @param configurations Client setup configurations
+     */
+    public ClientRegistry(ClientSetupConfig[] configurations) {
+        this.configurations = configurations;
+    }
+
+    /**
+     * Create a client setup instance. Search the list of {@link ClientSetupConfig} for a configuration, which
+     * {@link ClientSetupConfig#endpointName} matches or a {@link ClientSetupConfig#instanceUri} is contained in the
+     * registration.
+     * 
+     * @param client client to create a client setup.
+     * @return client setup, if configuration could be found, null, otherwise.
+     */
+    private BaseClientSetup createClientSetup(final Client client) {
+        ClientSetupConfig config = null;
+        for (ClientSetupConfig configuration : configurations) {
+            if (null != configuration.stateClass) {
+                if (ExtensionConfig.isDefined(configuration.endpointName)) {
+                    if (configuration.endpointName.equals(client.getEndpoint())) {
+                        config = configuration;
+                        break;
+                    }
+                } else if (ExtensionConfig.isDefined(configuration.instanceUri)) {
+                    if (BaseClientSetup.hasAvailableInstances(client, configuration.instanceUri)) {
+                        config = configuration;
+                        break;
+                    }
+                }
+            }
+        }
+        if (null != config) {
+            try {
+                BaseClientSetup state = (BaseClientSetup) config.stateClass.newInstance();
+                state.setConfiguration(client, config);
+                LOG.info("create client initializer {} for {}", config.name, state.getEndpoint());
+                return state;
+            } catch (InstantiationException e) {
+            } catch (IllegalAccessException e) {
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void registered(final Client client) {
+        if (enabled) {
+            BaseClientSetup state = createClientSetup(client);
+            if (null != state) {
+                String enpoint = state.getEndpoint();
+                LOG.info("register client {}", enpoint);
+                clients.put(enpoint, state);
+                synchronized (this) {
+                    notify();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void updated(ClientUpdate update, Client clientUpdated) {
+        // TODO: when the address/port is changed, it may be required to reestablish the observes.
+    }
+
+    @Override
+    public void unregistered(Client client) {
+        String endpoint = client.getEndpoint();
+        if (null != clients.remove(endpoint)) {
+            LOG.info("unregister client {}", endpoint);
+        }
+    }
+
+    /**
+     * Frequently check, if a client is in a state to execute some setup jobs.
+     * 
+     * @param server LWM2M server to be sued for setup requests.
+     */
+    public void loop(final LeshanServer server) {
+        while (true) {
+            int sz = clients.size();
+            if (0 < sz) {
+                LOG.info("process XDKs " + sz);
+                for (BaseClientSetup state : clients.values()) {
+                    String endpoint = state.getEndpoint();
+                    Client client = server.getClientRegistry().get(endpoint);
+                    if (null == client || state.process(server, client))
+                        clients.remove(endpoint, state);
+                }
+            }
+            synchronized (this) {
+                try {
+                    wait(1000);
+                } catch (InterruptedException e) {
+                }
+            }
+        }
+    }
+
+    public void start() {
+        enabled = true;
+    }
+
+    public void stop() {
+        enabled = false;
+    }
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/ClientSetupConfig.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/ClientSetupConfig.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions.clientsetup;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.leshan.server.demo.extensions.ExtensionConfig;
+
+/**
+ * Client setup configuration. Used for detail configuration for the {@link ClientSetupExtension}.
+ */
+@SuppressWarnings("serial")
+public class ClientSetupConfig extends ExtensionConfig {
+
+    /**
+     * Set, if this configuration is intended for a client with a special endpoint name.
+     */
+    public String endpointName;
+    /**
+     * Set, if no {@link #endpointName} is provided to filter the clients to apply this configuration. Checks the
+     * reported instances during registration to match with the provided URI. e.g. "/5/0" to configure devices, which
+     * supports the "firmware update".
+     */
+    public String instanceUri;
+    /**
+     * Delay after the registration before the initialization of the client starts.
+     */
+    public Integer delayInMs;
+    /**
+     * If enabled, synchronize device time during initialization.
+     */
+    public boolean syncTime;
+    /**
+     * Set of URIs to observe. If set only contains "*" all URIs contained in the registration are observed.
+     */
+    public Set<String> observeUris = new HashSet<>();
+
+    /**
+     * Class for the client initialization state. Extends {@link BaseClientSetup}. Setup during startup. Not intended to
+     * be contained in the JSON file.
+     */
+    public Class<?> stateClass;
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/ClientSetupExtension.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/ClientSetupExtension.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions.clientsetup;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.demo.extensions.ExtensionConfig;
+import org.eclipse.leshan.server.demo.extensions.LeshanServerExtension;
+import org.eclipse.leshan.server.demo.extensions.LeshanServerExtensionsManager;
+import org.eclipse.leshan.server.demo.extensions.Tagging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * Client setup extension. Extension to setup clients after registration. Configure client setup in separated JSON file.
+ */
+public class ClientSetupExtension implements LeshanServerExtension, Tagging {
+    /**
+     * Configuration key for client setup configuration file.
+     */
+    public static final String CONFIG_FILE = "FILE";
+    /**
+     * Configuration key for client setup default delay.
+     */
+    public static final String CONFIG_DELAY_IN_MS = "DELAY_IN_MS";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClientSetupExtension.class);
+
+    /**
+     * Value for client setup default delay.
+     */
+    private static final int DEFAULT_DELAY_IN_MS = 5000;
+
+    /**
+     * Client registry.
+     */
+    private volatile ClientRegistry clientRegistry;
+    /**
+     * Active tags for selection of client setups via tags.
+     * 
+     * @see ExtensionConfig#isActive(String[])
+     */
+    private String[] activeTags;
+
+    @Override
+    public void setActiveTags(String[] activeTags) {
+        this.activeTags = activeTags;
+    }
+
+    @Override
+    public void setup(final LeshanServer lwServer, ExtensionConfig configuration, LeshanServerExtensionsManager manager) {
+        String file = configuration.get(CONFIG_FILE, "");
+        int delay = configuration.get(CONFIG_DELAY_IN_MS, DEFAULT_DELAY_IN_MS);
+
+        ClientSetupConfig def = new ClientSetupConfig();
+        def.name = "Generic";
+        def.className = GenericClientSetup.class.getName();
+        def.stateClass = GenericClientSetup.class;
+        def.instanceUri = "/3/0";
+        def.observeUris.add("*");
+        def.delayInMs = delay;
+
+        ClientSetupConfig[] configurations = new ClientSetupConfig[] { def };
+        if (!file.isEmpty()) {
+            try (Reader reader = new InputStreamReader(new FileInputStream(file))) {
+                configurations = new Gson().fromJson(reader, ClientSetupConfig[].class);
+                for (ClientSetupConfig config : configurations) {
+                    if (!config.isActive(activeTags))
+                        continue;
+                    if (!ExtensionConfig.isDefined(config.className)) {
+                        config.className = def.className;
+                        config.stateClass = def.stateClass;
+                        if (null == config.delayInMs)
+                            config.delayInMs = delay;
+                        LOG.info("Generic client state {} loaded.", config.name);
+                    } else {
+                        try {
+                            Class<?> stateClass = Class.forName(config.className);
+                            Object state = stateClass.newInstance();
+                            if (state instanceof BaseClientSetup) {
+                                config.stateClass = stateClass;
+                                if (null == config.delayInMs)
+                                    config.delayInMs = delay;
+                                LOG.info("Client state {} loaded.", config.name);
+                            } else {
+                                LOG.error("Wrong client state class {}, doesn't extend BaseClientSetup.",
+                                        config.className);
+                            }
+                        } catch (ClassNotFoundException e) {
+                            LOG.error("Missing client state class {}.", config.className);
+                        } catch (InstantiationException e) {
+                            LOG.error("Error creating instance of client state class {}.", config.className);
+                            LOG.error("Error:", e);
+                        } catch (IllegalAccessException e) {
+                            LOG.error("Error creating instance of client state class {}.", config.className);
+                            LOG.error("Error:", e);
+                        }
+                    }
+                }
+            } catch (FileNotFoundException e1) {
+                LOG.error("File not found {}.", file);
+            } catch (IOException e1) {
+                LOG.error("File I/O error.", e1);
+            }
+        }
+
+        final ClientRegistry registry = new ClientRegistry(configurations);
+        lwServer.getClientRegistry().addListener(registry);
+        clientRegistry = registry;
+
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                registry.loop(lwServer);
+            }
+        }, "ClientSetupExtension");
+        thread.start();
+    }
+
+    @Override
+    public void start() {
+        ClientRegistry registry = clientRegistry;
+        if (null != registry) {
+            registry.start();
+            LOG.info("Extension client initialization enabled");
+        }
+    }
+
+    @Override
+    public void stop() {
+        ClientRegistry registry = clientRegistry;
+        if (null != registry) {
+            registry.stop();
+            LOG.info("Extension client initialization disabled");
+        }
+    }
+
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/GenericClientSetup.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/extensions/clientsetup/GenericClientSetup.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial contribution
+ ******************************************************************************/
+package org.eclipse.leshan.server.demo.extensions.clientsetup;
+
+import org.eclipse.leshan.server.californium.impl.LeshanServer;
+import org.eclipse.leshan.server.client.Client;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generic client setup. Supports configured setup of device time and observes.
+ */
+public class GenericClientSetup extends BaseClientSetup {
+    private static final Logger LOG = LoggerFactory.getLogger(GenericClientSetup.class);
+
+    private final static int STATE_START_OBSERVES = STATE_START + 1;
+    private int finish = STATE_START_OBSERVES;
+
+    public GenericClientSetup() {
+        super();
+    }
+
+    @Override
+    public int applyConfiguration(Client client) {
+        enableObserves(STATE_START_OBSERVES, null);
+        finish = super.applyConfiguration(client);
+        return finish;
+    }
+
+    @Override
+    public boolean process(LeshanServer server, Client client, int stateIndex) throws InterruptedException {
+        boolean done = false;
+        if (finish >= stateIndex) {
+            done = true;
+        } else {
+            LOG.error("error initialization for " + getEndpoint() + " step " + stateIndex);
+        }
+        return done;
+    }
+
+}


### PR DESCRIPTION
Though the "standalone"-server was promoted to a "demo"-server, it may be of general interest to add simple extension to it. Therefore I added a simple JSON configured extension functionality. I use this mainly for extend the server to setup clients and to setup the server in special test modes for testing clients.

Signed-off-by: Achim Kraus achim.kraus@bosch-si.com
