### PR TITLE
Avoid to spit error 500 on empty object list

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/LinkObject.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/LinkObject.java
@@ -100,6 +100,9 @@ public class LinkObject implements Serializable {
     }
 
     public static LinkObject[] parse(byte[] content) {
+        if (content == null) {
+            return new LinkObject[] {};
+        }
         String s = new String(content, Charsets.UTF_8);
         String[] links = s.split(",");
         LinkObject[] linksResult = new LinkObject[links.length];

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -150,7 +150,9 @@ public class RegisterResource extends CoapResource {
         String smsNumber = null;
         String lwVersion = null;
         BindingMode binding = null;
-        LinkObject[] objectLinks = null;
+
+        // Get object Links
+        LinkObject[] objectLinks = LinkObject.parse(request.getPayload());
 
         Map<String, String> additionalParams = new HashMap<String, String>();
 
@@ -172,10 +174,6 @@ public class RegisterResource extends CoapResource {
                     additionalParams.put(tokens[0], tokens[1]);
                 }
             }
-        }
-        // Get object Links
-        if (request.getPayload() != null) {
-            objectLinks = LinkObject.parse(request.getPayload());
         }
 
         // Create request


### PR DESCRIPTION
By initializing the list of object, it permits to be resilient to registration without any objects and to not spit "unexpected errors" even if the device is not supposed to do that.
