### PR TITLE
add a way to choose content format to use for bootstrap session

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandler.java
@@ -32,7 +32,6 @@ import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
 import org.eclipse.leshan.core.request.BootstrapRequest;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
-import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.DownlinkRequest;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapDeleteResponse;
@@ -127,8 +126,7 @@ public class BootstrapHandler {
         });
     }
 
-    private void sendBootstrap(final BootstrapSession session, final BootstrapConfig cfg,
-            final List<Integer> toSend) {
+    private void sendBootstrap(final BootstrapSession session, final BootstrapConfig cfg, final List<Integer> toSend) {
         if (!toSend.isEmpty()) {
             // 1st encode them into a juicy TLV binary
             Integer key = toSend.remove(0);
@@ -139,7 +137,7 @@ public class BootstrapHandler {
             final LwM2mNode securityInstance = convertToSecurityInstance(key, securityConfig);
 
             final BootstrapWriteRequest writeBootstrapRequest = new BootstrapWriteRequest(path, securityInstance,
-                    ContentFormat.TLV);
+                    session.getContentFormat());
             send(session, writeBootstrapRequest, new ResponseCallback<BootstrapWriteResponse>() {
                 @Override
                 public void onResponse(BootstrapWriteResponse response) {
@@ -173,7 +171,7 @@ public class BootstrapHandler {
             final LwM2mNode serverInstance = convertToServerInstance(key, serverConfig);
 
             final BootstrapWriteRequest writeServerRequest = new BootstrapWriteRequest(path, serverInstance,
-                    ContentFormat.TLV);
+                    session.getContentFormat());
             send(session, writeServerRequest, new ResponseCallback<BootstrapWriteResponse>() {
                 @Override
                 public void onResponse(BootstrapWriteResponse response) {
@@ -213,8 +211,8 @@ public class BootstrapHandler {
 
     private <T extends LwM2mResponse> void send(BootstrapSession session, DownlinkRequest<T> request,
             ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
-        sender.send(session.getEndpoint(), session.getIdentity().getPeerAddress(),
-                session.getIdentity().isSecure(), request, responseCallback, errorCallback);
+        sender.send(session.getEndpoint(), session.getIdentity().getPeerAddress(), session.getIdentity().isSecure(),
+                request, responseCallback, errorCallback);
     }
 
     private LwM2mObjectInstance convertToSecurityInstance(int instanceId, ServerSecurity securityConfig) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSession.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSession.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
+import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 
 /**
@@ -26,7 +27,7 @@ import org.eclipse.leshan.core.request.Identity;
 public interface BootstrapSession {
 
     /**
-     * @return the endpoint of the LwM2M client
+     * @return the endpoint of the LwM2M client.
      */
     String getEndpoint();
 
@@ -39,5 +40,10 @@ public interface BootstrapSession {
      * @return true if the LwM2M client is authorized to start a bootstrap session.
      */
     boolean isAuthorized();
+
+    /**
+     * @return the content format to use on write request during this bootstrap session.
+     */
+    ContentFormat getContentFormat();
 
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/DefaultBootstrapSession.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/DefaultBootstrapSession.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.impl;
 
+import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.server.bootstrap.BootstrapSession;
 
@@ -23,11 +24,18 @@ public class DefaultBootstrapSession implements BootstrapSession {
     private final String endpoint;
     private final Identity identity;
     private final boolean authorized;
+    private final ContentFormat contentFormat;
 
     public DefaultBootstrapSession(String endpoint, Identity identity, boolean authorized) {
+        this(endpoint, identity, authorized, ContentFormat.TLV);
+    }
+
+    public DefaultBootstrapSession(String endpoint, Identity identity, boolean authorized,
+            ContentFormat contentFormat) {
         this.endpoint = endpoint;
         this.identity = identity;
         this.authorized = authorized;
+        this.contentFormat = contentFormat;
     }
 
     @Override
@@ -46,9 +54,14 @@ public class DefaultBootstrapSession implements BootstrapSession {
     }
 
     @Override
+    public ContentFormat getContentFormat() {
+        return contentFormat;
+    }
+
+    @Override
     public String toString() {
-        return String.format("BootstrapSession [endpoint=%s, identity=%s, authorized=%s]", endpoint, identity,
-                authorized);
+        return String.format("BootstrapSession [endpoint=%s, identity=%s, authorized=%s, contentFormat=%s]", endpoint,
+                identity, authorized, contentFormat);
     }
 
 }


### PR DESCRIPTION
This could be used to supported backward compatibility for content format. (see #227, #225)