### PR TITLE
Destroy client and server on IntegrationTestHelper dispose().

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/CreateTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/CreateTest.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Zebra Technologies - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for create security object
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -54,8 +55,8 @@ public class CreateTest {
 
     @After
     public void stop() {
-        helper.client.stop(false);
-        helper.server.stop();
+        helper.client.destroy(false);
+        helper.server.destroy();
         helper.dispose();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
@@ -14,6 +14,7 @@
  *     Zebra Technologies - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for deleting a resource
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for delete security object
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -52,8 +53,8 @@ public class DeleteTest {
 
     @After
     public void stop() {
-        helper.client.stop(false);
-        helper.server.stop();
+        helper.client.destroy(false);
+        helper.server.destroy();
         helper.dispose();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
@@ -14,6 +14,7 @@
  *     Zebra Technologies - initial API and implementation
  *     Kiran Pradeep - add more test cases
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for execute security object
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -46,8 +47,8 @@ public class ExecuteTest {
 
     @After
     public void stop() {
-        helper.client.stop(false);
-        helper.server.stop();
+        helper.client.destroy(false);
+        helper.server.destroy();
         helper.dispose();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ObserveTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -72,8 +73,8 @@ public class ObserveTest {
 
     @After
     public void stop() {
-        helper.client.stop(false);
-        helper.server.stop();
+        helper.client.destroy(false);
+        helper.server.destroy();
         helper.dispose();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Zebra Technologies - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for read security object
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -48,8 +49,8 @@ public class ReadTest {
 
     @After
     public void stop() {
-        helper.client.stop(false);
-        helper.server.stop();
+        helper.client.destroy(false);
+        helper.server.destroy();
         helper.dispose();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -73,8 +74,8 @@ public class RegistrationTest {
 
     @After
     public void stop() throws InterruptedException {
-        helper.client.stop(true);
-        helper.server.stop();
+        helper.client.destroy(true);
+        helper.server.destroy();
         helper.dispose();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
@@ -63,8 +63,8 @@ public class WriteTest {
 
     @After
     public void stop() {
-        helper.client.stop(false);
-        helper.server.stop();
+        helper.client.destroy(false);
+        helper.server.destroy();
         helper.dispose();
     }
 


### PR DESCRIPTION
Executing the test on a (too) small VM reports problems creating new
threads. Destroying the client and server at the end of the test frees
that resources and the test are able to run.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>