### PR TITLE
#225: Support new Content-Format code for TLV/Json

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/DefaultLwM2mNodeDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/DefaultLwM2mNodeDecoder.java
@@ -60,10 +60,12 @@ public class DefaultLwM2mNodeDecoder implements LwM2mNodeDecoder {
         case ContentFormat.TEXT_CODE:
             return (T) LwM2mNodeTextDecoder.decode(content, path, model);
         case ContentFormat.TLV_CODE:
+        case ContentFormat.OLD_TLV_CODE:
             return LwM2mNodeTlvDecoder.decode(content, path, model, nodeClass);
         case ContentFormat.OPAQUE_CODE:
             return (T) LwM2mNodeOpaqueDecoder.decode(content, path, model);
         case ContentFormat.JSON_CODE:
+        case ContentFormat.OLD_JSON_CODE:
             return LwM2mNodeJsonDecoder.decode(content, path, model, nodeClass);
         case ContentFormat.LINK_CODE:
             throw new UnsupportedOperationException("Content format " + format + " not yet implemented '" + path + "'");
@@ -83,10 +85,12 @@ public class DefaultLwM2mNodeDecoder implements LwM2mNodeDecoder {
         case ContentFormat.TEXT_CODE:
             return toTimestampedNodes(LwM2mNodeTextDecoder.decode(content, path, model));
         case ContentFormat.TLV_CODE:
+        case ContentFormat.OLD_TLV_CODE:
             return toTimestampedNodes(LwM2mNodeTlvDecoder.decode(content, path, model, nodeClassFromPath(path)));
         case ContentFormat.OPAQUE_CODE:
             return toTimestampedNodes(LwM2mNodeOpaqueDecoder.decode(content, path, model));
         case ContentFormat.JSON_CODE:
+        case ContentFormat.OLD_JSON_CODE:
             return LwM2mNodeJsonDecoder.decodeTimestamped(content, path, model, nodeClassFromPath(path));
         case ContentFormat.LINK_CODE:
             throw new UnsupportedOperationException("Content format " + format + " not yet implemented '" + path + "'");
@@ -119,8 +123,10 @@ public class DefaultLwM2mNodeDecoder implements LwM2mNodeDecoder {
         switch (format.getCode()) {
         case ContentFormat.TEXT_CODE:
         case ContentFormat.TLV_CODE:
+        case ContentFormat.OLD_TLV_CODE:
         case ContentFormat.OPAQUE_CODE:
         case ContentFormat.JSON_CODE:
+        case ContentFormat.OLD_JSON_CODE:
             return true;
         default:
             return false;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/DefaultLwM2mNodeEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/DefaultLwM2mNodeEncoder.java
@@ -46,6 +46,7 @@ public class DefaultLwM2mNodeEncoder implements LwM2mNodeEncoder {
         byte[] encoded = null;
         switch (format.getCode()) {
         case ContentFormat.TLV_CODE:
+        case ContentFormat.OLD_TLV_CODE:
             encoded = LwM2mNodeTlvEncoder.encode(node, path, model);
             break;
         case ContentFormat.TEXT_CODE:
@@ -55,6 +56,7 @@ public class DefaultLwM2mNodeEncoder implements LwM2mNodeEncoder {
             encoded = LwM2mNodeOpaqueEncoder.encode(node, path, model);
             break;
         case ContentFormat.JSON_CODE:
+        case ContentFormat.OLD_JSON_CODE:
             encoded = LwM2mNodeJsonEncoder.encode(node, path, model);
             break;
         default:
@@ -91,8 +93,10 @@ public class DefaultLwM2mNodeEncoder implements LwM2mNodeEncoder {
         switch (format.getCode()) {
         case ContentFormat.TEXT_CODE:
         case ContentFormat.TLV_CODE:
+        case ContentFormat.OLD_TLV_CODE:
         case ContentFormat.OPAQUE_CODE:
         case ContentFormat.JSON_CODE:
+        case ContentFormat.OLD_JSON_CODE:
             return true;
         default:
             return false;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/ContentFormat.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/ContentFormat.java
@@ -19,11 +19,15 @@ package org.eclipse.leshan.core.request;
  * Data format defined by the LWM2M specification
  */
 public class ContentFormat {
-    public static final int TLV_CODE = 1542;
-    public static final int JSON_CODE = 1543;
+    public static final int TLV_CODE = 11542;
+    public static final int JSON_CODE = 11543;
     public static final int TEXT_CODE = 0;
     public static final int OPAQUE_CODE = 42;
     public static final int LINK_CODE = 40;
+
+    // Keep old code for backward-compatibility
+    public static final int OLD_JSON_CODE = 1543;
+    public static final int OLD_TLV_CODE = 1542;
 
     public static final ContentFormat TLV = new ContentFormat("TLV", "application/vnd.oma.lwm2m+tlv", TLV_CODE);
     public static final ContentFormat JSON = new ContentFormat("JSON", "application/vnd.oma.lwm2m+json", JSON_CODE);

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
@@ -74,11 +74,20 @@ public class WriteTest {
     public void can_write_string_resource_in_tlv() throws InterruptedException {
         write_string_resource(ContentFormat.TLV);
     }
+    
+    @Test
+    public void can_write_string_resource_in__old_tlv() throws InterruptedException {
+        write_string_resource(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
 
     @Test
-    // TODO fix json format
     public void can_write_string_resource_in_json() throws InterruptedException {
         write_string_resource(ContentFormat.JSON);
+    }
+
+    @Test
+    public void can_write_string_resource_in__old_json() throws InterruptedException {
+        write_string_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
     }
 
     private void write_string_resource(ContentFormat format) throws InterruptedException {
@@ -110,8 +119,18 @@ public class WriteTest {
     }
 
     @Test
+    public void can_write_boolean_resource_in_old_tlv() throws InterruptedException {
+        write_boolean_resource(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
+
+    @Test
     public void can_write_boolean_resource_in_json() throws InterruptedException {
         write_boolean_resource(ContentFormat.JSON);
+    }
+    
+    @Test
+    public void can_write_boolean_resource_in_old_json() throws InterruptedException {
+        write_boolean_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
     }
 
     private void write_boolean_resource(ContentFormat format) throws InterruptedException {
@@ -143,8 +162,18 @@ public class WriteTest {
     }
 
     @Test
+    public void can_write_integer_resource_in_old_tlv() throws InterruptedException {
+        write_integer_resource(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
+
+    @Test
     public void can_write_integer_resource_in_json() throws InterruptedException {
         write_integer_resource(ContentFormat.JSON);
+    }
+
+    @Test
+    public void can_write_integer_resource_in_old_json() throws InterruptedException {
+        write_integer_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
     }
 
     private void write_integer_resource(ContentFormat format) throws InterruptedException {
@@ -176,8 +205,18 @@ public class WriteTest {
     }
 
     @Test
+    public void can_write_float_resource_in_old_tlv() throws InterruptedException {
+        write_float_resource(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
+
+    @Test
     public void can_write_float_resource_in_json() throws InterruptedException {
         write_float_resource(ContentFormat.JSON);
+    }
+
+    @Test
+    public void can_write_float_resource_in_old_json() throws InterruptedException {
+        write_float_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
     }
 
     private void write_float_resource(ContentFormat format) throws InterruptedException {
@@ -209,8 +248,18 @@ public class WriteTest {
     }
 
     @Test
+    public void can_write_time_resource_in_old_tlv() throws InterruptedException {
+        write_time_resource(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
+
+    @Test
     public void can_write_time_resource_in_json() throws InterruptedException {
         write_time_resource(ContentFormat.JSON);
+    }
+
+    @Test
+    public void can_write_time_resource_in_old_json() throws InterruptedException {
+        write_time_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
     }
 
     private void write_time_resource(ContentFormat format) throws InterruptedException {
@@ -242,8 +291,18 @@ public class WriteTest {
     }
 
     @Test
+    public void can_write_opaque_resource_in_old_tlv() throws InterruptedException {
+        write_opaque_resource(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
+
+    @Test
     public void can_write_opaque_resource_in_json() throws InterruptedException {
         write_opaque_resource(ContentFormat.JSON);
+    }
+
+    @Test
+    public void can_write_opaque_resource_in_old_json() throws InterruptedException {
+        write_opaque_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
     }
 
     private void write_opaque_resource(ContentFormat format) throws InterruptedException {
@@ -289,12 +348,31 @@ public class WriteTest {
     }
 
     @Test
-    public void can_write_object_instance() throws InterruptedException {
+    public void can_write_object_instance_in_tlv() throws InterruptedException {
+        can_write_object_instance(ContentFormat.TLV);
+    }
+
+    @Test
+    public void can_write_object_instance_in_old_tlv() throws InterruptedException {
+        can_write_object_instance(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
+
+    @Test
+    public void can_write_object_instance_in_json() throws InterruptedException {
+        can_write_object_instance(ContentFormat.JSON);
+    }
+
+    @Test
+    public void can_write_object_instance_in_old_json() throws InterruptedException {
+        can_write_object_instance(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
+    }
+
+    public void can_write_object_instance(ContentFormat format) throws InterruptedException {
         // write device timezone and offset
         LwM2mResource utcOffset = LwM2mSingleResource.newStringResource(14, "+02");
         LwM2mResource timeZone = LwM2mSingleResource.newStringResource(15, "Europe/Paris");
         WriteResponse response = helper.server.send(helper.getCurrentRegistration(),
-                new WriteRequest(Mode.REPLACE, 3, 0, utcOffset, timeZone));
+                new WriteRequest(Mode.REPLACE, format, 3, 0, utcOffset, timeZone));
 
         // verify result
         assertEquals(ResponseCode.CHANGED, response.getCode());
@@ -384,26 +462,6 @@ public class WriteTest {
         assertNotNull(instance.getResource(3));
         assertNotNull(instance.getResource(6));
         assertNotNull(instance.getResource(7));
-    }
-
-    @Test
-    public void can_write_object_instance_in_json() throws InterruptedException {
-        // write device timezone and offset
-        LwM2mResource utcOffset = LwM2mSingleResource.newStringResource(14, "+02");
-        LwM2mResource timeZone = LwM2mSingleResource.newStringResource(15, "Europe/Paris");
-        WriteResponse response = helper.server.send(helper.getCurrentRegistration(),
-                new WriteRequest(Mode.REPLACE, ContentFormat.JSON, 3, 0, utcOffset, timeZone));
-
-        // verify result
-        assertEquals(ResponseCode.CHANGED, response.getCode());
-        assertNotNull(response.getCoapResponse());
-        assertThat(response.getCoapResponse(), is(instanceOf(Response.class)));
-
-        // read the timezone to check the value changed
-        ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(), new ReadRequest(3, 0));
-        LwM2mObjectInstance instance = (LwM2mObjectInstance) readResponse.getContent();
-        assertEquals(utcOffset, instance.getResource(14));
-        assertEquals(timeZone, instance.getResource(15));
     }
 
     @Test


### PR DESCRIPTION
I change the TLV and Json content format code. (see #225)

We keep backward compatibility as Leshan client or server will accept the old TLV/Json code too.

If some body want to send a request with the old content Format, he can use :
```java
new WriteRequest(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE), 3, 0, 15, "new value")
```

About backward compatibility, there remains a problem with `BootstrapServer`. All the requests sended by `BootstrapServer` will use the new code. This could be a problem for clients that expect old one...