### PR TITLE
Added notification of early failure

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapFailureCause.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapFailureCause.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap;
+
+/**
+ * Different causes for a bootstrap failure.
+ */
+public enum BootstrapFailureCause {
+    /**
+     * The device presented wrong credentials
+     */
+    UNAUTHORIZED,
+    /**
+     * The Boostrap Server could not find a configuration to send to the device
+     */
+    NO_BOOTSTRAP_CONFIG,
+    /**
+     * The "/" object could not be deleted on the device
+     */
+    DELETE_FAILED,
+    /**
+     * Object 1 (Server) could not be written on the device
+     */
+    WRITE_SERVER_FAILED,
+    /**
+     * Object 0 (Security) could not be written on the device
+     */
+    WRITE_SECURITY_FAILED,
+    /**
+     * 'Bootstrap Finish' message count not be sent to the device
+     */
+    SEND_FINISH_FAILED,
+    /**
+     * The device responded to 'Bootstrap Finish' with an error code
+     */
+    FINISHED_WITH_ERROR
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandler.java
@@ -83,6 +83,7 @@ public class BootstrapHandler {
         final BootstrapSession bsSession = this.bsSessionManager.begin(endpoint, sender);
 
         if (!bsSession.isAuthorized()) {
+            this.bsSessionManager.failed(bsSession, null, null);
             return BootstrapResponse.badRequest("Unauthorized");
         }
 
@@ -90,6 +91,7 @@ public class BootstrapHandler {
         final BootstrapConfig cfg = bsStore.getBootstrap(endpoint);
         if (cfg == null) {
             LOG.error("No bootstrap config for {}", endpoint);
+            this.bsSessionManager.failed(bsSession, null, null);
             return BootstrapResponse.badRequest("no bootstrap config");
         }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandler.java
@@ -83,7 +83,7 @@ public class BootstrapHandler {
         final BootstrapSession bsSession = this.bsSessionManager.begin(endpoint, sender);
 
         if (!bsSession.isAuthorized()) {
-            this.bsSessionManager.failed(bsSession, null, null);
+            this.bsSessionManager.failed(bsSession, BootstrapFailureCause.UNAUTHORIZED, null);
             return BootstrapResponse.badRequest("Unauthorized");
         }
 
@@ -91,7 +91,7 @@ public class BootstrapHandler {
         final BootstrapConfig cfg = bsStore.getBootstrap(endpoint);
         if (cfg == null) {
             LOG.error("No bootstrap config for {}", endpoint);
-            this.bsSessionManager.failed(bsSession, null, null);
+            this.bsSessionManager.failed(bsSession, BootstrapFailureCause.NO_BOOTSTRAP_CONFIG, null);
             return BootstrapResponse.badRequest("no bootstrap config");
         }
 
@@ -120,7 +120,7 @@ public class BootstrapHandler {
             @Override
             public void onError(Exception e) {
                 LOG.warn(String.format("Error pending bootstrap delete '/' on %s", bsSession.getEndpoint()), e);
-                bsSessionManager.failed(bsSession, writeDeleteRequest, e);
+                bsSessionManager.failed(bsSession, BootstrapFailureCause.DELETE_FAILED, writeDeleteRequest);
             }
         });
     }
@@ -150,7 +150,8 @@ public class BootstrapHandler {
                 public void onError(Exception e) {
                     LOG.warn(String.format("Error pending bootstrap write of security instance %s on %s",
                             securityInstance, bsSession.getEndpoint()), e);
-                    bsSessionManager.failed(bsSession, writeBootstrapRequest, e);
+                    bsSessionManager.failed(bsSession, BootstrapFailureCause.WRITE_SECURITY_FAILED,
+                            writeBootstrapRequest);
                 }
             });
         } else {
@@ -184,7 +185,7 @@ public class BootstrapHandler {
                 public void onError(Exception e) {
                     LOG.warn(String.format("Error pending bootstrap write of server instance %s on %s", serverInstance,
                             bsSession.getEndpoint()), e);
-                    bsSessionManager.failed(bsSession, writeServerRequest, e);
+                    bsSessionManager.failed(bsSession, BootstrapFailureCause.WRITE_SERVER_FAILED, writeServerRequest);
                 }
             });
         } else {
@@ -196,15 +197,16 @@ public class BootstrapHandler {
                     if (response.isSuccess()) {
                         bsSessionManager.end(bsSession);
                     } else {
-                        bsSessionManager.failed(bsSession, finishBootstrapRequest, new RuntimeException(
-                                String.format("Bootstrap finished with response code : %s", response)));
+                        bsSessionManager.failed(bsSession, BootstrapFailureCause.FINISHED_WITH_ERROR,
+                                finishBootstrapRequest);
                     }
                 }
             }, new ErrorCallback() {
                 @Override
                 public void onError(Exception e) {
                     LOG.warn(String.format("Error pending bootstrap finished on %s", bsSession.getEndpoint()), e);
-                    bsSessionManager.failed(bsSession, finishBootstrapRequest, e);
+                    bsSessionManager.failed(bsSession, BootstrapFailureCause.SEND_FINISH_FAILED,
+                            finishBootstrapRequest);
                 }
             });
         }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionManager.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionManager.java
