### PR TITLE
Simplify option logging

### DIFF
--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/log/CoapMessage.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/log/CoapMessage.java
@@ -88,13 +88,7 @@ public class CoapMessage {
                         values = new ArrayList<>();
                         optMap.put(strOption, values);
                     }
-                    switch (opt.getNumber()) {
-                    case OptionNumberRegistry.CONTENT_FORMAT:
-                        values.add(String.valueOf(opt.getIntegerValue()));
-                        break;
-                    default:
-                        values.add(opt.toValueString());
-                    }
+                    values.add(opt.toValueString());
                 }
 
                 StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
As integer handling is already done in toValueString, removed unecessary switch case.

Signed-off-by: Balasubramanian Azhagappan <balasubramanian.azhagappan@bosch-si.com>