### PR TITLE
Create a new store which handles registrations and observations.

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
@@ -20,13 +20,10 @@ import java.net.InetSocketAddress;
 
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
-import org.eclipse.leshan.server.californium.impl.CaliforniumObservationRegistryImpl;
 import org.eclipse.leshan.server.client.Client;
-import org.eclipse.leshan.server.client.ClientRegistry;
 import org.eclipse.leshan.server.client.ClientRegistryListener;
 import org.eclipse.leshan.server.client.ClientUpdate;
-import org.eclipse.leshan.server.cluster.RedisClientRegistry;
-import org.eclipse.leshan.server.cluster.RedisObservationStore;
+import org.eclipse.leshan.server.cluster.RedisRegistrationStore;
 import org.eclipse.leshan.server.impl.SecurityRegistryImpl;
 import org.eclipse.leshan.server.model.StaticModelProvider;
 
@@ -64,11 +61,7 @@ public class RedisIntegrationTestHelper extends IntegrationTestHelper {
         if (redisURI == null)
             redisURI = "";
         Pool<Jedis> jedis = new JedisPool(redisURI);
-        ClientRegistry clientRegistry = new RedisClientRegistry(jedis);
-        builder.setClientRegistry(clientRegistry);
-        builder.setObservationRegistry(
-                new CaliforniumObservationRegistryImpl(new RedisObservationStore(jedis), clientRegistry, modelProvider,
-                        decoder));
+        builder.setRegistrationStore(new RedisRegistrationStore(jedis));
 
         // Build server !
         server = builder.build();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
@@ -21,13 +21,10 @@ import java.security.cert.Certificate;
 
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
-import org.eclipse.leshan.server.californium.impl.CaliforniumObservationRegistryImpl;
 import org.eclipse.leshan.server.client.Client;
-import org.eclipse.leshan.server.client.ClientRegistry;
 import org.eclipse.leshan.server.client.ClientRegistryListener;
 import org.eclipse.leshan.server.client.ClientUpdate;
-import org.eclipse.leshan.server.cluster.RedisClientRegistry;
-import org.eclipse.leshan.server.cluster.RedisObservationStore;
+import org.eclipse.leshan.server.cluster.RedisRegistrationStore;
 import org.eclipse.leshan.server.cluster.RedisSecurityRegistry;
 import org.eclipse.leshan.server.model.StaticModelProvider;
 
@@ -51,10 +48,7 @@ public class RedisSecureIntegrationTestHelper extends SecureIntegrationTestHelpe
         if (redisURI == null)
             redisURI = "";
         Pool<Jedis> jedis = new JedisPool(redisURI);
-        ClientRegistry clientRegistry = new RedisClientRegistry(jedis);
-        builder.setClientRegistry(clientRegistry);
-        builder.setObservationRegistry(new CaliforniumObservationRegistryImpl(new RedisObservationStore(jedis),
-                clientRegistry, modelProvider, decoder));
+        builder.setRegistrationStore(new RedisRegistrationStore(jedis));
         builder.setSecurityRegistry(new RedisSecurityRegistry(jedis, null, null));
 
         // Build server !

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/CaliforniumRegistrationStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/CaliforniumRegistrationStore.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium;
+
+import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.leshan.server.registration.RegistrationStore;
+
+public interface CaliforniumRegistrationStore extends RegistrationStore, ObservationStore
+{
+
+}

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/CaliforniumRegistrationStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/CaliforniumRegistrationStore.java
@@ -18,6 +18,9 @@ package org.eclipse.leshan.server.californium;
 import org.eclipse.californium.core.observe.ObservationStore;
 import org.eclipse.leshan.server.registration.RegistrationStore;
 
+/**
+ * A registration store which is able to store Californium observation.
+ */
 public interface CaliforniumRegistrationStore extends RegistrationStore, ObservationStore
 {
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CaliforniumLwM2mRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CaliforniumLwM2mRequestSender.java
@@ -86,7 +86,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
         // Create the CoAP request from LwM2m request
         final CoapRequestBuilder coapRequestBuilder = new CoapRequestBuilder(
                 new InetSocketAddress(destination.getAddress(), destination.getPort()), destination.getRootPath(),
-                destination.getRegistrationId(), model, encoder);
+                destination.getRegistrationId(), destination.getEndpoint(), model, encoder);
         request.accept(coapRequestBuilder);
         final Request coapRequest = coapRequestBuilder.getRequest();
 
@@ -123,7 +123,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
         // Create the CoAP request from LwM2m request
         final CoapRequestBuilder coapRequestBuilder = new CoapRequestBuilder(
                 new InetSocketAddress(destination.getAddress(), destination.getPort()), destination.getRootPath(),
-                destination.getRegistrationId(), model, encoder);
+                destination.getRegistrationId(), destination.getEndpoint(), model, encoder);
         request.accept(coapRequestBuilder);
         final Request coapRequest = coapRequestBuilder.getRequest();
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CoapRequestBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CoapRequestBuilder.java
@@ -49,11 +49,13 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     private final InetSocketAddress destination;
     private final String rootPath;
     private final String registrationId;
+    private final String endpoint;
 
     private final LwM2mModel model;
     private final LwM2mNodeEncoder encoder;
 
     /* keys used to populate the request context */
+    public static final String CTX_ENDPOINT = "leshan-endpoint";
     public static final String CTX_REGID = "leshan-regId";
     public static final String CTX_LWM2M_PATH = "leshan-path";
 
@@ -61,14 +63,17 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         this.destination = destination;
         this.rootPath = null;
         this.registrationId = null;
+        this.endpoint = null;
         this.model = model;
         this.encoder = encoder;
     }
 
