### PR TITLE
Hides security-related values from toString()

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -68,11 +68,12 @@ public class BootstrapConfig implements Serializable {
 
         @Override
         public String toString() {
+            // Note : secretKey and smsBindingKeySecret are explicitly excluded from the display for security purposes
             return String
-                    .format("ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKeyOrId=%s, secretKey=%s, smsSecurityMode=%s, smsBindingKeyParam=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s]",
+                    .format("ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKeyOrId=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s]",
                             uri, bootstrapServer, securityMode, Arrays.toString(publicKeyOrId),
-                            Arrays.toString(serverPublicKeyOrId), Arrays.toString(secretKey), smsSecurityMode,
-                            Arrays.toString(smsBindingKeyParam), Arrays.toString(smsBindingKeySecret), serverSmsNumber,
+                            Arrays.toString(serverPublicKeyOrId), smsSecurityMode,
+                            Arrays.toString(smsBindingKeyParam), serverSmsNumber,
                             serverId, clientOldOffTime);
         }
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
@@ -146,4 +146,12 @@ public class SecurityInfo implements Serializable {
         return true;
     }
 
+    @Override
+    public String toString() {
+        // Note : preSharedKey is explicitly excluded from display for security purposes
+        return String.format(
+                "SecurityInfo [endpoint=%s, identity=%s, rawPublicKey=%s, useX509Cert=%s]", endpoint, identity,
+                rawPublicKey, useX509Cert);
+    }
+
 }


### PR DESCRIPTION
Loggging `BootstrapConfig.ServerSecurity` or `SecurityInfo` could
reveal sensitive info.

Signed-off-by: Pierre-Henri Trivier <phtrivier@sierrawireless.com>