### PR TITLE
Fixed a race condition while adding and cancelling an observation

### DIFF
--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CaliforniumObservationTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CaliforniumObservationTest.java
@@ -91,8 +91,7 @@ public class CaliforniumObservationTest {
         Assert.assertEquals(2, observations.size());
 
         // cancel it
-        int nbCancelled = registry.cancelObservations(support.client, "/3/0/12");
-        Assert.assertEquals(1, nbCancelled);
+        registry.cancelObservation(support.client, "/3/0/12");
 
         // check its absence
         observations = registry.getObservations(support.client);

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/demo/cluster/RedisObservationRegistry.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/demo/cluster/RedisObservationRegistry.java
@@ -128,17 +128,16 @@ public class RedisObservationRegistry
     }
 
     @Override
-    public int cancelObservations(Client client, String resourcepath) {
+    public void cancelObservation(Client client, String resourcepath) {
         // check registration id
         String registrationId = client.getRegistrationId();
         if (registrationId == null || resourcepath == null || resourcepath.isEmpty())
-            return 0;
+            return;
 
         Set<Observation> observations = getObservations(registrationId, resourcepath);
         for (Observation observation : observations) {
             cancelObservation(observation);
         }
-        return observations.size();
     }
 
     @Override
@@ -215,6 +214,7 @@ public class RedisObservationRegistry
         }
     }
 
+    @Override
     public ObservationStore getObservationStore() {
         return observationStore;
     }
@@ -311,7 +311,7 @@ public class RedisObservationRegistry
                 }
             } catch (InvalidValueException e) {
                 String msg = String.format("[%s] ([%s])", e.getMessage(), e.getPath().toString());
-                LOG.debug(msg);
+                LOG.debug(msg, e);
             }
         }
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/observation/ObservationRegistry.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/observation/ObservationRegistry.java
@@ -45,16 +45,15 @@ public interface ObservationRegistry {
     int cancelObservations(Client client);
 
     /**
-     * Cancels all active observations for the given resource of a given client.
+     * Cancels the active observations for the given resource of a given client.
      * 
      * As a consequence the LWM2M Client will stop sending notifications about updated values of resources in scope of
      * the canceled observation.
      * 
      * @param client the LWM2M Client to cancel observation for
      * @param resourcepath resource to cancel observation for
-     * @return the number of canceled observations
      */
-    int cancelObservations(Client client, String resourcepath);
+    void cancelObservation(Client client, String resourcepath);
 
     /**
      * Cancels an observation.

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/ClientServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/ClientServlet.java
@@ -329,7 +329,7 @@ public class ClientServlet extends HttpServlet {
                 String target = StringUtils.substringsBetween(req.getPathInfo(), clientEndpoint, "/observe")[0];
                 Client client = server.getClientRegistry().get(clientEndpoint);
                 if (client != null) {
-                    server.getObservationRegistry().cancelObservations(client, target);
+                    server.getObservationRegistry().cancelObservation(client, target);
                     resp.setStatus(HttpServletResponse.SC_OK);
                 } else {
                     resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);


### PR DESCRIPTION
This PR fixes a race condition in `CaliforniumObservationRegistryImpl` while invoking `addObservation` and `cancelObservation` calls. Due to this race condition it could still be possible to have a duplicate observation for the same resource and client reported in https://github.com/eclipse/leshan/issues/163

Due to change that came in as a bug fix for issue #168 there can be at most only one active observation for a given resource. So the `ObservationRegistry` interface was changed to reflect the same.

Signed-off-by: Bala Azhagappan <balasubramanian.azhagappan@bosch-si.com>