### PR TITLE
Add registration parameters for observations event

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
@@ -50,6 +50,7 @@ import org.eclipse.leshan.core.request.WriteRequest;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
+import org.eclipse.leshan.server.client.Registration;
 import org.eclipse.leshan.server.observation.ObservationListener;
 import org.junit.After;
 import org.junit.Before;
@@ -361,7 +362,7 @@ public class ObserveTest {
         private Exception error;
 
         @Override
-        public void onResponse(Observation observation, ObserveResponse response) {
+        public void onResponse(Observation observation, Registration registration, ObserveResponse response) {
             receivedNotify.set(true);
             this.response = response;
             this.error = null;
@@ -369,7 +370,7 @@ public class ObserveTest {
         }
 
         @Override
-        public void onError(Observation observation, Exception error) {
+        public void onError(Observation observation, Registration registration, Exception error) {
             receivedNotify.set(true);
             this.response = null;
             this.error = error;
@@ -382,7 +383,7 @@ public class ObserveTest {
         }
 
         @Override
-        public void newObservation(final Observation observation) {
+        public void newObservation(Observation observation, Registration registration) {
         }
 
         public AtomicBoolean receivedNotify() {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
@@ -243,7 +243,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
                 // observe request successful
                 Observation observation = new Observation(coapRequest.getToken(), registration.getId(),
                         request.getPath(), request.getContext());
-                observationService.addObservation(observation);
+                observationService.addObservation(registration, observation);
                 // add the observation to an ObserveResponse instance
                 lwM2mresponse = new ObserveResponse(ResponseCode.CONTENT, content, null, observation, null,
                         coapResponse);

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/ObservationServiceImpl.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/ObservationServiceImpl.java
@@ -80,7 +80,7 @@ public class ObservationServiceImpl implements ObservationService, NotificationL
         this.decoder = decoder;
     }
 
-    public void addObservation(Observation observation) {
+    public void addObservation(Registration registration, Observation observation) {
         // cancel any other observation for the same path and registration id.
         // delegate this to the observation store to avoid race conditions on add/cancel?
         for (Observation obs : getObservations(observation.getRegistrationId())) {
@@ -92,7 +92,7 @@ public class ObservationServiceImpl implements ObservationService, NotificationL
         // the observation is already persisted by the CoAP layer
 
         for (ObservationListener listener : listeners) {
-            listener.newObservation(observation);
+            listener.newObservation(observation, registration);
         }
     }
 
@@ -220,13 +220,13 @@ public class ObservationServiceImpl implements ObservationService, NotificationL
             if (observation == null)
                 return;
 
-            try {
-                // get registration
-                Registration registration = registrationStore.getRegistration(observation.getRegistrationId());
-                if (registration == null)
-                    // TODO Should we clean registrationIDs maps ?
-                    return;
+            // get registration
+            Registration registration = registrationStore.getRegistration(observation.getRegistrationId());
+            if (registration == null)
+                // TODO Should we clean registrationIDs maps ?
+                return;
 
+            try {
                 // get model for this registration
                 LwM2mModel model = modelProvider.getObjectModel(registration);
 
@@ -252,14 +252,14 @@ public class ObservationServiceImpl implements ObservationService, NotificationL
 
                 // notify all listeners
                 for (ObservationListener listener : listeners) {
-                    listener.onResponse(observation, response);
+                    listener.onResponse(observation, registration, response);
                 }
             } catch (InvalidValueException | RuntimeException e) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(String.format("Unable to handle notification for observation [%s]", observation), e);
                 }
                 for (ObservationListener listener : listeners) {
-                    listener.onError(observation, e);
+                    listener.onError(observation, registration, e);
                 }
             }
         }

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CaliforniumObservationTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/CaliforniumObservationTest.java
@@ -127,9 +127,12 @@ public class CaliforniumObservationTest {
     }
 
     private Observation givenAnObservation(String registrationId, LwM2mPath target) {
-        if (store.getRegistration(registrationId) == null)
-            store.addRegistration(givenASimpleClient(registrationId));
-        
+        Registration registration = store.getRegistration(registrationId);
+        if (registration == null) {
+            registration = givenASimpleClient(registrationId);
+            store.addRegistration(registration);
+        }
+
         coapRequest = Request.newGet();
         coapRequest.setToken(CaliforniumTestSupport.createToken());
         coapRequest.getOptions().addUriPath(String.valueOf(target.getObjectId()));
@@ -145,7 +148,7 @@ public class CaliforniumObservationTest {
         store.add(new org.eclipse.californium.core.observe.Observation(coapRequest, null));
 
         Observation observation = new Observation(coapRequest.getToken(), registrationId, target, null);
-        observationService.addObservation(observation);
+        observationService.addObservation(registration, observation);
 
         return observation;
     }

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRequestResponseHandler.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRequestResponseHandler.java
@@ -80,12 +80,12 @@ public class RedisRequestResponseHandler {
         this.observationService.addListener(new ObservationListener() {
 
             @Override
-            public void onResponse(Observation observation, ObserveResponse response) {
+            public void onResponse(Observation observation, Registration registration, ObserveResponse response) {
                 handleNotification(observation, response.getContent());
             }
 
             @Override
-            public void onError(Observation observation, Exception error) {
+            public void onError(Observation observation, Registration registration, Exception error) {
                 if (LOG.isWarnEnabled()) {
                     LOG.warn(String.format("Unable to handle notification of [%s:%s]", observation.getRegistrationId(),
                             observation.getPath()), error);
@@ -93,7 +93,7 @@ public class RedisRequestResponseHandler {
             }
 
             @Override
-            public void newObservation(Observation observation) {
+            public void newObservation(Observation observation, Registration registration) {
             }
 
             @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/observation/ObservationListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/observation/ObservationListener.java
@@ -17,10 +17,11 @@ package org.eclipse.leshan.server.observation;
 
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.server.client.Registration;
 
 public interface ObservationListener {
 
-    void newObservation(Observation observation);
+    void newObservation(Observation observation, Registration registration);
 
     void cancelled(Observation observation);
 
@@ -28,15 +29,18 @@ public interface ObservationListener {
      * Called on new notification.
      * 
      * @param observation the observation for which new data are received
+     * @param registration the registration concerned by this observation
      * @param reponse the lwm2m response received
+     * 
      */
-    void onResponse(Observation observation, ObserveResponse response);
+    void onResponse(Observation observation, Registration registration, ObserveResponse response);
 
     /**
      * Called when an error occurs on new notification.
      * 
      * @param observation the observation for which new data are received
+     * @param registration the registration concerned by this observation
      * @param error the exception raised when we handle the notification
      */
-    void onError(Observation observation, Exception error);
+    void onError(Observation observation, Registration registration, Exception error);
 }

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
@@ -99,12 +99,11 @@ public class EventServlet extends EventSourceServlet {
         }
 
         @Override
-        public void onResponse(Observation observation, ObserveResponse response) {
+        public void onResponse(Observation observation, Registration registration, ObserveResponse response) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Received notification from [{}] containing value [{}]", observation.getPath(),
                         response.getContent().toString());
             }
-            Registration registration = server.getRegistrationService().getById(observation.getRegistrationId());
 
             if (registration != null) {
                 String data = new StringBuffer("{\"ep\":\"").append(registration.getEndpoint()).append("\",\"res\":\"")
@@ -117,7 +116,7 @@ public class EventServlet extends EventSourceServlet {
         }
 
         @Override
-        public void onError(Observation observation, Exception error) {
+        public void onError(Observation observation, Registration registration, Exception error) {
             if (LOG.isWarnEnabled()) {
                 LOG.warn(String.format("Unable to handle notification of [%s:%s]", observation.getRegistrationId(),
                         observation.getPath()), error);
@@ -125,7 +124,7 @@ public class EventServlet extends EventSourceServlet {
         }
 
         @Override
-        public void newObservation(Observation observation) {
+        public void newObservation(Observation observation, Registration registration) {
         }
     };
 


### PR DESCRIPTION
Add the registration in parameters of observations events. This allow for example to easily send request when we receive a new notification.