### PR TITLE
Remove outdated comment

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -63,7 +63,7 @@ public class BootstrapConfig implements Serializable {
         public SmsSecurityMode smsSecurityMode = SmsSecurityMode.NO_SEC;
         public byte[] smsBindingKeyParam = new byte[] {};
         public byte[] smsBindingKeySecret = new byte[] {};
-        public String serverSmsNumber = ""; // spec says integer WTF?
+        public String serverSmsNumber = "";
         public Integer serverId;
         public int clientOldOffTime = 1;
 


### PR DESCRIPTION
Current version of the spec says server SMS number is a string.