### PR TITLE
Use "Option.toValueString()" for more descriptive log.

### DIFF
--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/log/CoapMessage.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/log/CoapMessage.java
@@ -93,7 +93,7 @@ public class CoapMessage {
                         values.add(String.valueOf(opt.getIntegerValue()));
                         break;
                     default:
-                        values.add(opt.getStringValue());
+                        values.add(opt.toValueString());
                     }
                 }
 


### PR DESCRIPTION
Using "Option.toValueString()" would log a more descriptive message for some options (e.g. block2).

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>