### PR TITLE
Registration store fixes

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -145,7 +145,6 @@ public class LeshanServer implements LwM2mServer {
 
             @Override
             public void unregistered(Registration registration, Collection<Observation> observations) {
-                LeshanServer.this.observationService.cancelObservations(registration);
                 requestSender.cancelPendingRequests(registration);
             }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -86,14 +86,16 @@ public interface RegistrationStore {
     Deregistration removeRegistration(String registrationId);
 
     /**
-     * Add a new Observation for a given registration.
+     * Add a new {@link Observation} for a given registration.
+     * 
+     * The store is in charge of removing the observations already existing for the same path and registration id.
      * 
      * @param registrationId the id of the registration
      * @param observation the observation to add
      * 
-     * @return the previous observation or null if any.
+     * @return the list of removed observations or an empty list if none were removed.
      */
-    Observation addObservation(String registrationId, Observation observation);
+    Collection<Observation> addObservation(String registrationId, Observation observation);
 
     /**
      * Get the observation for the given registration with the given observationId

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -27,10 +27,13 @@ import org.eclipse.leshan.core.observation.Observation;
 public interface RegistrationStore {
 
     /**
-     * Add a new registration. If there is already a registration with the same endpoint removed it.
+     * Store a new registration.
+     * 
+     * If a registration already exists with the given endpoint, the store is in charge of removing this registration as
+     * well as the ongoing observations.
      * 
      * @param registration the new registration.
-     * @return the old registration and its observations removed or null.
+     * @return the old registration and its observations or <code>null</code> if it does not already exists.
      */
     Deregistration addRegistration(Registration registration);
 


### PR DESCRIPTION
The RegistrationStore should be responsible for removing existing observations (same path/registrationId) when a new observation is persisted.