### PR TITLE
Remove secondary index on ADD if endpoint already register in redisStore

### DIFF
--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
@@ -137,7 +137,12 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
 
                 if (old != null) {
                     Registration oldRegistration = deserializeReg(old);
+                    // remove old secondary index
+                    if (registration.getId() != oldRegistration.getId())
+                        j.del(toRegIdKey(oldRegistration.getId()));
+                    // remove old observation
                     Collection<Observation> obsRemoved = unsafeRemoveAllObservations(j, oldRegistration.getId());
+
                     return new Deregistration(oldRegistration, obsRemoved);
                 }
 


### PR DESCRIPTION
We didn't remove secondary index on ADD if endpoint already register in redisStore.
It should be fixed now.