### PR TITLE
Security test base work

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -150,6 +150,10 @@ public class IntegrationTestHelper {
         builder.setSecurityStore(new InMemorySecurityStore());
         server = builder.build();
         // monitor client registration
+        setupRegistrationMonitoring();
+    }
+
+    protected void setupRegistrationMonitoring() {
         resetLatch();
         server.getRegistrationService().addListener(new RegistrationListener() {
             @Override

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
@@ -60,6 +60,7 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
 
     public static final String GOOD_PSK_ID = "Good_Client_identity";
     public static final byte[] GOOD_PSK_KEY = Hex.decodeHex("73656372657450534b".toCharArray());
+    public static final String GOOD_ENDPOINT = "good_endpoint";
     public static final String BAD_PSK_ID = "Bad_Client_identity";
     public static final byte[] BAD_PSK_KEY = Hex.decodeHex("010101010101010101".toCharArray());
     public static final String BAD_ENDPOINT = "bad_endpoint";

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
@@ -245,6 +245,8 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
         builder.setSecurityStore(new InMemorySecurityStore());
 
         server = builder.build();
+        // monitor client registration
+        setupRegistrationMonitoring();
     }
 
     public void createServerWithX509Cert(Certificate[] trustedCertificates) {
@@ -257,6 +259,8 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
         builder.setSecurityStore(new InMemorySecurityStore());
 
         server = builder.build();
+        // monitor client registration
+        setupRegistrationMonitoring();
     }
 
     public PublicKey getServerPublicKey() {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
@@ -234,8 +234,6 @@ public class SecurityTest {
         assertNotNull(helper.getCurrentRegistration());
     }
 
-    @Ignore
-    // TODO implement RPK support for client
     @Test
     public void registered_device_with_bad_rpk_to_server_with_rpk() throws NonUniqueSecurityInfoException {
         helper.createServerWithRPK();
@@ -254,8 +252,6 @@ public class SecurityTest {
         assertTrue(timedout);
     }
 
-    @Ignore
-    // TODO implement RPK support for client
     @Test
     public void registered_device_with_rpk_and_bad_endpoint_to_server_with_rpk() throws NonUniqueSecurityInfoException {
         helper.createServerWithRPK();
@@ -290,8 +286,6 @@ public class SecurityTest {
         assertNotNull(helper.getCurrentRegistration());
     }
 
-    @Ignore
-    // TODO implement X509 support for client
     @Test
     public void registered_device_with_x509cert_and_bad_endpoint_to_server_with_x509cert()
             throws NonUniqueSecurityInfoException {
@@ -308,8 +302,6 @@ public class SecurityTest {
         assertTrue(timedout);
     }
 
-    @Ignore
-    // TODO implement X509 support for client
     @Test
     public void registered_device_with_x509cert_and_bad_cn_certificate_to_server_with_x509cert()
             throws NonUniqueSecurityInfoException {
@@ -326,8 +318,6 @@ public class SecurityTest {
         assertTrue(timedout);
     }
 
-    @Ignore
-    // TODO implement X509 support for client
     @Test
     public void registered_device_with_x509cert_and_bad_private_key_to_server_with_x509cert()
             throws NonUniqueSecurityInfoException {
@@ -346,8 +336,6 @@ public class SecurityTest {
         assertTrue(timedout);
     }
 
-    @Ignore
-    // TODO implement X509 support for client
     @Test
     public void registered_device_with_x509cert_and_untrusted_CA_to_server_with_x509cert()
             throws NonUniqueSecurityInfoException {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
@@ -263,7 +263,7 @@ public class SecurityTest {
         helper.createRPKClient();
 
         helper.getSecurityStore()
-                .add(SecurityInfo.newRawPublicKeyInfo("bad_endpoint", helper.clientPublicKey));
+                .add(SecurityInfo.newRawPublicKeyInfo(BAD_ENDPOINT, helper.clientPublicKey));
 
         helper.client.start();
         boolean timedout = !helper.waitForRegistration(1);
@@ -298,7 +298,7 @@ public class SecurityTest {
 
         helper.createX509CertClient(helper.clientPrivateKeyFromCert, helper.trustedCertificates);
 
-        helper.getSecurityStore().add(SecurityInfo.newX509CertInfo("bad_endpoint"));
+        helper.getSecurityStore().add(SecurityInfo.newX509CertInfo(BAD_ENDPOINT));
 
         helper.client.start();
         boolean timedout = !helper.waitForRegistration(1);
@@ -316,7 +316,7 @@ public class SecurityTest {
 
         helper.createX509CertClient(helper.clientPrivateKeyFromCert, helper.trustedCertificates);
 
-        helper.getSecurityStore().add(SecurityInfo.newX509CertInfo("good_endpoint"));
+        helper.getSecurityStore().add(SecurityInfo.newX509CertInfo(GOOD_ENDPOINT));
 
         helper.client.start();
         boolean timedout = !helper.waitForRegistration(1);

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
@@ -227,6 +227,7 @@ public class SecurityTest {
         helper.getSecurityStore()
                 .add(SecurityInfo.newRawPublicKeyInfo(helper.getCurrentEndpoint(), helper.clientPublicKey));
 
+        helper.assertClientNotRegisterered();
         helper.client.start();
         helper.waitForRegistration(1);
 
@@ -282,6 +283,7 @@ public class SecurityTest {
 
         helper.getSecurityStore().add(SecurityInfo.newX509CertInfo(helper.getCurrentEndpoint()));
 
+        helper.assertClientNotRegisterered();
         helper.client.start();
         helper.waitForRegistration(1);
 


### PR DESCRIPTION
Some trivial base work to security tests, making them closer to working when client RPK/X509 support is testable.