### PR TITLE
Limit message log to last 256 messages.

### DIFF
--- a/leshan-server-demo/src/main/resources/webapp/js/client-controllers.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/client-controllers.js
@@ -239,6 +239,7 @@ lwClientControllers.controller('ClientDetailCtrl', [
                     var log = JSON.parse(msg.data);
                     log.date = $filter('date')(new Date(log.timestamp), 'HH:mm:ss.sss');
                     console.log(log);
+                    if (256 < $scope.coaplogs.length) $scope.coaplogs.shift();
                     $scope.coaplogs.push(log);
                 });
             };


### PR DESCRIPTION
In my experience, web clients with "too many message" in the coap logs slow down even the LWM2M server processing. Limit the messages to the last 256 fixes that.
(Considering blockwise transferes or "long term observations" results easily in a lot of messages.)

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>