### PR TITLE
Add expired parameter to the unregistered event

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -164,7 +164,7 @@ public class IntegrationTestHelper {
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
                 if (registration.getEndpoint().equals(currentEndpointIdentifier)) {
                     deregisterLatch.countDown();
                 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
@@ -65,7 +65,7 @@ public class RedisIntegrationTestHelper extends IntegrationTestHelper {
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
                 if (registration.getEndpoint().equals(getCurrentEndpoint())) {
                     deregisterLatch.countDown();
                 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
@@ -66,7 +66,7 @@ public class RedisSecureIntegrationTestHelper extends SecureIntegrationTestHelpe
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
                 if (registration.getEndpoint().equals(getCurrentEndpoint())) {
                     deregisterLatch.countDown();
                 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -148,7 +148,7 @@ public class LeshanServer implements LwM2mServer {
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
                 requestSender.cancelPendingRequests(registration);
             }
 

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationEventPublisher.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationEventPublisher.java
@@ -63,7 +63,7 @@ public class RedisRegistrationEventPublisher implements RegistrationListener {
     }
 
     @Override
-    public void unregistered(Registration registration, Collection<Observation> observations) {
+    public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
         String payload = RegistrationSerDes.sSerialize(registration);
         try (Jedis j = pool.getResource()) {
             j.publish(DEREGISTER_EVENT, payload);

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisTokenHandler.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisTokenHandler.java
@@ -66,11 +66,10 @@ public class RedisTokenHandler implements RegistrationListener {
     }
 
     @Override
-    public void unregistered(Registration registration, Collection<Observation> observations) {
+    public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
         try (Jedis j = pool.getResource()) {
             // create registration entry
-            byte[] k = (EP_UID + registration.getEndpoint()).getBytes();
-            j.del(k);
+            j.del((EP_UID + registration.getEndpoint()).getBytes());
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
@@ -70,7 +70,7 @@ public class RegistrationServiceImpl implements RegistrationService, ExpirationL
     @Override
     public void registrationExpired(Registration registration, Collection<Observation> observations) {
         for (RegistrationListener l : listeners) {
-            l.unregistered(registration, observations);
+            l.unregistered(registration, observations, true);
         }
     }
 
@@ -82,7 +82,7 @@ public class RegistrationServiceImpl implements RegistrationService, ExpirationL
 
     public void fireUnregistered(Registration registration, Collection<Observation> observations) {
         for (RegistrationListener l : listeners) {
-            l.unregistered(registration, observations);
+            l.unregistered(registration, observations, false);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
@@ -74,7 +74,7 @@ public class RegistrationServiceImpl implements RegistrationService, ExpirationL
         }
     }
 
-    public void fireRegistred(Registration registration) {
+    public void fireRegistered(Registration registration) {
         for (RegistrationListener l : listeners) {
             l.registered(registration);
         }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -74,7 +74,7 @@ public class RegistrationHandler {
         if (deregistration != null) {
             registrationService.fireUnregistered(deregistration.getRegistration(), deregistration.getObservations());
         }
-        registrationService.fireRegistred(registration);
+        registrationService.fireRegistered(registration);
             
         return RegisterResponse.success(registration.getId());
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationListener.java
@@ -44,6 +44,8 @@ public interface RegistrationListener {
      *
      * @param registration
      * @param observations all the observations linked to this registration which has been passively cancelled
+     * @param expired <code>true</code> if the client has been unregistered because of its lifetime expiration and
+     *        <code>false</code> otherwise
      */
-    void unregistered(Registration registration, Collection<Observation> observations);
+    void unregistered(Registration registration, Collection<Observation> observations, boolean expired);
 }

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
@@ -85,7 +85,7 @@ public class EventServlet extends EventSourceServlet {
         }
 
         @Override
-        public void unregistered(Registration registration, Collection<Observation> observations) {
+        public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
             String jReg = EventServlet.this.gson.toJson(registration);
             sendEvent(EVENT_DEREGISTRATION, jReg, registration.getEndpoint());
         }
@@ -107,8 +107,7 @@ public class EventServlet extends EventSourceServlet {
             if (registration != null) {
                 String data = new StringBuilder("{\"ep\":\"").append(registration.getEndpoint()).append("\",\"res\":\"")
                         .append(observation.getPath().toString()).append("\",\"val\":")
-                        .append(gson.toJson(response.getContent()))
-                        .append("}").toString();
+                        .append(gson.toJson(response.getContent())).append("}").toString();
 
                 sendEvent(EVENT_NOTIFICATION, data, registration.getEndpoint());
             }


### PR DESCRIPTION
Add a parameter to determine whether a client has been unregistered because of its lifetime expiration.