### PR TITLE
Add previous registration on RegistrationListener.updated() event

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -157,7 +157,8 @@ public class IntegrationTestHelper {
         resetLatch();
         server.getRegistrationService().addListener(new RegistrationListener() {
             @Override
-            public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+            public void updated(RegistrationUpdate update, Registration updatedRegistration,
+                    Registration previousRegistration) {
                 if (updatedRegistration.getEndpoint().equals(currentEndpointIdentifier)) {
                     updateLatch.countDown();
                 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
@@ -58,7 +58,8 @@ public class RedisIntegrationTestHelper extends IntegrationTestHelper {
         resetLatch();
         server.getRegistrationService().addListener(new RegistrationListener() {
             @Override
-            public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+            public void updated(RegistrationUpdate update, Registration updatedRegistration,
+                    Registration previousRegistration) {
                 if (updatedRegistration.getEndpoint().equals(getCurrentEndpoint())) {
                     updateLatch.countDown();
                 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
@@ -59,7 +59,8 @@ public class RedisSecureIntegrationTestHelper extends SecureIntegrationTestHelpe
         resetLatch();
         server.getRegistrationService().addListener(new RegistrationListener() {
             @Override
-            public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+            public void updated(RegistrationUpdate update, Registration updatedRegistration,
+                    Registration previousRegistration) {
                 if (updatedRegistration.getEndpoint().equals(getCurrentEndpoint())) {
                     updateLatch.countDown();
                 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
@@ -48,6 +48,7 @@ import org.eclipse.leshan.server.registration.Deregistration;
 import org.eclipse.leshan.server.registration.ExpirationListener;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.eclipse.leshan.server.registration.UpdatedRegistration;
 import org.eclipse.leshan.util.Key;
 import org.eclipse.leshan.util.NamedThreadFactory;
 import org.slf4j.Logger;
@@ -109,7 +110,7 @@ public class InMemoryRegistrationStore implements CaliforniumRegistrationStore, 
     }
 
     @Override
-    public Registration updateRegistration(RegistrationUpdate update) {
+    public UpdatedRegistration updateRegistration(RegistrationUpdate update) {
         try {
             lock.writeLock().lock();
 
@@ -119,7 +120,7 @@ public class InMemoryRegistrationStore implements CaliforniumRegistrationStore, 
             } else {
                 Registration updatedRegistration = update.update(registration);
                 regsByEp.put(updatedRegistration.getEndpoint(), updatedRegistration);
-                return updatedRegistration;
+                return new UpdatedRegistration(registration, updatedRegistration);
             }
         } finally {
             lock.writeLock().unlock();

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -144,7 +144,8 @@ public class LeshanServer implements LwM2mServer {
         this.registrationService.addListener(new RegistrationListener() {
 
             @Override
-            public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+            public void updated(RegistrationUpdate update, Registration updatedRegistration,
+                    Registration previousRegistration) {
             }
 
             @Override

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStoreTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStoreTest.java
@@ -25,6 +25,7 @@ import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.RegistrationStore;
 import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.eclipse.leshan.server.registration.UpdatedRegistration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,10 +55,12 @@ public class InMemoryRegistrationStoreTest {
         store.addRegistration(registration);
 
         RegistrationUpdate update = new RegistrationUpdate(registrationId, address, port, null, null, null, null);
-        Registration updatedRegistration = store.updateRegistration(update);
-        Assert.assertEquals(lifetime, updatedRegistration.getLifeTimeInSec());
-        Assert.assertSame(binding, updatedRegistration.getBindingMode());
-        Assert.assertEquals(sms, updatedRegistration.getSmsNumber());
+        UpdatedRegistration updatedRegistration = store.updateRegistration(update);
+        Assert.assertEquals(lifetime, updatedRegistration.getUpdatedRegistration().getLifeTimeInSec());
+        Assert.assertSame(binding, updatedRegistration.getUpdatedRegistration().getBindingMode());
+        Assert.assertEquals(sms, updatedRegistration.getUpdatedRegistration().getSmsNumber());
+
+        Assert.assertEquals(registration, updatedRegistration.getPreviousRegistration());
 
         Registration reg = store.getRegistrationByEndpoint(ep);
         Assert.assertEquals(lifetime, reg.getLifeTimeInSec());
@@ -79,8 +82,8 @@ public class InMemoryRegistrationStoreTest {
         Assert.assertFalse(registration.isAlive());
 
         RegistrationUpdate update = new RegistrationUpdate(registrationId, address, port, lifetime, null, null, null);
-        Registration updatedRegistration = store.updateRegistration(update);
-        Assert.assertTrue(updatedRegistration.isAlive());
+        UpdatedRegistration updatedRegistration = store.updateRegistration(update);
+        Assert.assertTrue(updatedRegistration.getUpdatedRegistration().isAlive());
 
         Registration reg = store.getRegistrationByEndpoint(ep);
         Assert.assertTrue(reg.isAlive());

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationEventPublisher.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationEventPublisher.java
@@ -52,7 +52,8 @@ public class RedisRegistrationEventPublisher implements RegistrationListener {
     }
 
     @Override
-    public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+    public void updated(RegistrationUpdate update, Registration updatedRegistration,
+            Registration previousRegistration) {
         JsonObject value = new JsonObject();
         value.add("regUpdate", RegistrationUpdateSerDes.jSerialize(update));
         value.add("regUpdated", RegistrationSerDes.jSerialize(updatedRegistration));

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
@@ -46,6 +46,7 @@ import org.eclipse.leshan.server.registration.Deregistration;
 import org.eclipse.leshan.server.registration.ExpirationListener;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.eclipse.leshan.server.registration.UpdatedRegistration;
 import org.eclipse.leshan.util.NamedThreadFactory;
 import org.eclipse.leshan.util.Validate;
 import org.slf4j.Logger;
@@ -148,7 +149,7 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
     }
 
     @Override
-    public Registration updateRegistration(RegistrationUpdate update) {
+    public UpdatedRegistration updateRegistration(RegistrationUpdate update) {
         try (Jedis j = pool.getResource()) {
 
             // fetch the client ep by registration ID index
@@ -175,7 +176,7 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
                 // store the new client
                 j.set(toEndpointKey(updatedRegistration.getEndpoint()), serializeReg(updatedRegistration));
 
-                return updatedRegistration;
+                return new UpdatedRegistration(r, updatedRegistration);
 
             } finally {
                 RedisLock.release(j, lockKey, lockValue);

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisTokenHandler.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisTokenHandler.java
@@ -56,7 +56,8 @@ public class RedisTokenHandler implements RegistrationListener {
     }
 
     @Override
-    public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+    public void updated(RegistrationUpdate update, Registration updatedRegistration,
+            Registration previousRegistration) {
         try (Jedis j = pool.getResource()) {
             // create registration entry
             byte[] k = (EP_UID + updatedRegistration.getEndpoint()).getBytes();

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
@@ -86,9 +86,10 @@ public class RegistrationServiceImpl implements RegistrationService, ExpirationL
         }
     }
 
-    public void fireUpdated(RegistrationUpdate update, Registration registration) {
+    public void fireUpdated(RegistrationUpdate update, Registration updatedRegistration,
+            Registration previousRegistration) {
         for (RegistrationListener l : listeners) {
-            l.updated(update, registration);
+            l.updated(update, updatedRegistration, previousRegistration);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -107,7 +107,8 @@ public class RegistrationHandler {
         } else {
             LOG.debug("Updated registration {} by {}", updatedRegistration, update);
             // notify registration update
-            registrationService.fireUpdated(update, updatedRegistration.getUpdatedRegistration());
+            registrationService.fireUpdated(update, updatedRegistration.getUpdatedRegistration(),
+                    updatedRegistration.getPreviousRegistration());
             return UpdateResponse.success();
         }
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -51,8 +51,8 @@ public class RegistrationHandler {
             InetSocketAddress serverEndpoint) {
 
         Registration.Builder builder = new Registration.Builder(RegistrationHandler.createRegistrationId(),
-                registerRequest.getEndpointName(), sender.getPeerAddress().getAddress(), sender.getPeerAddress()
-                        .getPort(), serverEndpoint);
+                registerRequest.getEndpointName(), sender.getPeerAddress().getAddress(),
+                sender.getPeerAddress().getPort(), serverEndpoint);
 
         builder.lwM2mVersion(registerRequest.getLwVersion()).lifeTimeInSec(registerRequest.getLifetime())
                 .bindingMode(registerRequest.getBindingMode()).objectLinks(registerRequest.getObjectLinks())
@@ -75,7 +75,7 @@ public class RegistrationHandler {
             registrationService.fireUnregistered(deregistration.getRegistration(), deregistration.getObservations());
         }
         registrationService.fireRegistred(registration);
-            
+
         return RegisterResponse.success(registration.getId());
     }
 
@@ -94,19 +94,20 @@ public class RegistrationHandler {
         }
 
         // Create update
-        RegistrationUpdate update = new RegistrationUpdate(updateRequest.getRegistrationId(), sender
-                .getPeerAddress().getAddress(), sender.getPeerAddress().getPort(), updateRequest.getLifeTimeInSec(),
-                updateRequest.getSmsNumber(), updateRequest.getBindingMode(), updateRequest.getObjectLinks());
+        RegistrationUpdate update = new RegistrationUpdate(updateRequest.getRegistrationId(),
+                sender.getPeerAddress().getAddress(), sender.getPeerAddress().getPort(),
+                updateRequest.getLifeTimeInSec(), updateRequest.getSmsNumber(), updateRequest.getBindingMode(),
+                updateRequest.getObjectLinks());
 
         // update registration
-        Registration updatedRegistration = registrationService.getStore().updateRegistration(update);
+        UpdatedRegistration updatedRegistration = registrationService.getStore().updateRegistration(update);
         if (updatedRegistration == null) {
             LOG.debug("Invalid update:  registration {} not found", registration.getId());
             return UpdateResponse.notFound();
         } else {
             LOG.debug("Updated registration {} by {}", updatedRegistration, update);
             // notify registration update
-            registrationService.fireUpdated(update, updatedRegistration);
+            registrationService.fireUpdated(update, updatedRegistration.getUpdatedRegistration());
             return UpdateResponse.success();
         }
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationListener.java
@@ -36,8 +36,9 @@ public interface RegistrationListener {
      *
      * @param update the registration properties to update
      * @param updatedRegistration the registration after the update
+     * @param previousRegistration the registration before the update
      */
-    void updated(RegistrationUpdate update, Registration updatedRegistration);
+    void updated(RegistrationUpdate update, Registration updatedRegistration, Registration previousRegistration);
 
     /**
      * Invoked when a client has been unregistered from the server.

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -41,9 +41,9 @@ public interface RegistrationStore {
      * Update an existing registration
      * 
      * @param update data to update
-     * @return the registration updated
+     * @return return the previous and updated registration
      */
-    Registration updateRegistration(RegistrationUpdate update);
+    UpdatedRegistration updateRegistration(RegistrationUpdate update);
 
     /**
      * Get the registration by registration Id.

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/UpdatedRegistration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/UpdatedRegistration.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+/**
+ * An UpdatedRegistration contains the registration before and after a registration update.
+ * 
+ * @see RegistrationStore
+ */
+public class UpdatedRegistration {
+    private final Registration previousRegistration;
+    private final Registration updatedRegistration;
+
+    public UpdatedRegistration(Registration previousRegistration, Registration updatedRegistration) {
+        this.previousRegistration = previousRegistration;
+        this.updatedRegistration = updatedRegistration;
+    }
+
+    /**
+     * The registration before the update registration.
+     */
+    public Registration getPreviousRegistration() {
+        return previousRegistration;
+    }
+
+    /**
+     * The registration after the update registration.
+     */
+    public Registration getUpdatedRegistration() {
+        return updatedRegistration;
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
@@ -79,7 +79,8 @@ public class EventServlet extends EventSourceServlet {
         }
 
         @Override
-        public void updated(RegistrationUpdate update, Registration updatedRegistration) {
+        public void updated(RegistrationUpdate update, Registration updatedRegistration,
+                Registration previousRegistration) {
             String jReg = EventServlet.this.gson.toJson(updatedRegistration);
             sendEvent(EVENT_UPDATED, jReg, updatedRegistration.getEndpoint());
         }
@@ -107,8 +108,7 @@ public class EventServlet extends EventSourceServlet {
             if (registration != null) {
                 String data = new StringBuffer("{\"ep\":\"").append(registration.getEndpoint()).append("\",\"res\":\"")
                         .append(observation.getPath().toString()).append("\",\"val\":")
-                        .append(gson.toJson(response.getContent()))
-                        .append("}").toString();
+                        .append(gson.toJson(response.getContent())).append("}").toString();
 
                 sendEvent(EVENT_NOTIFICATION, data, registration.getEndpoint());
             }


### PR DESCRIPTION
The PR aims to add previous registration to `RegistrationListener.updated()` API.
```java
/**
 * Invoked when a client updated its registration.
 *
 * @param update the registration properties to update
 * @param updatedRegistration the registration after the update
 * @param previousRegistration the registration before the update
 */
void updated(RegistrationUpdate update, Registration updatedRegistration, Registration previousRegistration);
```