### PR TITLE
Fix issue #200: server cannot read null object link

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
@@ -191,10 +191,8 @@ public class TlvDecoder {
     public static ObjectLink decodeObjlnk(byte[] value) throws TlvException {
         ByteBuffer bff = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
         bff.put(value);
-        int val1 = bff.getShort(0);
-        if (val1 < 0) val1 = 65536 + val1;
-        int val2 = bff.getShort(2);
-        if (val2 < 0) val2 = 65536 + val2;
+        int val1 = bff.getShort(0) & 0xFFFF;
+        int val2 = bff.getShort(2) & 0xFFFF;
         return new ObjectLink(val1, val2);
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/tlv/TlvDecoder.java
@@ -192,7 +192,9 @@ public class TlvDecoder {
         ByteBuffer bff = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
         bff.put(value);
         int val1 = bff.getShort(0);
+        if (val1 < 0) val1 = 65536 + val1;
         int val2 = bff.getShort(2);
+        if (val2 < 0) val2 = 65536 + val2;
         return new ObjectLink(val1, val2);
     }
 

--- a/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvDecoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/tlv/TlvDecoderTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.util.Hex;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -60,5 +61,20 @@ public class TlvDecoderTest {
             // TODO: replace with more robust assertion or simply check for TlvException being thrown
             assertEquals("Impossible to parse TLV: \n0011223344556677889900", ex.getMessage());
         }
+    }
+
+    @Test
+    public void decode_object_link() throws TlvException {
+        String dataStr = "12345678";
+        byte[] bytes = Hex.decodeHex(dataStr.toCharArray());
+        ObjectLink objlnk = TlvDecoder.decodeObjlnk(bytes);
+        assertEquals(0x1234, objlnk.getObjectId());
+        assertEquals(0x5678, objlnk.getObjectInstanceId());
+
+        dataStr = "ffffffff";
+        bytes = Hex.decodeHex(dataStr.toCharArray());
+        objlnk = TlvDecoder.decodeObjlnk(bytes);
+        assertEquals(0xffff, objlnk.getObjectId());
+        assertEquals(0xffff, objlnk.getObjectInstanceId());
     }
 }


### PR DESCRIPTION
This is to fix issue #200
Tests can be done by sending negative short integers and positive short integers as object link IDs.
This works for it is the same as modulo 65536.

Signed-off-by: wu.chunhao <wu.chunhao@nifty.co.jp>