### PR TITLE
Queue mode sender concurrency fix

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/QueuedRequestSender.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/QueuedRequestSender.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
@@ -66,6 +68,8 @@ public class QueuedRequestSender implements LwM2mRequestSender, Stoppable {
     private final ObservationRegistry observationRegistry;
     private final ClientStatusTracker clientStatusTracker;
     private final Collection<ResponseListener> responseListeners = new ConcurrentLinkedQueue<>();
+
+    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock(false);
 
     /**
      * Creates a new QueueRequestSender using given builder.
@@ -114,17 +118,25 @@ public class QueuedRequestSender implements LwM2mRequestSender, Stoppable {
 
         String endpoint = destination.getEndpoint();
 
-        // Accept messages only when the client is already known to ClientRegistry
-        if (clientRegistry.get(endpoint) != null) {
-            QueuedRequest queuedRequest = new QueuedRequestImpl(endpoint, castedDownlinkRequest, requestTicket);
-            messageStore.add(queuedRequest);
-            // If Client is reachable and this is the first message, we send it
-            // immediately.
-            if (clientStatusTracker.startClientReceiving(endpoint)) {
-                processingExecutor.execute(newRequestSendingTask(endpoint));
+        readWriteLock.readLock().lock();
+        try {
+            // Accept messages only when the client is already known to ClientRegistry
+            if (clientRegistry.get(endpoint) != null) {
+                QueuedRequest queuedRequest = new QueuedRequestImpl(endpoint, castedDownlinkRequest, requestTicket);
+                messageStore.add(queuedRequest);
+                // If Client is reachable and this is the first message, we send it
+                // immediately.
+                if (clientStatusTracker.startClientReceiving(endpoint)) {
+                    processingExecutor.execute(newRequestSendingTask(endpoint));
+                }
+            } else {
+                String message = String.format("message received in Queue Mode for the unknown client [%s]", endpoint);
+                LOG.warn(message);
+                // notify application layer that the message will not be sent with an exception.
+                throw new RequestCanceledException(message);
             }
-        } else {
-            LOG.warn("Ignoring a message received in Queue Mode for the unknown client [{}]", endpoint);
+        } finally {
+            readWriteLock.readLock().unlock();
         }
     }
 
@@ -163,16 +175,21 @@ public class QueuedRequestSender implements LwM2mRequestSender, Stoppable {
             LOG.debug("Cancelling and removing all pending messages for client {}", client.getEndpoint());
         }
 
-        // Potentially the first message in the queue would have been sent.
-        // So try to cancel it now.
-        delegateSender.cancelPendingRequests(client);
+        readWriteLock.writeLock().lock();
+        try {
+            // Potentially the first message in the queue would have been sent.
+            // So try to cancel it now.
+            delegateSender.cancelPendingRequests(client);
 
-        // It is better to notify the listener with a RequestCanceledException
-        // for each queued message to keep the behavior consistent with CaliforniumLwM2mRequestSender.
-        List<QueuedRequest> removedMessages = messageStore.removeAll(client.getEndpoint());
-        for (QueuedRequest request : removedMessages) {
-            processingExecutor.execute(new ResponseProcessingTask(client, request.getRequestTicket(), responseListeners,
-                    new RequestCanceledException("Queued message cancelled")));
+            // It is better to notify the listener with a RequestCanceledException
+            // for each queued message to keep the behavior consistent with CaliforniumLwM2mRequestSender.
+            List<QueuedRequest> removedMessages = messageStore.removeAll(client.getEndpoint());
+            for (QueuedRequest request : removedMessages) {
+                processingExecutor.execute(new ResponseProcessingTask(client, request.getRequestTicket(),
+                        responseListeners, new RequestCanceledException("Queued message cancelled")));
+            }
+        } finally {
+            readWriteLock.writeLock().unlock();
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/RequestSendingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/RequestSendingTask.java
@@ -43,7 +43,7 @@ class RequestSendingTask implements Runnable {
      * Creates a new task which is responsible for sending a queue request.
      *
      * @param clientRegistry client registry
-     * @param requestSender sender to perform send on (delegate)
+     * @param delegateSender sender to perform send on (delegate)
      * @param clientStatusTracker tracks the status of the client
      * @param messageStore holds queued messages for the client
      * @param endpoint clients endpoint identifier
@@ -75,8 +75,7 @@ class RequestSendingTask implements Runnable {
             LOG.debug("Sending request: {}", downlinkRequest);
             Client client = clientRegistry.get(firstRequest.getEndpoint());
             if (client == null) {
-                // client not registered anymore -> ignore this request
-                // Actually this should never happen.
+                // client not registered anymore -> don't send this request
                 LOG.debug("Client {} not registered anymore: {}", endpoint, downlinkRequest);
             } else {
                 requestSender.send(client, firstRequest.getRequestTicket(), downlinkRequest);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ResponseProcessingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ResponseProcessingTask.java
@@ -90,7 +90,7 @@ public class ResponseProcessingTask implements Runnable {
         for (ResponseListener listener : responseListeners) {
             if (listener != null) {
                 if (hasException) {
-                    LOG.debug("invoke response listener for requestTicket {} with exception {}", requestTicket,
+                    LOG.debug("invoke response listener for requestTicket {} with exception", requestTicket,
                             exception);
                     listener.onError(client, requestTicket, exception);
                 } else {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ResponseProcessingTask.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/response/ResponseProcessingTask.java
@@ -41,9 +41,10 @@ public class ResponseProcessingTask implements Runnable {
     /**
      * Creates a new task for processing response on an ordinary response result.
      *
-     * @param client
+     * @param client instance of {@link Client}
+     * @param requestTicket unique ticket correlating the response to its request.
      * @param request request being processed
-     * @param responseContext response context map for mapping response ID to the callback
+     * @param responseListeners listeners which are notified for response.
      * @param response response to propagate
      */
     public ResponseProcessingTask(Client client, String requestTicket, Collection<ResponseListener> responseListeners,
@@ -59,9 +60,9 @@ public class ResponseProcessingTask implements Runnable {
     /**
      * Creates a new task for processing response on exception.
      *
-     * @param client
-     * @param request request being processed
-     * @param responseListeners response context map for mapping response ID to the callback
+     * @param client instance of {@link Client}
+     * @param requestTicket unique ticket correlating the response to its request.
+     * @param responseListeners listeners which are notified about the exception.
      * @param exception exception to propagate
      */
     public ResponseProcessingTask(Client client, String requestTicket, Collection<ResponseListener> responseListeners,
@@ -90,8 +91,7 @@ public class ResponseProcessingTask implements Runnable {
         for (ResponseListener listener : responseListeners) {
             if (listener != null) {
                 if (hasException) {
-                    LOG.debug("invoke response listener for requestTicket {} with exception", requestTicket,
-                            exception);
+                    LOG.debug("invoke response listener for requestTicket {} with exception", requestTicket, exception);
                     listener.onError(client, requestTicket, exception);
                 } else {
                     LOG.trace("invoke response listener for requestTicket {} with response {}", requestTicket,


### PR DESCRIPTION
This PR is based on the source of #158 (contains the first three commits) and aims to fix the concurrency problem in

(https://github.com/eclipse/leshan/blob/master/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/impl/QueuedRequestSender.java#L124

 if we assume two threads t1 (user thread that calls `LwM2mRequestSender.send()`) and t2 (another user thread that calls `cancelPendingMessage()`):
- t1 passes the check mentioned above, but request was not added to messageStore yet
- t2 removes all request from queue (could be because client was unregistered)
- t1 adds the request to message store (we have a request in the store without a corresponding registered client, i.e. this request may stay there forever)

PS: I will update this PR if #158 is accepted.

Signed-off-by: Bala Azhagappan balasubramanian.azhagappan@bosch-si.com