### PR TITLE
fixed humitidy minimum value to be float instead of string

### DIFF
--- a/leshan-core/src/main/resources/oma-objects-spec.json
+++ b/leshan-core/src/main/resources/oma-objects-spec.json
@@ -1705,7 +1705,7 @@
         "operations": "R",
         "instancetype": "single",
         "mandatory": false,
-        "type": "string",
+        "type": "float",
         "range": "",
         "units": "Defined by “Units” resource.",
         "description": "The minimum value that can be measured by the sensor"


### PR DESCRIPTION
Signed-off-by: Joakim Eriksson <joakime@sics.se>

I Had some issues with the humidity sensors and it seems to be the JSON description file that was configured for string intstead of float for the minimum humidity value. This is a fix for that.

BTW: Is there anyone planning to add the other IPSO objects that are not yet supported?