### PR TITLE
Add a way to configure CoAP network config

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
@@ -26,6 +26,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -155,7 +156,8 @@ public class LeshanBootstrapServerDemo {
         BootstrapSessionManager bsSessionManager = new DefaultBootstrapSessionManager(securityStore);
 
         LeshanBootstrapServer bsServer = new LeshanBootstrapServer(new InetSocketAddress(localAddress, localPort),
-                new InetSocketAddress(secureLocalAddress, secureLocalPort), bsStore, securityStore, bsSessionManager);
+                new InetSocketAddress(secureLocalAddress, secureLocalPort), bsStore, securityStore, bsSessionManager,
+                new NetworkConfig());
         bsServer.start();
 
         // Now prepare and start jetty

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.client.californium;
 import java.net.InetSocketAddress;
 import java.util.List;
 
+import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.leshan.LwM2mId;
 import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
@@ -38,6 +39,8 @@ public class LeshanClientBuilder {
     private InetSocketAddress localSecureAddress;
     private List<? extends LwM2mObjectEnabler> objectEnablers;
 
+    private NetworkConfig networkConfig;
+
     /**
      * Creates a new instance for setting the configuration options for a {@link LeshanClient} instance.
      * 
@@ -47,7 +50,8 @@ public class LeshanClientBuilder {
      * <li><em>local secure address</em>: a local address and an ephemeral port (picked up during binding)</li>
      * <li><em>object enablers</em>:
      * <ul>
-     * <li>Security(0) with one instance (DM server security): uri=<em>coap://leshan.eclipse.org:5683</em>, mode=NoSec</li>
+     * <li>Security(0) with one instance (DM server security): uri=<em>coap://leshan.eclipse.org:5683</em>, mode=NoSec
+     * </li>
      * <li>Server(1) with one instance (DM server): id=12345, lifetime=5minutes</li>
      * <li>Device(3): manufacturer=Eclipse Leshan, modelNumber=model12345, serialNumber=12345</li>
      * </ul>
@@ -93,6 +97,11 @@ public class LeshanClientBuilder {
         return this;
     }
 
+    public LeshanClientBuilder setNetworkConfig(NetworkConfig config) {
+        this.networkConfig = config;
+        return this;
+    }
+
     /**
      * Creates an instance of {@link LeshanClient} based on the properties set on this builder.
      */
@@ -105,12 +114,16 @@ public class LeshanClientBuilder {
         }
         if (objectEnablers == null) {
             ObjectsInitializer initializer = new ObjectsInitializer();
-            initializer
-                    .setInstancesForObject(LwM2mId.SECURITY, Security.noSec("coap://leshan.eclipse.org:5683", 12345));
+            initializer.setInstancesForObject(LwM2mId.SECURITY,
+                    Security.noSec("coap://leshan.eclipse.org:5683", 12345));
             initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, 5 * 60, BindingMode.U, false));
             initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", "model12345", "12345", "U"));
             objectEnablers = initializer.createMandatory();
         }
-        return new LeshanClient(endpoint, localAddress, localSecureAddress, objectEnablers);
+        if (networkConfig == null) {
+            networkConfig = new NetworkConfig();
+        }
+
+        return new LeshanClient(endpoint, localAddress, localSecureAddress, objectEnablers, networkConfig);
     }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.leshan.LwM2mId;
 import org.eclipse.leshan.SecurityMode;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
@@ -37,8 +38,8 @@ import org.eclipse.leshan.server.bootstrap.BootstrapStore;
 import org.eclipse.leshan.server.californium.impl.LeshanBootstrapServer;
 import org.eclipse.leshan.server.impl.DefaultBootstrapSessionManager;
 import org.eclipse.leshan.server.security.BootstrapSecurityStore;
-import org.eclipse.leshan.server.security.SecurityInfo;
 import org.eclipse.leshan.server.security.EditableSecurityStore;
+import org.eclipse.leshan.server.security.SecurityInfo;
 import org.eclipse.leshan.util.Hex;
 
 /**
@@ -94,7 +95,8 @@ public class BootstrapIntegrationTestHelper extends IntegrationTestHelper {
         BootstrapSessionManager bsSessionManager = new DefaultBootstrapSessionManager(securityStore);
 
         bootstrapServer = new LeshanBootstrapServer(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), bsStore, securityStore, bsSessionManager);
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), bsStore, securityStore, bsSessionManager,
+                new NetworkConfig());
     }
 
     @Override

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
@@ -35,6 +35,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.leshan.Link;
 import org.eclipse.leshan.ResponseCode;
 import org.eclipse.leshan.client.californium.LeshanClient;
@@ -249,7 +250,7 @@ public class RegistrationTest {
         objects.add(objectEnabler);
         objects.add(objectEnabler2);
         helper.client = new LeshanClient("test", new InetSocketAddress(InetAddress.getLoopbackAddress(), 0),
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), objects);
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), objects, new NetworkConfig());
     }
 
     @Test

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -22,6 +22,7 @@ import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 
+import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.leshan.LwM2m;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
@@ -58,6 +59,8 @@ public class LeshanServerBuilder {
     private PrivateKey privateKey;
     private X509Certificate[] certificateChain;
     private Certificate[] trustedCertificates;
+
+    private NetworkConfig networkConfig;
 
     public LeshanServerBuilder setLocalAddress(String hostname, int port) {
         if (hostname == null) {
@@ -137,6 +140,11 @@ public class LeshanServerBuilder {
         return this;
     }
 
+    public LeshanServerBuilder setNetworkConfig(NetworkConfig config) {
+        this.networkConfig = config;
+        return this;
+    }
+
     public LeshanServer build() {
         if (localAddress == null)
             localAddress = new InetSocketAddress((InetAddress) null, LwM2m.DEFAULT_COAP_PORT);
@@ -152,8 +160,12 @@ public class LeshanServerBuilder {
             encoder = new DefaultLwM2mNodeEncoder();
         if (decoder == null)
             decoder = new DefaultLwM2mNodeDecoder();
+        if (networkConfig == null) {
+            networkConfig = new NetworkConfig();
+        }
 
         return new LeshanServer(localAddress, localSecureAddress, registrationStore, securityStore, authorizer,
-                modelProvider, encoder, decoder, publicKey, privateKey, certificateChain, trustedCertificates);
+                modelProvider, encoder, decoder, publicKey, privateKey, certificateChain, trustedCertificates,
+                networkConfig);
     }
 }


### PR DESCRIPTION
Now you can provide a CoAP network config for Leshan server, bootstrap server and client.

1) By default we use the Californium default one.
2) DTLS configuration (max connections, stale connection threshold) are synchronized with coap network configuration (max active peers, max peer inactivity period). 
3) A file is not created or loaded anymore, if users want to do that it should load/store itself like this :

```java
builder.setNetworkConfig(NetworkConfig.getStandard());
```