### PR TITLE
Fix issue #200: server cannot read null object link

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
@@ -192,7 +192,9 @@ public class TlvDecoder {
         ByteBuffer bff = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
         bff.put(value);
         int val1 = bff.getShort(0);
+        if (val1 < 0) val1 = 65536 + val1;
         int val2 = bff.getShort(2);
+        if (val2 < 0) val2 = 65536 + val2;
         return new ObjectLink(val1, val2);
     }
 


### PR DESCRIPTION
This is to fix issue #200 
Tests can be done by sending negative short integers and positive short integers as object link IDs.
This works for it is the same as modulo 65536.

Signed-off-by: wu.chunhao <wu.chunhao@nifty.co.jp>