@@ -46,8 +46,8 @@ public interface BootstrapSessionManager {
      * Performs any housekeeping related to the failure of a Boostraping session.
      * 
      * @param bsSession
-     * @param request
-     * @param exception
+     * @param request last request sent to the device. Can be null.
+     * @param exception exception raised while sending the request. Can be null.
      */
     public void failed(BootstrapSession bsSession, DownlinkRequest<? extends LwM2mResponse> request,
             Exception exception);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionManager.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionManager.java
@@ -46,10 +46,10 @@ public interface BootstrapSessionManager {
      * Performs any housekeeping related to the failure of a Boostraping session.
      * 
      * @param bsSession
+     * @param cause why the bootstrap failed
      * @param request last request sent to the device. Can be null.
-     * @param exception exception raised while sending the request. Can be null.
      */
-    public void failed(BootstrapSession bsSession, DownlinkRequest<? extends LwM2mResponse> request,
-            Exception exception);
+    public void failed(BootstrapSession bsSession, BootstrapFailureCause cause,
+            DownlinkRequest<? extends LwM2mResponse> request);
 
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/BootstrapSessionManagerImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/BootstrapSessionManagerImpl.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.eclipse.leshan.core.request.DownlinkRequest;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.server.bootstrap.BootstrapFailureCause;
 import org.eclipse.leshan.server.bootstrap.BootstrapSession;
 import org.eclipse.leshan.server.bootstrap.BootstrapSessionManager;
 import org.eclipse.leshan.server.security.BootstrapSecurityStore;
@@ -58,7 +59,8 @@ public class BootstrapSessionManagerImpl implements BootstrapSessionManager {
     }
 
     @Override
-    public void failed(BootstrapSession bsSession, DownlinkRequest<? extends LwM2mResponse> request, Exception e) {
+    public void failed(BootstrapSession bsSession, BootstrapFailureCause cause,
+            DownlinkRequest<? extends LwM2mResponse> request) {
     }
 
 }

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapHandlerTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapHandlerTest.java
@@ -15,9 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executor;
@@ -160,7 +158,8 @@ public class BootstrapHandlerTest {
         }
 
         @Override
-        public void failed(BootstrapSession bsSession, DownlinkRequest<? extends LwM2mResponse> request, Exception e) {
+        public void failed(BootstrapSession bsSession, BootstrapFailureCause cause,
+                DownlinkRequest<? extends LwM2mResponse> request) {
         }
     }
 }


### PR DESCRIPTION
The `fail()` API of `BootstrapManager` was not called when the BS failed early (for example, when no  no `BootstrapConfig` exists. 
(This could be useful for logging or reporting.)