### PR TITLE
Send registration event after sending response to device

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/ExchangeObserverAdapter.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/ExchangeObserverAdapter.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.impl;
+
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.ExchangeObserver;
+
+/**
+ * An abstract adapter class for reacting to exchange events. The methods in this class are empty. This class exists as
+ * convenience for creating exchange observer objects.
+ */
+// TODO should be part of californium ?
+public class ExchangeObserverAdapter implements ExchangeObserver {
+
+    @Override
+    public void completed(Exchange exchange) {
+    }
+
+    @Override
+    public void contextEstablished(Exchange exchange) {
+    }
+}

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -192,15 +192,6 @@ public class RegisterResource extends CoapResource {
                 registerRequest, serverEndpoint);
         RegisterResponse response = sendableResponse.getResponse();
 
-        // Mark the response as sended when the exchange is complete
-        exchange.advanced().setObserver(new ExchangeObserverAdapter() {
-            @Override
-            public void completed(Exchange exchange) {
-                sendableResponse.sent();
-
-            }
-        });
-
         // Create CoAP Response from LwM2m request
         // -------------------------------
         if (response.getCode() == org.eclipse.leshan.ResponseCode.CREATED) {
@@ -209,6 +200,7 @@ public class RegisterResource extends CoapResource {
         } else {
             exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
         }
+        sendableResponse.sent();
     }
 
     private void handleUpdate(CoapExchange exchange, Request request, String registrationId) {
@@ -238,16 +230,9 @@ public class RegisterResource extends CoapResource {
         final SendableResponse<UpdateResponse> sendableResponse = registrationHandler.update(sender, updateRequest);
         UpdateResponse updateResponse = sendableResponse.getResponse();
 
-        // Mark the response as sended when the exchange is complete
-        exchange.advanced().setObserver(new ExchangeObserverAdapter() {
-            @Override
-            public void completed(Exchange exchange) {
-                sendableResponse.sent();
-            }
-        });
-
         // Create CoAP Response from LwM2m request
         exchange.respond(fromLwM2mCode(updateResponse.getCode()), updateResponse.getErrorMessage());
+        sendableResponse.sent();
     }
 
     private void handleDeregister(CoapExchange exchange, String registrationId) {
@@ -262,16 +247,9 @@ public class RegisterResource extends CoapResource {
                 deregisterRequest);
         DeregisterResponse deregisterResponse = sendableResponse.getResponse();
 
-        // Mark the response as sended when the exchange is complete
-        exchange.advanced().setObserver(new ExchangeObserverAdapter() {
-            @Override
-            public void completed(Exchange exchange) {
-                sendableResponse.sent();
-            }
-        });
-
         // Create CoAP Response from LwM2m request
         exchange.respond(fromLwM2mCode(deregisterResponse.getCode()), deregisterResponse.getErrorMessage());
+        sendableResponse.sent();
     }
 
     // Since the V1_0-20150615-D version of specification, the registration update should be a CoAP POST.

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/SendableResponse.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/SendableResponse.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.impl;
+
+import org.eclipse.leshan.core.response.LwM2mResponse;
+
+/**
+ * A Response wrapper which can be notify when the response is sent
+ */
+public class SendableResponse<T extends LwM2mResponse> {
+
+    private T response;
+    private Runnable sentCallback;
+
+    public SendableResponse(T response) {
+        this(response, null);
+    }
+
+    public SendableResponse(T response, Runnable sentCallback) {
+        this.response = response;
+        this.sentCallback = sentCallback;
+    }
+
+    public T getResponse() {
+        return response;
+    }
+
+    public void sent() {
+        if (sentCallback != null)
+                     sentCallback.run(); 
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.leshan.core.response.DeregisterResponse;
 import org.eclipse.leshan.core.response.RegisterResponse;
 import org.eclipse.leshan.core.response.UpdateResponse;
 import org.eclipse.leshan.server.impl.RegistrationServiceImpl;
+import org.eclipse.leshan.server.impl.SendableResponse;
 import org.eclipse.leshan.server.security.Authorizer;
 import org.eclipse.leshan.util.RandomStringUtils;
 import org.slf4j.Logger;
@@ -47,7 +48,7 @@ public class RegistrationHandler {
         this.authorizer = authorizer;
     }
 
-    public RegisterResponse register(Identity sender, RegisterRequest registerRequest,
+    public SendableResponse<RegisterResponse> register(Identity sender, RegisterRequest registerRequest,
             InetSocketAddress serverEndpoint) {
 
         Registration.Builder builder = new Registration.Builder(RegistrationHandler.createRegistrationId(),
@@ -59,82 +60,98 @@ public class RegistrationHandler {
                 .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
                 .additionalRegistrationAttributes(registerRequest.getAdditionalAttributes());
 
-        Registration registration = builder.build();
+        final Registration registration = builder.build();
 
         // We must check if the client is using the right identity.
         if (!authorizer.isAuthorized(registerRequest, registration, sender)) {
-            return RegisterResponse.forbidden(null);
+            return new SendableResponse<>(RegisterResponse.forbidden(null));
         }
 
         // Add registration to the store
-        Deregistration deregistration = registrationService.getStore().addRegistration(registration);
+        final Deregistration deregistration = registrationService.getStore().addRegistration(registration);
 
-        // notify new registration and de-registration
+        // Create callback to notify new registration and de-registration
         LOG.debug("New registration: {}", registration);
-        if (deregistration != null) {
-            registrationService.fireUnregistered(deregistration.getRegistration(), deregistration.getObservations());
-        }
-        registrationService.fireRegistred(registration);
-            
-        return RegisterResponse.success(registration.getId());
+
+        Runnable whenSent = new Runnable() {
+            @Override
+            public void run() {
+                if (deregistration != null) {
+                    registrationService.fireUnregistered(deregistration.getRegistration(),
+                            deregistration.getObservations());
+                }
+                registrationService.fireRegistred(registration);
+            }
+        };
+        return new SendableResponse<>(RegisterResponse.success(registration.getId()), whenSent);
     }
 
-    public UpdateResponse update(Identity sender, UpdateRequest updateRequest) {
+    public SendableResponse<UpdateResponse> update(Identity sender, UpdateRequest updateRequest) {
 
         // We must check if the client is using the right identity.
         Registration registration = registrationService.getById(updateRequest.getRegistrationId());
         if (registration == null) {
-            return UpdateResponse.notFound();
+            return new SendableResponse<>(UpdateResponse.notFound());
         }
 
         if (!authorizer.isAuthorized(updateRequest, registration, sender)) {
             // TODO replace by Forbidden if https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181 is
             // closed.
-            return UpdateResponse.badRequest("forbidden");
+            return new SendableResponse<>(UpdateResponse.badRequest("forbidden"));
         }
 
         // Create update
-        RegistrationUpdate update = new RegistrationUpdate(updateRequest.getRegistrationId(), sender
+        final RegistrationUpdate update = new RegistrationUpdate(updateRequest.getRegistrationId(), sender
                 .getPeerAddress().getAddress(), sender.getPeerAddress().getPort(), updateRequest.getLifeTimeInSec(),
                 updateRequest.getSmsNumber(), updateRequest.getBindingMode(), updateRequest.getObjectLinks());
 
         // update registration
-        Registration updatedRegistration = registrationService.getStore().updateRegistration(update);
+        final Registration updatedRegistration = registrationService.getStore().updateRegistration(update);
         if (updatedRegistration == null) {
             LOG.debug("Invalid update:  registration {} not found", registration.getId());
-            return UpdateResponse.notFound();
+            return new SendableResponse<>(UpdateResponse.notFound());
         } else {
             LOG.debug("Updated registration {} by {}", updatedRegistration, update);
-            // notify registration update
-            registrationService.fireUpdated(update, updatedRegistration);
-            return UpdateResponse.success();
+            // Create callback to notify registration update
+            Runnable whenSent = new Runnable() {
+                @Override
+                public void run() {
+                    registrationService.fireUpdated(update, updatedRegistration);
+                };
+            };
+            return new SendableResponse<>(UpdateResponse.success(), whenSent);
         }
     }
 
-    public DeregisterResponse deregister(Identity sender, DeregisterRequest deregisterRequest) {
+    public SendableResponse<DeregisterResponse> deregister(Identity sender, DeregisterRequest deregisterRequest) {
 
         // We must check if the client is using the right identity.
         Registration registration = registrationService.getById(deregisterRequest.getRegistrationId());
         if (registration == null) {
-            return DeregisterResponse.notFound();
+            return new SendableResponse<>(DeregisterResponse.notFound());
         }
         if (!authorizer.isAuthorized(deregisterRequest, registration, sender)) {
             // TODO replace by Forbidden if https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181 is
             // closed.
-            return DeregisterResponse.badRequest("forbidden");
+            return new SendableResponse<>(DeregisterResponse.badRequest("forbidden"));
         }
 
-        Deregistration deregistration = registrationService.getStore()
+        final Deregistration deregistration = registrationService.getStore()
                 .removeRegistration(deregisterRequest.getRegistrationId());
 
         if (deregistration != null) {
             LOG.debug("Deregistered client: {}", deregistration.getRegistration());
-            // notify new de-registration
-            registrationService.fireUnregistered(deregistration.getRegistration(), deregistration.getObservations());
-            return DeregisterResponse.success();
+            // Create callback to notify new de-registration
+            Runnable whenSent = new Runnable() {
+                @Override
+                public void run() {
+                    registrationService.fireUnregistered(deregistration.getRegistration(), deregistration.getObservations());
+                };
+            };
+            return new SendableResponse<>(DeregisterResponse.success(), whenSent);
         } else {
             LOG.debug("Invalid deregistration :  registration {} not found", registration.getId());
-            return DeregisterResponse.notFound();
+            return new SendableResponse<>(DeregisterResponse.notFound());
         }
     }
 


### PR DESCRIPTION
This PR was motivated by #247.

It aims to send registration event (register, update, deregister) after we effectively send the LWM2M response to the device. Even if UDP does not guarantee ordered and like it is explain [here](https://github.com/eclipse/wakaama/pull/24#issuecomment-78451687) it is not mandatory to make it works, this could be an improvement most of the time. 

It is largely inspired by what I have done [here](https://github.com/eclipse/leshan/commit/776c8e48595e050569553a7b6c5b089a18485697) for #16, but trying to keep the `LwM2mResponse` immutable.

