### PR TITLE
introduced a simplified Queue mode API and implementation.

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -42,6 +42,7 @@ import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.request.DownlinkRequest;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.server.Destroyable;
 import org.eclipse.leshan.server.LwM2mServer;
@@ -51,7 +52,10 @@ import org.eclipse.leshan.server.californium.CaliforniumRegistrationStore;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.impl.RegistrationServiceImpl;
 import org.eclipse.leshan.server.model.LwM2mModelProvider;
+import org.eclipse.leshan.server.observation.ObservationListener;
 import org.eclipse.leshan.server.observation.ObservationService;
+import org.eclipse.leshan.server.queue.PresenceService;
+import org.eclipse.leshan.server.queue.PresenceServiceImpl;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.RegistrationHandler;
 import org.eclipse.leshan.server.registration.RegistrationListener;
@@ -98,6 +102,8 @@ public class LeshanServer implements LwM2mServer {
 
     private final CoapEndpoint secureEndpoint;
 
+    private final PresenceServiceImpl presenceService;
+
     private final CaliforniumRegistrationStore registrationStore;
 
     /**
@@ -135,6 +141,7 @@ public class LeshanServer implements LwM2mServer {
         this.securityStore = securityStore;
         this.observationService = new ObservationServiceImpl(registrationStore, modelProvider, decoder);
         this.modelProvider = modelProvider;
+        this.presenceService = new PresenceServiceImpl();
 
         // Cancel observations on client unregistering
         this.registrationService.addListener(new RegistrationListener() {
@@ -151,6 +158,48 @@ public class LeshanServer implements LwM2mServer {
 
             @Override
             public void registered(Registration registration) {
+            }
+        });
+
+        // notify applications of LWM2M client coming online/offline
+        this.registrationService.addListener(new RegistrationListener() {
+
+            @Override
+            public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+                presenceService.setOnline(updatedRegistration);
+            }
+
+            @Override
+            public void unregistered(Registration registration, Collection<Observation> observations) {
+                // Noop.
+
+            }
+
+            @Override
+            public void registered(Registration registration) {
+                presenceService.setOnline(registration);
+            }
+        });
+        this.observationService.addListener(new ObservationListener() {
+
+            @Override
+            public void onResponse(Observation observation, Registration registration, ObserveResponse response) {
+                presenceService.setOnline(registration);
+            }
+
+            @Override
+            public void onError(Observation observation, Registration registration, Exception error) {
+                presenceService.setOnline(registration);
+            }
+
+            @Override
+            public void newObservation(Observation observation, Registration registration) {
+                // Noop.
+            }
+
+            @Override
+            public void cancelled(Observation observation) {
+                // Noop.
             }
         });
 
@@ -266,6 +315,11 @@ public class LeshanServer implements LwM2mServer {
     @Override
     public ObservationService getObservationService() {
         return this.observationService;
+    }
+
+    @Override
+    public PresenceService getPresenceService() {
+        return this.presenceService;
     }
 
     @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/LwM2mServer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/LwM2mServer.java
@@ -25,6 +25,8 @@ import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.server.model.LwM2mModelProvider;
 import org.eclipse.leshan.server.observation.ObservationService;
+import org.eclipse.leshan.server.queue.PresenceListener;
+import org.eclipse.leshan.server.queue.PresenceService;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.RegistrationService;
 import org.eclipse.leshan.server.security.SecurityStore;
@@ -121,6 +123,12 @@ public interface LwM2mServer {
      * observation or cancel it.
      */
     ObservationService getObservationService();
+
+    /**
+     * Get the Presence service to get the status of LWM2M clients connected with binding mode 'Q'. You can use this
+     * object to add {@link PresenceListener} to get notified when a device comes online or offline.
+     */
+    PresenceService getPresenceService();
 
     /**
      * Get the SecurityStore containing of security information.

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/Presence.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/Presence.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+/**
+ * Possible states of a LWM2M client registered with Queue mode binding.
+ */
+public enum Presence {
+    /** LWM2M Client is reachable and messages can be sent **/
+    ONLINE,
+    /** LWM2M Client is not reachable and no messages can be sent **/
+    OFFLINE
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceListener.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import org.eclipse.leshan.server.registration.Registration;
+
+/**
+ * A listener aware of the status of LWM2M Client using queue mode binding.
+ *
+ */
+public interface PresenceListener {
+
+    /**
+     * This method is invoked when the LWM2M client with the given endpoint state changes from online to offline. This
+     * listener method will be invoked only once when the state change occurs;i.e:- it will not be invoked when the
+     * previous state of the endpoint is offline and further events from the client indicates that the client is still
+     * offline.
+     * 
+     * @param registration data of the lwm2m client.
+     */
+    void onOffline(Registration registration);
+
+    /**
+     * This method is invoked when the LWM2M client with the given endpoint state changes from offline to online again.
+     * This listener method will be invoked only once when the state change occurs;i.e:- it will not be invoked when the
+     * previous state of the endpoint is online and further events from the client indicates that the client is still
+     * online.
+     * 
+     * @param registration data of the lwm2m client.
+     */
+    void onOnline(Registration registration);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceService.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceService.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import org.eclipse.leshan.server.registration.Registration;
+
+/**
+ * Tracks the status of each LWM2M client registered with Queue mode binding. Also ensures that the
+ * {@link PresenceListener} are notified on state changes only for those LWM2M clients registered using Queue mode
+ * binding.
+ *
+ * @see Presence
+ */
+public interface PresenceService {
+
+    /**
+     * Add the listener to get notified when the LWM2M client goes online or offline.
+     * 
+     * @param listener target to notify
+     */
+    void addListener(PresenceListener listener);
+
+    /**
+     * Remove the listener previously added. This method has no effect if the given listener is not previously added.
+     * 
+     * @param listener target to be removed.
+     */
+    void removeListener(PresenceListener listener);
+    
+    /**
+     * Returns the current status of a given LWM2M client registration.
+     * 
+     * @param registration data to check
+     * @return true if the status is {@link Presence#ONLINE}
+     */
+    boolean isOnline(Registration registration);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceServiceImpl.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.leshan.server.registration.Registration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks the status of each LWM2M client registered with Queue mode binding. Also ensures that the
+ * {@link PresenceListener} are notified on state changes only for those LWM2M clients registered using Queue mode
+ * binding.
+ *      
+ * @see Presence
+ */
+public final class PresenceServiceImpl implements PresenceService {
+    private static final Logger LOG = LoggerFactory.getLogger(PresenceServiceImpl.class);
+    private final ConcurrentMap<String, Presence> clientStatus = new ConcurrentHashMap<>();
+    private final List<PresenceListener> listeners = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void addListener(PresenceListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(PresenceListener listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public boolean isOnline(Registration registration) {
+        return Presence.ONLINE.equals(clientStatus.get(registration.getEndpoint()));
+    }
+
+    /**
+     * Sets the client identified by the given registration in {@link Presence#OFFLINE} mode if the current state is
+     * {@link Presence#ONLINE}. If the state is changed successfully, then the corresponding
+     * {@link PresenceListener} are notified.
+     * 
+     * @param registration lwm2m client registration data
+     */
+    public void setOffline(Registration registration) {
+        if (registration.usesQueueMode()
+                && transitState(registration.getEndpoint(), Presence.ONLINE, Presence.OFFLINE)) {
+            for (PresenceListener listener : listeners) {
+                listener.onOffline(registration);
+            }
+        }
+
+    }
+
+    /**
+     * Sets the client identified by the given registration in {@link Presence.ONLINE} mode if the current state is
+     * either {@link Presence#OFFLINE} or <code>null</code>. If the state is changed successfully, then the
+     * corresponding {@link PresenceListener} are notified.
+     * 
+     * @param registration lwm2m client registration data
+     */
+    public void setOnline(Registration registration) {
+        if (registration.usesQueueMode()
+                && transitState(registration.getEndpoint(), Presence.OFFLINE, Presence.ONLINE)) {
+            for (PresenceListener listener : listeners) {
+                listener.onOnline(registration);
+            }
+        }
+    }
+
+    private boolean transitState(String endpoint, Presence from, Presence to) {
+        boolean updated = clientStatus.replace(endpoint, from, to);
+        if (updated) {
+            LOG.debug("Client {} state update from {} -> {}", endpoint, from, to);
+        } else if (clientStatus.putIfAbsent(endpoint, to) == null) {
+            LOG.debug("Client {} state update to -> {}", endpoint, to);
+            updated = true;
+        } else {
+            LOG.trace("Cannot update Client {} state {} -> {}. Current state is {}", endpoint, from, to,
+                    clientStatus.get(endpoint));
+        }
+        return updated;
+    }
+}

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/PresenceServiceTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/PresenceServiceTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bosch Software Innovations GmbH - initial API
+ *******************************************************************************/
+package org.eclipse.leshan.server.queue;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.Test;
+
+/**
+ * tests the implementation of {@link PresenceService}
+ *
+ */
+public class PresenceServiceTest {
+
+    private PresenceServiceImpl instance = new PresenceServiceImpl();
+
+    @Test
+    public void testSetOnlineForNonQueueMode() throws Exception {
+        Registration registration = givenASimpleClient();
+        instance.addListener(new PresenceListener() {
+
+            @Override
+            public void onOnline(Registration registration) {
+                fail("No invocation was expected");
+            }
+
+            @Override
+            public void onOffline(Registration registration) {
+                fail("No invocation was expected");
+            }
+        });
+        instance.setOnline(registration);
+    }
+
+    /**
+     * Test method for
+     * {@link org.eclipse.leshan.server.queue.PresenceService#setOffline(org.eclipse.leshan.server.client.Registration)}.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSetOnlineAndOffline() throws Exception {
+        Registration queueModeRegistration = givenASimpleClientWithQueueMode();
+        instance.addListener(new PresenceListener() {
+            int onlineStatusCountDown = 0;
+            int offlineStatusCountDown = 0;
+
+            @Override
+            public void onOnline(Registration registration) {
+                onlineStatusCountDown++;
+                assertTrue("Expected online state to be invoked only once but invoked" + onlineStatusCountDown,
+                        onlineStatusCountDown == 1);
+            }
+
+            @Override
+            public void onOffline(Registration registration) {
+                offlineStatusCountDown++;
+                assertTrue("Expected offline state to be invoked only once but invoked" + offlineStatusCountDown,
+                        offlineStatusCountDown == 1);
+            }
+        });
+        // invoke setOnline multiple times
+        instance.setOnline(queueModeRegistration);
+        instance.setOnline(queueModeRegistration);
+        // invoke setOffline multiple times
+        instance.setOffline(queueModeRegistration);
+        instance.setOffline(queueModeRegistration);
+    }
+
+    @Test
+    public void testIsOnline() throws Exception {
+        Registration queueModeRegistration = givenASimpleClientWithQueueMode();
+
+        assertFalse(instance.isOnline(queueModeRegistration));
+        instance.setOnline(queueModeRegistration);
+        assertTrue(instance.isOnline(queueModeRegistration));
+    }
+
+    private Registration givenASimpleClient() throws UnknownHostException {
+        InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 5683);
+
+        Registration.Builder builder = new Registration.Builder("ID", "urn:client", InetAddress.getLocalHost(), 10000,
+                address);
+
+        return builder.build();
+    }
+
+    private Registration givenASimpleClientWithQueueMode() throws UnknownHostException {
+        InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 5683);
+
+        Registration.Builder builder = new Registration.Builder("ID", "urn:client", InetAddress.getLocalHost(), 10000,
+                address);
+
+        return builder.bindingMode(BindingMode.UQ).build();
+    }
+}


### PR DESCRIPTION
This PR aims to provide a simplified QueueMode API and implementation as defined in the latest LWM2M Specification (without actually queuing any messages instead notifying applications when the LWM2M client state changes to online or offline).

TODO: When a LWM2M client timeout on an request, no notification (offline) is sent. Once we agree on the initial API, it can be done. For example: one could have such a notification sent from `SyncRequestObserver`.

I would like to get the following questions answered as part of this PR.

1. What qualifies a LWM2M Client to be online (previous state: offline)?
    Possibility: Once we receive a notification for an observation, when we receive a registration update and when we receive a response 

2. What qualifies a LWM2M Client to be offline (previous state: online)?
    Possibility: Once a request timeout and ...?

Signed-off-by: Bala Azhagappan <balasubramanian.azhagappan@bosch-si.com>