### PR TITLE
Cancelling all pending messages support

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/exception/RequestCanceledException.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/exception/RequestCanceledException.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH
+ *               - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.request.exception;
+
+/**
+ * Exception indicating that the message was cancelled on the CoAP layer and any retries will be stopped.
+ */
+public class RequestCanceledException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public RequestCanceledException() {
+        super();
+    }
+
+    public RequestCanceledException(String message) {
+        super(message);
+    }
+
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -76,10 +76,12 @@ public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
         networkConfig = new NetworkConfig();
         networkConfig.setLong(Keys.ACK_TIMEOUT, ACK_TIMEOUT);
         networkConfig.setInt(Keys.MAX_RETRANSMIT, 0);
-        noSecureEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(),
-                networkConfig.getInt(Keys.COAP_PORT)), networkConfig);
-        secureEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(),
-                networkConfig.getInt(Keys.COAP_SECURE_PORT)), networkConfig);
+        noSecureEndpoint = new CoapEndpoint(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), networkConfig.getInt(Keys.COAP_PORT)),
+                networkConfig);
+        secureEndpoint = new CoapEndpoint(
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), networkConfig.getInt(Keys.COAP_SECURE_PORT)),
+                networkConfig);
     }
 
     private void createCoapServer(ClientRegistry clientRegistry, SecurityStore securityStore) {
@@ -123,8 +125,8 @@ public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
         noSecureEndpoint.addNotificationListener(observationRegistry);
         LwM2mRequestSender delegateSender = new CaliforniumLwM2mRequestSender(new HashSet<>(coapServer.getEndpoints()),
                 observationRegistry, modelProvider, encoder, decoder);
-        LwM2mRequestSender secondDelegateSender = new CaliforniumLwM2mRequestSender(new HashSet<>(
-                coapServer.getEndpoints()), observationRegistry, modelProvider, encoder, decoder);
+        LwM2mRequestSender secondDelegateSender = new CaliforniumLwM2mRequestSender(
+                new HashSet<>(coapServer.getEndpoints()), observationRegistry, modelProvider, encoder, decoder);
         QueuedRequestSender queueRequestSender = QueuedRequestSender.builder().setMessageStore(inMemoryMessageStore)
                 .setRequestSender(secondDelegateSender).setClientRegistry(clientRegistry)
                 .setObservationRegistry(observationRegistry).build();
@@ -141,13 +143,12 @@ public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
 
     public QueuedModeLeshanClient createClient(long lifeTime) {
         ObjectsInitializer initializer = new ObjectsInitializer();
-        initializer.setInstancesForObject(
-                LwM2mId.SECURITY,
+        initializer.setInstancesForObject(LwM2mId.SECURITY,
                 Security.noSec("coap://" + noSecureEndpoint.getAddress().getHostString() + ":"
                         + noSecureEndpoint.getAddress().getPort(), 12345));
         if (lifeTime == 0) {
-            initializer
-                    .setInstancesForObject(LwM2mId.SERVER, new Server(12345, CUSTOM_LIFETIME, BindingMode.UQ, false));
+            initializer.setInstancesForObject(LwM2mId.SERVER,
+                    new Server(12345, CUSTOM_LIFETIME, BindingMode.UQ, false));
         } else {
             initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, lifeTime, BindingMode.UQ, false));
         }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/QueueModeLeshanServer.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/QueueModeLeshanServer.java
@@ -47,21 +47,21 @@ public class QueueModeLeshanServer implements LwM2mServer {
     private final LwM2mRequestSender lwM2mRequestSender;
     private final MessageStore messageStore;
 
-    public QueueModeLeshanServer(CoapServer tCoapServer, ClientRegistry tClientRegistry,
-            ObservationRegistry tObservationRegistry, SecurityRegistry tSecurityRegistry,
-            LwM2mModelProvider tModelProvider, LwM2mRequestSender tLwM2mRequestSender,
-            MessageStore tInMemoryMessageStore) {
+    public QueueModeLeshanServer(CoapServer coapServer, ClientRegistry clientRegistry,
+            ObservationRegistry observationRegistry, SecurityRegistry securityRegistry,
+            LwM2mModelProvider modelProvider, LwM2mRequestSender lwM2mRequestSender,
+            MessageStore inMemoryMessageStore) {
 
-        this.coapServer = tCoapServer;
-        this.clientRegistry = tClientRegistry;
-        this.observationRegistry = tObservationRegistry;
-        this.securityRegistry = tSecurityRegistry;
-        this.modelProvider = tModelProvider;
-        this.lwM2mRequestSender = tLwM2mRequestSender;
-        this.messageStore = tInMemoryMessageStore;
+        this.coapServer = coapServer;
+        this.clientRegistry = clientRegistry;
+        this.observationRegistry = observationRegistry;
+        this.securityRegistry = securityRegistry;
+        this.modelProvider = modelProvider;
+        this.lwM2mRequestSender = lwM2mRequestSender;
+        this.messageStore = inMemoryMessageStore;
 
         // Cancel observations on client unregistering
-        tClientRegistry.addListener(new ClientRegistryListener() {
+        this.clientRegistry.addListener(new ClientRegistryListener() {
 
             @Override
             public void updated(ClientUpdate update, Client clientUpdated) {
@@ -69,8 +69,8 @@ public class QueueModeLeshanServer implements LwM2mServer {
 
             @Override
             public void unregistered(Client client) {
-                observationRegistry.cancelObservations(client);
-                lwM2mRequestSender.cancelPendingRequests(client);
+                QueueModeLeshanServer.this.observationRegistry.cancelObservations(client);
+                QueueModeLeshanServer.this.lwM2mRequestSender.cancelPendingRequests(client);
             }
 
             @Override

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/QueueModeLeshanServer.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/QueueModeLeshanServer.java
@@ -47,21 +47,21 @@ public class QueueModeLeshanServer implements LwM2mServer {
     private final LwM2mRequestSender lwM2mRequestSender;
     private final MessageStore messageStore;
 
-    public QueueModeLeshanServer(CoapServer coapServer, ClientRegistry clientRegistry,
-            ObservationRegistry observationRegistry, SecurityRegistry securityRegistry,
-            LwM2mModelProvider modelProvider, LwM2mRequestSender lwM2mRequestSender,
-            MessageStore inMemoryMessageStore) {
+    public QueueModeLeshanServer(CoapServer tCoapServer, ClientRegistry tClientRegistry,
+            ObservationRegistry tObservationRegistry, SecurityRegistry tSecurityRegistry,
+            LwM2mModelProvider tModelProvider, LwM2mRequestSender tLwM2mRequestSender,
+            MessageStore tInMemoryMessageStore) {
 
-        this.coapServer = coapServer;
-        this.clientRegistry = clientRegistry;
-        this.observationRegistry = observationRegistry;
-        this.securityRegistry = securityRegistry;
-        this.modelProvider = modelProvider;
-        this.lwM2mRequestSender = lwM2mRequestSender;
-        this.messageStore = inMemoryMessageStore;
+        this.coapServer = tCoapServer;
+        this.clientRegistry = tClientRegistry;
+        this.observationRegistry = tObservationRegistry;
+        this.securityRegistry = tSecurityRegistry;
+        this.modelProvider = tModelProvider;
+        this.lwM2mRequestSender = tLwM2mRequestSender;
+        this.messageStore = tInMemoryMessageStore;
 
         // Cancel observations on client unregistering
-        clientRegistry.addListener(new ClientRegistryListener() {
+        tClientRegistry.addListener(new ClientRegistryListener() {
 
             @Override
             public void updated(ClientUpdate update, Client clientUpdated) {
@@ -69,7 +69,8 @@ public class QueueModeLeshanServer implements LwM2mServer {
 
             @Override
             public void unregistered(Client client) {
-                QueueModeLeshanServer.this.observationRegistry.cancelObservations(client);
+                observationRegistry.cancelObservations(client);
+                lwM2mRequestSender.cancelPendingRequests(client);
             }
 
             @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/AsyncRequestObserver.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/AsyncRequestObserver.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.server.californium.impl;
 
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.leshan.core.request.exception.RequestCanceledException;
 import org.eclipse.leshan.core.request.exception.RequestFailedException;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
@@ -62,7 +63,7 @@ public abstract class AsyncRequestObserver<T extends LwM2mResponse> extends Abst
 
     @Override
     public void onCancel() {
-        errorCallback.onError(new RequestFailedException("Canceled request"));
+        errorCallback.onError(new RequestCanceledException("Canceled request"));
     }
 
     @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CaliforniumLwM2mRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CaliforniumLwM2mRequestSender.java
@@ -211,6 +211,18 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
         responseListeners.remove(listener);
     }
 
+    @Override
+    public void cancelPendingRequests(Client client) {
+        Validate.notNull(client);
+        String registrationId = client.getRegistrationId();
+        SortedMap<String, Request> requests = pendingRequests.subMap(getFloorKey(registrationId),
+                getCeilingKey(registrationId));
+        for (Request coapRequest : requests.values()) {
+            coapRequest.cancel();
+        }
+        requests.clear();
+    }
+
     private String getFloorKey(String registrationId) {
         // The key format is regid#int, So we need a key which is always before this pattern (in natural order).
         return registrationId + '#';
@@ -223,16 +235,6 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
 
     private String getKey(String registrationId, int requestId) {
         return registrationId + '#' + requestId;
-    }
-
-    public void cancelPendingRequests(String registrationId) {
-        Validate.notNull(registrationId);
-        SortedMap<String, Request> requests = pendingRequests.subMap(getFloorKey(registrationId),
-                getCeilingKey(registrationId));
-        for (Request coapRequest : requests.values()) {
-            coapRequest.cancel();
-        }
-        requests.clear();
     }
 
     private void addPendingRequest(String registrationId, Request coapRequest) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -55,6 +55,7 @@ import org.eclipse.leshan.server.client.ClientUpdate;
 import org.eclipse.leshan.server.model.LwM2mModelProvider;
 import org.eclipse.leshan.server.observation.ObservationRegistry;
 import org.eclipse.leshan.server.registration.RegistrationHandler;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
 import org.eclipse.leshan.server.security.SecurityInfo;
 import org.eclipse.leshan.server.security.SecurityRegistry;
 import org.eclipse.leshan.util.Validate;
@@ -80,7 +81,7 @@ public class LeshanServer implements LwM2mServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(LeshanServer.class);
 
-    private final CaliforniumLwM2mRequestSender requestSender;
+    private final LwM2mRequestSender requestSender;
 
     private final ClientRegistry clientRegistry;
 
@@ -141,7 +142,7 @@ public class LeshanServer implements LwM2mServer {
             @Override
             public void unregistered(final Client client) {
                 LeshanServer.this.observationRegistry.cancelObservations(client);
-                requestSender.cancelPendingRequests(client.getRegistrationId());
+                requestSender.cancelPendingRequests(client);
             }
 
             @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/LwM2mRequestSenderImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/LwM2mRequestSenderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -92,6 +92,15 @@ public class LwM2mRequestSenderImpl implements LwM2mRequestSender, Stoppable {
         }
         if (defaultRequestSender instanceof Stoppable) {
             ((Stoppable) defaultRequestSender).stop();
+        }
+    }
+
+    @Override
+    public void cancelPendingRequests(Client client) {
+        if (client.usesQueueMode()) {
+            queuedRequestSender.cancelPendingRequests(client);
+        } else {
+            defaultRequestSender.cancelPendingRequests(client);
         }
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/LwM2mRequestSenderImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/LwM2mRequestSenderImpl.java
@@ -97,10 +97,9 @@ public class LwM2mRequestSenderImpl implements LwM2mRequestSender, Stoppable {
 
     @Override
     public void cancelPendingRequests(Client client) {
-        if (client.usesQueueMode()) {
-            queuedRequestSender.cancelPendingRequests(client);
-        } else {
-            defaultRequestSender.cancelPendingRequests(client);
-        }
+        // cancel on the both the senders are required for the scenario
+        // where the LWM2M client could change binding modes.
+        defaultRequestSender.cancelPendingRequests(client);
+        queuedRequestSender.cancelPendingRequests(client);
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/MessageStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/MessageStore.java
@@ -18,6 +18,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.queue;
 
+import java.util.List;
+
 /**
  * a message store provide basic operations to handle storage of requests destined for a client which has connected in
  * Queue Mode. Messages in the message store will be present until one of the following events occur
@@ -55,16 +57,16 @@ public interface MessageStore {
     boolean isEmpty(String endpoint);
 
     /**
-     * deletes all queued request for a given client endpoint.
-     *
-     * @param endpoint client's endpoint
-     */
-    void removeAll(String endpoint);
-
-    /**
      * Deletes the first request from message queue for the given client.
      *
      * @param endpoint client endpoint name
      */
     void deleteFirst(String endpoint);
+
+    /**
+     * 
+     * @param endpoint
+     * @return
+     */
+    List<QueuedRequest> removeAll(String endpoint);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/MessageStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/MessageStore.java
@@ -64,9 +64,10 @@ public interface MessageStore {
     void deleteFirst(String endpoint);
 
     /**
+     * removes all the requests from queue and returns the list of all the requests that got removed.
      * 
-     * @param endpoint
-     * @return
+     * @param endpoint client's endpoint.
+     * @return the list of all the requests that got removed.
      */
     List<QueuedRequest> removeAll(String endpoint);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/ClientStatusTracker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/ClientStatusTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/RequestSendingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/RequestSendingTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender.java
@@ -17,6 +17,7 @@
 package org.eclipse.leshan.server.request;
 
 import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.exception.RequestCanceledException;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
@@ -66,4 +67,13 @@ public interface LwM2mRequestSender {
      * @param listener target listener to be removed.
      */
     void removeResponseListener(ResponseListener listener);
+
+    /**
+     * cancel all pending messages for a LWM2M client identified by the registration identifier. In case a client
+     * de-registers, the consumer can use this method to cancel all messages pending for the given client.
+     * 
+     * @param client client registration meta data of a LWM2M client.
+     * @throws RequestCanceledException when a request is already being sent in CoAP, then the exception is thrown.
+     */
+    void cancelPendingRequests(Client client);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ResponseProcessingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ResponseProcessingTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/ClientStatusTrackerTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/impl/ClientStatusTrackerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
  * <p/>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
`CaliforniumLwM2mRequestSender `implementation had this method (cancelPendingMessages) and this concrete implementation was directly used in LeshanServer. This prevented from using the new `LwM2mRequestSender` API (containing support for both queue and non-queue mode) in Leshan Server. This PR aims to add the `cancelPendingMessages` to `LwM2mRequestSender` API and implements the same in all the concrete implementations (`LwM2mRequestSenderImpl`, `QueuedRequestSender` and `CaliforniumLwM2mRequestSender`). With this PR, Leshan Server will officially have the QueueMode support.

Signed-off-by: Bala Azhagappan <balasubramanian.azhagappan@bosch-si.com>