-    public CoapRequestBuilder(InetSocketAddress destination, String rootPath, String registrationId, LwM2mModel model,
+    public CoapRequestBuilder(InetSocketAddress destination, String rootPath, String registrationId, String endpoint,
+            LwM2mModel model,
             LwM2mNodeEncoder encoder) {
         this.destination = destination;
         this.rootPath = rootPath;
+        this.endpoint = endpoint;
         this.registrationId = registrationId;
         this.model = model;
         this.encoder = encoder;
@@ -141,6 +146,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
 
         // add context info to the observe request
         Map<String, String> context = new HashMap<>();
+        context.put(CTX_ENDPOINT, endpoint);
         context.put(CTX_REGID, registrationId);
         context.put(CTX_LWM2M_PATH, request.getPath().toString());
         for (Entry<String, String> ctx : request.getContext().entrySet()) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
@@ -1,0 +1,326 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.impl;
+
+import static org.eclipse.leshan.server.californium.impl.CoapRequestBuilder.*;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.network.serialization.DataParser;
+import org.eclipse.californium.core.network.serialization.DataSerializer;
+import org.eclipse.californium.core.network.serialization.UdpDataParser;
+import org.eclipse.californium.core.network.serialization.UdpDataSerializer;
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.server.californium.CaliforniumRegistrationStore;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryRegistrationStore implements CaliforniumRegistrationStore {
+    private final Logger LOG = LoggerFactory.getLogger(InMemoryRegistrationStore.class);
+
+    private final Map<String /* end-point */, Client> clientsByEp = new ConcurrentHashMap<>();
+
+    private static final DataSerializer serializer = new UdpDataSerializer();
+    private Map<KeyToken, org.eclipse.californium.core.observe.Observation> byToken = new HashMap<>();
+    private Map<String, List<KeyToken>> byRegId = new HashMap<>();
+    /* lock for udpate */
+    private ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    @Override
+    public Client addRegistration(Client registration) {
+        Client registrationRemoved = clientsByEp.put(registration.getEndpoint(), registration);
+        if (registrationRemoved != null)
+            removeAll(registrationRemoved.getRegistrationId());
+        return registrationRemoved;
+    }
+
+    @Override
+    public Client updateRegistration(ClientUpdate update) {
+        Client client = getRegistration(update.getRegistrationId());
+        if (client == null) {
+            return null;
+        } else {
+            Client registrationUpdated = update.updateClient(client);
+            clientsByEp.put(registrationUpdated.getEndpoint(), registrationUpdated);
+            return registrationUpdated;
+        }
+    }
+
+    @Override
+    public Client getRegistration(String registrationId) {
+        Client result = null;
+        if (registrationId != null) {
+            for (Client client : clientsByEp.values()) {
+                if (registrationId.equals(client.getRegistrationId())) {
+                    result = client;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Client getRegistrationByEndpoint(String endpoint) {
+        return clientsByEp.get(endpoint);
+    }
+
+    @Override
+    public Collection<Client> getRegistrationByAdress(InetSocketAddress address) {
+        // TODO needed to remove getAllRegistration()
+        return null;
+    }
+
+    @Override
+    public Collection<Client> getAllRegistration() {
+        return clientsByEp.values();
+    }
+
+    @Override
+    public Client removeRegistration(String registrationId) {
+        Client registration = getRegistration(registrationId);
+        if (registration != null) {
+            removeAll(registration.getRegistrationId());
+            return clientsByEp.remove(registration.getEndpoint());
+        }
+        return null;
+    }
+
+    @Override
+    public Observation addObservation(String registrationId, Observation observation) {
+        // not used observation was added by Californium
+        return null;
+    }
+
+    @Override
+    public Observation removeObservation(String registrationId, byte[] observationId) {
+        Observation observation = build(get(observationId));
+        if (observation != null && registrationId.equals(observation.getRegistrationId())) {
+            remove(observationId);
+            return observation;
+        }
+        return null;
+    }
+
+    @Override
+    public Observation getObservation(String registrationId, byte[] ObservationId) {
+        return build(get(ObservationId));
+    }
+
+    @Override
+    public Collection<Observation> getObservations(String registrationId) {
+        return build(getByRegistrationId(registrationId));
+    }
+
+    @Override
+    public Collection<Observation> removeObservations(String registrationId) {
+        return build(removeAll(registrationId));
+    }
+
+    private Collection<Observation> build(Collection<org.eclipse.californium.core.observe.Observation> cfObss) {
+        List<Observation> obs = new ArrayList<>();
+
+        for (org.eclipse.californium.core.observe.Observation cfObs : cfObss) {
+            obs.add(build(cfObs));
+        }
+        return obs;
+    }
+
+    private Observation build(org.eclipse.californium.core.observe.Observation cfObs) {
+        if (cfObs == null)
+            return null;
+
+        String regId = null;
+        String lwm2mPath = null;
+        Map<String, String> context = null;
+
+        for (Entry<String, String> ctx : cfObs.getRequest().getUserContext().entrySet()) {
+            switch (ctx.getKey()) {
+            case CTX_REGID:
+                regId = ctx.getValue();
+                break;
+            case CTX_LWM2M_PATH:
+                lwm2mPath = ctx.getValue();
+                break;
+            default:
+                if (context == null) {
+                    context = new HashMap<>();
+                }
+                context.put(ctx.getKey(), ctx.getValue());
+            }
+        }
+        return new Observation(cfObs.getRequest().getToken(), regId, new LwM2mPath(lwm2mPath), context);
+    }
+
+    @Override
+    public void add(org.eclipse.californium.core.observe.Observation obs) {
+        if (obs != null) {
+            try {
+                lock.writeLock().lock();
+
+                validateObservation(obs);
+
+                String registrationId = getRegistrationId(obs);
+                KeyToken token = new KeyToken(obs.getRequest().getToken());
+                org.eclipse.californium.core.observe.Observation previousObservation = byToken.put(token, obs);
+                if (!byRegId.containsKey(registrationId)) {
+                    byRegId.put(registrationId, new ArrayList<KeyToken>());
+                }
+                byRegId.get(registrationId).add(token);
+
+                // log any collisions
+                if (previousObservation != null) {
+                    LOG.warn(
+                            "Token collision ? observation from request [{}] will be replaced by observation from request [{}] ",
+                            previousObservation.getRequest(), obs.getRequest());
+                }
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+    }
+
+    @Override
+    public org.eclipse.californium.core.observe.Observation get(byte[] token) {
+        return get(new KeyToken(token));
+    }
+
+    private org.eclipse.californium.core.observe.Observation get(KeyToken token) {
+        try {
+            lock.readLock().lock();
+
+            org.eclipse.californium.core.observe.Observation obs = byToken.get(token);
+            if (obs != null) {
+                RawData serialize = serializer.serializeRequest(obs.getRequest(), null);
+                DataParser parser = new UdpDataParser();
+                Request newRequest = (Request) parser.parseMessage(serialize);
+                newRequest.setUserContext(obs.getRequest().getUserContext());
+                return new org.eclipse.californium.core.observe.Observation(newRequest, obs.getContext());
+            }
+            return null;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public Collection<org.eclipse.californium.core.observe.Observation> getByRegistrationId(String registrationId) {
+        try {
+            lock.readLock().lock();
+
+            Collection<org.eclipse.californium.core.observe.Observation> result = new ArrayList<>();
+            List<KeyToken> tokens = byRegId.get(registrationId);
+            if (tokens != null) {
+                for (KeyToken token : tokens) {
+                    org.eclipse.californium.core.observe.Observation obs = get(token);
+                    if (obs != null) {
+                        result.add(obs);
+                    }
+                }
+            }
+            return result;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void remove(byte[] token) {
+        try {
+            lock.writeLock().lock();
+
+            KeyToken kToken = new KeyToken(token);
+            org.eclipse.californium.core.observe.Observation removed = byToken.remove(kToken);
+
+            if (removed != null) {
+                String registrationId = getRegistrationId(removed);
+                List<KeyToken> tokens = byRegId.get(registrationId);
+                tokens.remove(kToken);
+                if (tokens.isEmpty()) {
+                    byRegId.remove(registrationId);
+                }
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public Collection<org.eclipse.californium.core.observe.Observation> removeAll(String registrationId) {
+        try {
+            lock.writeLock().lock();
+
+            Collection<org.eclipse.californium.core.observe.Observation> removed = new ArrayList<>();
+            List<KeyToken> tokens = byRegId.get(registrationId);
+            if (tokens != null) {
+                for (KeyToken token : tokens) {
+                    org.eclipse.californium.core.observe.Observation observationRemoved = byToken.remove(token);
+                    if (observationRemoved != null) {
+                        removed.add(observationRemoved);
+                    }
+                }
+            }
+            byRegId.remove(registrationId);
+            return removed;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void setContext(byte[] token, CorrelationContext ctx) {
+        try {
+            lock.writeLock().lock();
+
+            org.eclipse.californium.core.observe.Observation obs = byToken.get(new KeyToken(token));
+            if (obs != null) {
+                byToken.put(new KeyToken(token),
+                        new org.eclipse.californium.core.observe.Observation(obs.getRequest(), ctx));
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /* Retrieve the registrationId from the request context */
+    private String getRegistrationId(org.eclipse.californium.core.observe.Observation observation) {
+        return observation.getRequest().getUserContext().get(CoapRequestBuilder.CTX_REGID);
+    }
+
+    private void validateObservation(org.eclipse.californium.core.observe.Observation observation) {
+        if (!observation.getRequest().getUserContext().containsKey(CoapRequestBuilder.CTX_REGID))
+            throw new IllegalStateException("missing registrationId info in the request context");
+        if (!observation.getRequest().getUserContext().containsKey(CoapRequestBuilder.CTX_LWM2M_PATH))
+            throw new IllegalStateException("missing lwm2m path info in the request context");
+        if (getRegistration(observation.getRequest().getUserContext().get(CoapRequestBuilder.CTX_REGID)) == null) {
+            throw new IllegalStateException("no registration for this Id");
+        }
+    }
+}

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
@@ -51,6 +51,9 @@ import org.eclipse.leshan.server.registration.ExpirationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * An in memory store for registration and observation.
+ */
 public class InMemoryRegistrationStore implements CaliforniumRegistrationStore, Startable, Stoppable {
     private final Logger LOG = LoggerFactory.getLogger(InMemoryRegistrationStore.class);
 

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/ClientRegistryImplTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/ClientRegistryImplTest.java
@@ -13,7 +13,7 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
-package org.eclipse.leshan.server.impl;
+package org.eclipse.leshan.server.californium.impl;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -22,6 +22,7 @@ import org.eclipse.leshan.LinkObject;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.server.client.Client;
 import org.eclipse.leshan.server.client.ClientUpdate;
+import org.eclipse.leshan.server.impl.ClientRegistryImpl;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class ClientRegistryImplTest {
     @Before
     public void setUp() throws Exception {
         address = InetAddress.getLocalHost();
-        registry = new ClientRegistryImpl();
+        registry = new ClientRegistryImpl(new InMemoryRegistrationStore());
     }
 
     @Test

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CoapRequestBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CoapRequestBuilderTest.java
@@ -89,7 +89,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         ReadRequest request = new ReadRequest(3, 0);
         builder.visit(request);
 
@@ -108,7 +108,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         ReadRequest request = new ReadRequest(3, 0, 1);
         builder.visit(request);
 
@@ -124,7 +124,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         ReadRequest request = new ReadRequest(3);
         builder.visit(request);
 
@@ -140,7 +140,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         DiscoverRequest request = new DiscoverRequest(3, 0);
         builder.visit(request);
 
@@ -160,7 +160,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         WriteRequest request = new WriteRequest(Mode.UPDATE, 3, 0, LwM2mSingleResource.newStringResource(4, "value"));
         builder.visit(request);
 
@@ -185,7 +185,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         WriteRequest request = new WriteRequest(3, 0, 14, "value");
         builder.visit(request);
 
@@ -201,7 +201,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         WriteAttributesRequest request = new WriteAttributesRequest(3, 0, 14,
                 new ObserveSpec.Builder().minPeriod(10).maxPeriod(100).build());
         builder.visit(request);
@@ -221,7 +221,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         ExecuteRequest request = new ExecuteRequest(3, 0, 12, "params");
         builder.visit(request);
 
@@ -241,7 +241,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         CreateRequest request = new CreateRequest(12, LwM2mSingleResource.newStringResource(0, "value"));
         builder.visit(request);
 
@@ -265,7 +265,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         CreateRequest request = new CreateRequest(12,
                 new LwM2mObjectInstance(26, LwM2mSingleResource.newStringResource(0, "value")));
         builder.visit(request);
@@ -291,7 +291,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         DeleteRequest request = new DeleteRequest(12, 0);
         builder.visit(request);
 
@@ -310,7 +310,7 @@ public class CoapRequestBuilderTest {
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(
                 new InetSocketAddress(client.getAddress(), client.getPort()), client.getRootPath(),
-                client.getRegistrationId(), model, encoder);
+                client.getRegistrationId(), client.getEndpoint(), model, encoder);
         ObserveRequest request = new ObserveRequest(12, 0);
         builder.visit(request);
 

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
@@ -1,0 +1,481 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.cluster;
+
+import static org.eclipse.leshan.server.californium.impl.CoapRequestBuilder.*;
+import static org.eclipse.leshan.util.Charsets.UTF_8;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.scandium.util.ByteArrayUtils;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.server.californium.CaliforniumRegistrationStore;
+import org.eclipse.leshan.server.californium.impl.CoapRequestBuilder;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientUpdate;
+import org.eclipse.leshan.server.cluster.serialization.ClientSerDes;
+import org.eclipse.leshan.server.cluster.serialization.ObservationSerDes;
+import org.eclipse.leshan.util.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+import redis.clients.util.Pool;
+
+public class RedisRegistrationStore implements CaliforniumRegistrationStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedisClientRegistry.class);
+
+    private static final String EP_CLIENT = "EP#CLIENT#";
+    private static final String REG_EP = "REG#EP#";
+    private static final String LOCK_EP = "LOCK#EP#";
+
+    // Redis key prefixes
+    private static final byte[] OBS_TKN = "OBS#TKN#".getBytes(UTF_8);
+    private static final String OBS_REG = "OBS#REG#";
+
+    private final Pool<Jedis> pool;
+
+    public RedisRegistrationStore(Pool<Jedis> p) {
+        this.pool = p;
+    }
+
+    @Override
+    public Client addRegistration(Client registration) {
+        try (Jedis j = pool.getResource()) {
+            byte[] lockValue = null;
+            byte[] lockKey = toLockKey(registration.getEndpoint());
+
+            try {
+                lockValue = RedisLock.acquire(j, lockKey);
+
+                byte[] k = toEndpointKey(registration.getEndpoint());
+                byte[] old = j.getSet(k, serializeReg(registration));
+
+                // secondary index
+                byte[] idx = toRegKey(registration.getRegistrationId());
+                j.set(idx, registration.getEndpoint().getBytes(UTF_8));
+
+                if (old != null) {
+                    Client oldRegistration = deserializeReg(old);
+                    return oldRegistration;
+                }
+
+                return null;
+            } finally {
+                RedisLock.release(j, lockKey, lockValue);
+            }
+        }
+    }
+
+    @Override
+    public Client updateRegistration(ClientUpdate update) {
+        try (Jedis j = pool.getResource()) {
+
+            // fetch the client ep by registration ID index
+            byte[] ep = j.get(toRegKey(update.getRegistrationId()));
+            if (ep == null) {
+                return null;
+            }
+
+            // fetch the client
+            byte[] data = j.get(toEndpointKey(ep));
+            if (data == null) {
+                return null;
+            }
+
+            Client r = deserializeReg(data);
+
+            byte[] lockValue = null;
+            byte[] lockKey = toLockKey(r.getEndpoint());
+            try {
+                lockValue = RedisLock.acquire(j, lockKey);
+
+                Client clientUpdated = update.updateClient(r);
+
+                // store the new client
+                j.set(toEndpointKey(clientUpdated.getEndpoint()), serializeReg(clientUpdated));
+
+                return clientUpdated;
+
+            } finally {
+                RedisLock.release(j, lockKey, lockValue);
+            }
+        }
+    }
+
+    @Override
+    public Client getRegistration(String registrationId) {
+        try (Jedis j = pool.getResource()) {
+            byte[] ep = j.get(toRegKey(registrationId));
+            if (ep == null) {
+                return null;
+            }
+            byte[] data = j.get(toEndpointKey(ep));
+            if (data == null) {
+                return null;
+            }
+
+            return deserializeReg(data);
+        }
+    }
+
+    @Override
+    public Client getRegistrationByEndpoint(String endpoint) {
+        Validate.notNull(endpoint);
+        try (Jedis j = pool.getResource()) {
+            byte[] data = j.get(toEndpointKey(endpoint));
+            if (data == null) {
+                return null;
+            }
+            Client r = deserializeReg(data);
+            return r.isAlive() ? r : null;
+        }
+    }
+
+    @Override
+    public Collection<Client> getRegistrationByAdress(InetSocketAddress address) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Collection<Client> getAllRegistration() {
+        try (Jedis j = pool.getResource()) {
+            ScanParams params = new ScanParams().match(EP_CLIENT + "*").count(100);
+            Collection<Client> list = new LinkedList<>();
+            String cursor = "0";
+            do {
+                ScanResult<byte[]> res = j.scan(cursor.getBytes(), params);
+                for (byte[] key : res.getResult()) {
+                    byte[] element = j.get(key);
+                    if (element != null) {
+                        Client c = deserializeReg(element);
+                        if (c.isAlive()) {
+                            list.add(c);
+                        }
+                    }
+                }
+                cursor = res.getStringCursor();
+            } while (!"0".equals(cursor));
+            return list;
+        }
+    }
+
+    @Override
+    public Client removeRegistration(String registrationId) {
+        try (Jedis j = pool.getResource()) {
+
+            byte[] regKey = toRegKey(registrationId);
+
+            // fetch the client ep by registration ID index
+            byte[] ep = j.get(regKey);
+            if (ep == null) {
+                return null;
+            }
+
+            byte[] data = j.get(toEndpointKey(ep));
+            if (data == null) {
+                return null;
+            }
+
+            Client r = deserializeReg(data);
+            deleteClient(j, r);
+
+            return r;
+        }
+    }
+
+    private void deleteClient(Jedis j, Client c) {
+        byte[] lockValue = null;
+        byte[] lockKey = toLockKey(c.getEndpoint());
+        try {
+            lockValue = RedisLock.acquire(j, lockKey);
+
+            // delete all entries
+            j.del(toRegKey(c.getRegistrationId()));
+            j.del(toEndpointKey(c.getEndpoint()));
+
+        } finally {
+            RedisLock.release(j, lockKey, lockValue);
+        }
+    }
+
+    private byte[] toRegKey(String registrationId) {
+        return (REG_EP + registrationId).getBytes(UTF_8);
+    }
+
+    private byte[] toEndpointKey(String endpoint) {
+        return (EP_CLIENT + endpoint).getBytes(UTF_8);
+    }
+
+    private byte[] toEndpointKey(byte[] endpoint) {
+        return ByteArrayUtils.concatenate(EP_CLIENT.getBytes(UTF_8), endpoint);
+    }
+
+    private byte[] toLockKey(String endpoint) {
+        return (LOCK_EP + endpoint).getBytes(UTF_8);
+    }
+
+    private byte[] serializeReg(Client client) {
+        return ClientSerDes.bSerialize(client);
+    }
+
+    private Client deserializeReg(byte[] data) {
+        return ClientSerDes.deserialize(data);
+    }
+
+    @Override
+    public Observation addObservation(String registrationId, Observation observation) {
+        // not used observation was added by Californium
+        return null;
+    }
+
+    @Override
+    public Observation removeObservation(String registrationId, byte[] observationId) {
+        Observation observation = build(get(observationId));
+        if (observation != null && registrationId.equals(observation.getRegistrationId())) {
+            remove(observationId);
+            return observation;
+        }
+        return null;
+    }
+
+    @Override
+    public Observation getObservation(String registrationId, byte[] ObservationId) {
+        return build(get(ObservationId));
+    }
+
+    @Override
+    public Collection<Observation> getObservations(String registrationId) {
+        return build(getByRegistrationId(registrationId));
+    }
+
+    @Override
+    public Collection<Observation> removeObservations(String registrationId) {
+        return build(removeAll(registrationId));
+    }
+
+    private Collection<Observation> build(Collection<org.eclipse.californium.core.observe.Observation> cfObss) {
+        List<Observation> obs = new ArrayList<>();
+
+        for (org.eclipse.californium.core.observe.Observation cfObs : cfObss) {
+            obs.add(build(cfObs));
+        }
+        return obs;
+    }
+
+    private Observation build(org.eclipse.californium.core.observe.Observation cfObs) {
+        if (cfObs == null)
+            return null;
+
+        String regId = null;
+        String lwm2mPath = null;
+        Map<String, String> context = null;
+
+        for (Entry<String, String> ctx : cfObs.getRequest().getUserContext().entrySet()) {
+            switch (ctx.getKey()) {
+            case CTX_REGID:
+                regId = ctx.getValue();
+                break;
+            case CTX_LWM2M_PATH:
+                lwm2mPath = ctx.getValue();
+                break;
+            default:
+                if (context == null) {
+                    context = new HashMap<>();
+                }
+                context.put(ctx.getKey(), ctx.getValue());
+            }
+        }
+        return new Observation(cfObs.getRequest().getToken(), regId, new LwM2mPath(lwm2mPath), context);
+    }
+
+    @Override
+    public void add(org.eclipse.californium.core.observe.Observation obs) {
+        Client registration = this.validateObservation(obs);
+
+        try (Jedis j = pool.getResource()) {
+            byte[] lockValue = null;
+            byte[] lockKey = toKey(LOCK_EP, registration.getEndpoint());
+            try {
+                lockValue = RedisLock.acquire(j, lockKey);
+
+                byte[] previousValue = j.getSet(toKey(OBS_TKN, obs.getRequest().getToken()), serializeObs(obs));
+
+                // secondary index to get the list by registrationId
+                j.lpush(toKey(OBS_REG, registration.getRegistrationId()), obs.getRequest().getToken());
+
+                // log any collisions
+                if (previousValue != null && previousValue.length != 0) {
+                    org.eclipse.californium.core.observe.Observation previousObservation = deserializeObs(
+                            previousValue);
+                    LOG.warn(
+                            "Token collision ? observation from request [{}] will be replaced by observation from request [{}] ",
+                            previousObservation.getRequest(), obs.getRequest());
+                }
+            } finally {
+                RedisLock.release(j, lockKey, lockValue);
+            }
+        }
+    }
+
+    @Override
+    public void remove(byte[] token) {
+        try (Jedis j = pool.getResource()) {
+            byte[] tokenKey = toKey(OBS_TKN, token);
+
+            // fetch the observation by token
+            byte[] serializedObs = j.get(tokenKey);
+            if (serializedObs == null)
+                return;
+
+            org.eclipse.californium.core.observe.Observation obs = deserializeObs(serializedObs);
+            String registrationId = getRegistrationId(obs);
+            Client registration = getRegistration(registrationId);
+            String endpoint = registration.getEndpoint();
+
+            byte[] lockValue = null;
+            byte[] lockKey = toKey(LOCK_EP, endpoint);
+            try {
+                lockValue = RedisLock.acquire(j, lockKey);
+
+                if (j.del(tokenKey) > 0L) {
+                    j.lrem(toKey(OBS_REG, registrationId), 0, token);
+                }
+
+            } finally {
+                RedisLock.release(j, lockKey, lockValue);
+            }
+        }
+
+    }
+
+    @Override
+    public org.eclipse.californium.core.observe.Observation get(byte[] token) {
+        try (Jedis j = pool.getResource()) {
+            byte[] obs = j.get(toKey(OBS_TKN, token));
+            if (obs == null) {
+                return null;
+            } else {
+                return deserializeObs(obs);
+            }
+        }
+    }
+
+    public Collection<org.eclipse.californium.core.observe.Observation> removeAll(String registrationId) {
+        try (Jedis j = pool.getResource()) {
+            Client registration = getRegistration(registrationId);
+            if (registration == null)
+                return Collections.emptyList();
+            String endpoint = registration.getEndpoint();
+
+
+            byte[] lockValue = null;
+            byte[] lockKey = toKey(LOCK_EP, endpoint);
+            try {
+                lockValue = RedisLock.acquire(j, lockKey);
+
+                Collection<org.eclipse.californium.core.observe.Observation> removed = new ArrayList<>();
+                byte[] regIdKey = toKey(OBS_REG, registrationId);
+
+                // fetch all observations by token
+                for (byte[] token : j.lrange(regIdKey, 0, -1)) {
+                    byte[] obs = j.get(toKey(OBS_TKN, token));
+                    if (obs != null) {
+                        removed.add(deserializeObs(obs));
+                    }
+                    j.del(toKey(OBS_TKN, token));
+                }
+                j.del(regIdKey);
+
+                return removed;
+
+            } finally {
+                RedisLock.release(j, lockKey, lockValue);
+            }
+        }
+    }
+
+    public Collection<org.eclipse.californium.core.observe.Observation> getByRegistrationId(String regId) {
+        Collection<org.eclipse.californium.core.observe.Observation> result = new ArrayList<>();
+        try (Jedis j = pool.getResource()) {
+            for (byte[] token : j.lrange(toKey(OBS_REG, regId), 0, -1)) {
+                byte[] obs = j.get(toKey(OBS_TKN, token));
+                if (obs != null) {
+                    result.add(deserializeObs(obs));
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void setContext(byte[] token, CorrelationContext correlationContext) {
+        // TODO Auto-generated method stub
+
+    }
+    
+    private byte[] toKey(byte[] prefix, byte[] key) {
+        byte[] result = new byte[prefix.length + key.length];
+        System.arraycopy(prefix, 0, result, 0, prefix.length);
+        System.arraycopy(key, 0, result, prefix.length, key.length);
+        return result;
+    }
+
+    private byte[] toKey(String prefix, String registrationID) {
+        return (prefix + registrationID).getBytes();
+    }
+
+    private byte[] serializeObs(org.eclipse.californium.core.observe.Observation obs) {
+        return ObservationSerDes.serialize(obs);
+    }
+
+    private org.eclipse.californium.core.observe.Observation deserializeObs(byte[] data) {
+        return ObservationSerDes.deserialize(data);
+    }
+
+    /* Retrieve the registrationId from the request context */
+    private String getRegistrationId(org.eclipse.californium.core.observe.Observation observation) {
+        return observation.getRequest().getUserContext().get(CoapRequestBuilder.CTX_REGID);
+    }
+
+    private Client validateObservation(org.eclipse.californium.core.observe.Observation observation) {
+        String registrationId = observation.getRequest().getUserContext().get(CoapRequestBuilder.CTX_REGID);
+        if (registrationId == null)
+            throw new IllegalStateException("missing registrationId info in the request context");
+        if (!observation.getRequest().getUserContext().containsKey(CoapRequestBuilder.CTX_LWM2M_PATH))
+            throw new IllegalStateException("missing lwm2m path info in the request context");
+        Client registration = getRegistration(registrationId);
+        if (registration == null)
+            throw new IllegalStateException("no registration for this Id");
+
+        return registration;
+    }
+
+}

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
@@ -52,6 +52,9 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.util.Pool;
 
+/**
+ * A RegistrationStore which stores registrations and observations in Redis.
+ */
 public class RedisRegistrationStore implements CaliforniumRegistrationStore, Startable, Stoppable {
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisClientRegistry.class);

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
@@ -43,6 +43,7 @@ import org.eclipse.leshan.server.client.Client;
 import org.eclipse.leshan.server.client.ClientUpdate;
 import org.eclipse.leshan.server.cluster.serialization.ClientSerDes;
 import org.eclipse.leshan.server.cluster.serialization.ObservationSerDes;
+import org.eclipse.leshan.server.registration.Deregistration;
 import org.eclipse.leshan.server.registration.ExpirationListener;
 import org.eclipse.leshan.util.Validate;
 import org.slf4j.Logger;
@@ -73,7 +74,7 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
     }
 
     @Override
-    public Client addRegistration(Client registration) {
+    public Deregistration addRegistration(Client registration) {
         try (Jedis j = pool.getResource()) {
             byte[] lockValue = null;
             byte[] lockKey = toLockKey(registration.getEndpoint());
@@ -90,7 +91,7 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
 
                 if (old != null) {
                     Client oldRegistration = deserializeReg(old);
-                    return oldRegistration;
+                    return new Deregistration(oldRegistration, null);
                 }
 
                 return null;
@@ -195,7 +196,7 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
     }
 
     @Override
-    public Client removeRegistration(String registrationId) {
+    public Deregistration removeRegistration(String registrationId) {
         try (Jedis j = pool.getResource()) {
 
             byte[] regKey = toRegKey(registrationId);
@@ -214,7 +215,7 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
             Client r = deserializeReg(data);
             deleteClient(j, r);
 
-            return r;
+            return new Deregistration(r, null);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/ClientRegistryImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/ClientRegistryImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.leshan.server.client.Client;
 import org.eclipse.leshan.server.client.ClientRegistry;
 import org.eclipse.leshan.server.client.ClientRegistryListener;
 import org.eclipse.leshan.server.client.ClientUpdate;
+import org.eclipse.leshan.server.registration.Deregistration;
 import org.eclipse.leshan.server.registration.ExpirationListener;
 import org.eclipse.leshan.server.registration.RegistrationStore;
 import org.eclipse.leshan.util.Validate;
@@ -75,10 +76,10 @@ public class ClientRegistryImpl implements ClientRegistry, Startable, Stoppable,
 
         LOG.debug("Registering new client: {}", client);
 
-        Client previous = store.addRegistration(client);
+        Deregistration previous = store.addRegistration(client);
         if (previous != null) {
             for (ClientRegistryListener l : listeners) {
-                l.unregistered(previous);
+                l.unregistered(previous.getRegistration());
             }
         }
         for (ClientRegistryListener l : listeners) {
@@ -110,12 +111,12 @@ public class ClientRegistryImpl implements ClientRegistry, Startable, Stoppable,
 
         LOG.debug("Deregistering client with registrationId: {}", registrationId);
 
-        Client unregistered = store.removeRegistration(registrationId);
+        Deregistration unregistered = store.removeRegistration(registrationId);
         for (ClientRegistryListener l : listeners) {
-            l.unregistered(unregistered);
+            l.unregistered(unregistered.getRegistration());
         }
         LOG.debug("Deregistered client: {}", unregistered);
-        return unregistered;
+        return unregistered.getRegistration();
     }
 
     @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Deregistration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Deregistration.java
@@ -21,6 +21,11 @@ import java.util.Collections;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.server.client.Client;
 
+/**
+ * A Deregistration contains all informations which are removed after a client was unregistered.
+ * 
+ * @see RegistrationStore
+ */
 public class Deregistration {
     final Client registration;
     final Collection<Observation> observations;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Deregistration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Deregistration.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.server.client.Client;
+
+public class Deregistration {
+    final Client registration;
+    final Collection<Observation> observations;
+
+    public Deregistration(Client registration, Collection<Observation> observations) {
+        this.registration = registration;
+        if (observations == null)
+            this.observations = Collections.emptyList();
+        else
+            this.observations = observations;
+    }
+
+    public Client getRegistration() {
+        return registration;
+    }
+
+    public Collection<Observation> getObservations() {
+        return observations;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ExpirationListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ExpirationListener.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+import java.util.Collection;
+
+import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.server.client.Client;
+
+public interface ExpirationListener {
+
+    void registrationExpired(Client registration, Collection<Observation> observation);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ExpirationListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/ExpirationListener.java
@@ -20,6 +20,11 @@ import java.util.Collection;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.server.client.Client;
 
+/**
+ * A listener to be aware of registration expiration.
+ * 
+ * @see RegistrationStore
+ */
 public interface ExpirationListener {
 
     void registrationExpired(Client registration, Collection<Observation> observation);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -24,7 +24,7 @@ import org.eclipse.leshan.server.client.ClientUpdate;
 
 public interface RegistrationStore {
 
-    Client addRegistration(Client registration);
+    Deregistration addRegistration(Client registration);
 
     Client updateRegistration(ClientUpdate update);
 
@@ -37,7 +37,7 @@ public interface RegistrationStore {
     // TODO should be removed
     Collection<Client> getAllRegistration();
 
-    Client removeRegistration(String registrationId);
+    Deregistration removeRegistration(String registrationId);
 
     Observation addObservation(String registrationId, Observation observation);
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -48,4 +48,6 @@ public interface RegistrationStore {
     Collection<Observation> getObservations(String registrationId);
 
     Collection<Observation> removeObservations(String registrationId);
+
+    void setExpirationListener(ExpirationListener listener);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -22,32 +22,99 @@ import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.server.client.Client;
 import org.eclipse.leshan.server.client.ClientUpdate;
 
+/**
+ * A store for registrations and observations. This interface is also responsible to handle registration expiration.
+ */
 public interface RegistrationStore {
 
+    /**
+     * Add a new registration. If there is already a registration with the same endpoint removed it.
+     * 
+     * @param registration the new registration.
+     * @return the old registration and its observations removed or null.
+     */
     Deregistration addRegistration(Client registration);
 
+    /**
+     * Update an existing registration
+     * 
+     * @param update data to update
+     * @return the registration updated
+     */
     Client updateRegistration(ClientUpdate update);
 
+    /**
+     * Get the registration by registration Id.
+     * 
+     * @param registrationId of the registration.
+     * @return the registration or null if there is no registration with this id.
+     */
     Client getRegistration(String registrationId);
 
+    /**
+     * Get the registration by endpoint.
+     * 
+     * @param endpoint of the registration.
+     * @return the registration or null if there is no registration with this endpoint.
+     */
     Client getRegistrationByEndpoint(String endpoint);
 
+    /**
+     * Get the registration by socket address.
+     * 
+     * @param address of the client registered.
+     * @return the registration or null if there is no client registered with this socket address.
+     */
     Collection<Client> getRegistrationByAdress(InetSocketAddress address);
 
-    // TODO should be removed
+    /**
+     * @return all registrations in this store.
+     * @Deprecated should be replaced by an iterator.
+     */
+    // TODO Should be replaced by an iterator.
+    @Deprecated
     Collection<Client> getAllRegistration();
 
+    /**
+     * Remove the registration with the given registration Id
+     * 
+     * @param registrationId the id of the registration to removed
+     * @return the registration and observations removed or null if there is no registration for this Id.
+     */
     Deregistration removeRegistration(String registrationId);
 
+    /**
+     * Add a new Observation for a given registration.
+     * 
+     * @param registrationId the id of the registration
+     * @param observation the observation to add
+     * 
+     * @return the previous observation or null if any.
+     */
     Observation addObservation(String registrationId, Observation observation);
 
+    /**
+     * Get the observation for the given registration with the given observationId
+     */
     Observation getObservation(String registrationId, byte[] observationId);
 
+    /**
+     * Remove the observation for the given registration with the given observationId
+     */
     Observation removeObservation(String registrationId, byte[] observationId);
 
+    /**
+     * Get all observations for the given registrationId
+     */
     Collection<Observation> getObservations(String registrationId);
 
+    /**
+     * Remove all observations for the given registrationId
+     */
     Collection<Observation> removeObservations(String registrationId);
 
+    /**
+     * set a listener for registration expiration.
+     */
     void setExpirationListener(ExpirationListener listener);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+
+import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.server.client.Client;
+import org.eclipse.leshan.server.client.ClientUpdate;
+
+public interface RegistrationStore {
+
+    Client addRegistration(Client registration);
+
+    Client updateRegistration(ClientUpdate update);
+
+    Client getRegistration(String registrationId);
+
+    Client getRegistrationByEndpoint(String endpoint);
+
+    Collection<Client> getRegistrationByAdress(InetSocketAddress address);
+
+    // TODO should be removed
+    Collection<Client> getAllRegistration();
+
+    Client removeRegistration(String registrationId);
+
+    Observation addObservation(String registrationId, Observation observation);
+
+    Observation getObservation(String registrationId, byte[] observationId);
+
+    Observation removeObservation(String registrationId, byte[] observationId);
+
+    Collection<Observation> getObservations(String registrationId);
+
+    Collection<Observation> removeObservations(String registrationId);
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -45,11 +45,8 @@ import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeDecoder;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
-import org.eclipse.leshan.server.californium.impl.CaliforniumObservationRegistryImpl;
 import org.eclipse.leshan.server.californium.impl.LeshanServer;
-import org.eclipse.leshan.server.client.ClientRegistry;
-import org.eclipse.leshan.server.cluster.RedisClientRegistry;
-import org.eclipse.leshan.server.cluster.RedisObservationStore;
+import org.eclipse.leshan.server.cluster.RedisRegistrationStore;
 import org.eclipse.leshan.server.cluster.RedisSecurityRegistry;
 import org.eclipse.leshan.server.demo.servlet.ClientServlet;
 import org.eclipse.leshan.server.demo.servlet.EventServlet;
@@ -217,11 +214,8 @@ public class LeshanServerDemo {
                 builder.setSecurityRegistry(new SecurityRegistryImpl(privateKey, publicKey));
             } else {
                 // use Redis
-                ClientRegistry clientRegistry = new RedisClientRegistry(jedis);
                 builder.setSecurityRegistry(new RedisSecurityRegistry(jedis, privateKey, publicKey));
-                builder.setClientRegistry(clientRegistry);
-                builder.setObservationRegistry(new CaliforniumObservationRegistryImpl(
-                        new RedisObservationStore(jedis), clientRegistry, modelProvider, decoder));
+                builder.setRegistrationStore(new RedisRegistrationStore(jedis));
             }
         } catch (InvalidKeySpecException | NoSuchAlgorithmException | InvalidParameterSpecException e) {
             LOG.error("Unable to initialize RPK.", e);


### PR DESCRIPTION
I refactor the code to create a new store which handles registrations and observations.

This aims to fix several issues about registrations and observations lifecycle. Merging the store allow to easily handle atomicity on registration/observations operations. (E.g. deregister will removed current observations)
more details : #192

This PR is focused on introducing the store without too many impact on current user API. (ClientRegistry and ObservationRegistry).

But this reveal some issues in the current API (e.g. `ClientRegistry` expose methods like `registerClient()` or `updateClient()` which is internal API). So the next step will probably to clean the API (with some renaming :-/ ).