### PR TITLE
Specify the Coap Server for LeshanClient

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.client.californium;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import org.eclipse.californium.core.CoapServer;
 
 import org.eclipse.leshan.LwM2mId;
 import org.eclipse.leshan.client.object.Device;
@@ -37,6 +38,7 @@ public class LeshanClientBuilder {
     private InetSocketAddress localAddress;
     private InetSocketAddress localSecureAddress;
     private List<? extends LwM2mObjectEnabler> objectEnablers;
+    private CoapServer clientSideServer;
 
     /**
      * Creates a new instance for setting the configuration options for a {@link LeshanClient} instance.
@@ -92,6 +94,14 @@ public class LeshanClientBuilder {
         this.objectEnablers = objectEnablers;
         return this;
     }
+    
+    /**
+     * Sets the client side server to use
+     */
+    public LeshanClientBuilder setClientSideServer(CoapServer server) {
+        this.clientSideServer = server;
+        return this;
+    }
 
     /**
      * Creates an instance of {@link LeshanClient} based on the properties set on this builder.
@@ -111,6 +121,11 @@ public class LeshanClientBuilder {
             initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", "model12345", "12345", "U"));
             objectEnablers = initializer.createMandatory();
         }
-        return new LeshanClient(endpoint, localAddress, localSecureAddress, objectEnablers);
+        
+        if (clientSideServer == null) {
+            return new LeshanClient(endpoint, localAddress, localSecureAddress, objectEnablers);
+        } else {
+            return new LeshanClient(endpoint, localAddress, localSecureAddress, objectEnablers, clientSideServer);
+        }
     }
 }


### PR DESCRIPTION
Allows for the Coap server to be specified for a new instance of a LashanClient. 

In LeshanClientBuilder, the method `setCoapServer` was added, allowing for the specification of a Coap Server to be used by the LeshanClient.

In LeshanClient, a new constructor was added that allows for an existing Coap Server to be used.