### PR TITLE
Simple MessageIdProvider (memory consumption fix)

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -30,10 +30,13 @@ import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
@@ -168,8 +171,13 @@ public class LeshanServer implements LwM2mServer {
                 return new RootResource();
             }
         };
-        nonSecureEndpoint = new CoapEndpoint(localAddress, networkConfig,
-                this.observationService.getObservationStore());
+
+        // exchange store for non-secure endpoint
+        InMemoryMessageExchangeStore nsExchangeStore = new InMemoryMessageExchangeStore(networkConfig);
+        nsExchangeStore.setMessageIdProvider(new SimpleMessageIdProvider(networkConfig));
+
+        nonSecureEndpoint = new CoapEndpoint(createUDPConnector(localAddress, networkConfig), networkConfig,
+                this.observationService.getObservationStore(), nsExchangeStore);
         nonSecureEndpoint.addNotificationListener(observationService);
         observationService.setNonSecureEndpoint(nonSecureEndpoint);
         coapServer.addEndpoint(nonSecureEndpoint);
@@ -197,8 +205,12 @@ public class LeshanServer implements LwM2mServer {
                 builder.setTrustStore(trustedCertificates);
             }
 
+            // exchange store for secure endpoint
+            InMemoryMessageExchangeStore sExchangeStore = new InMemoryMessageExchangeStore(networkConfig);
+            sExchangeStore.setMessageIdProvider(new SimpleMessageIdProvider(networkConfig));
+
             secureEndpoint = new CoapEndpoint(new DTLSConnector(builder.build()), networkConfig,
-                    this.observationService.getObservationStore(), null);
+                    this.observationService.getObservationStore(), sExchangeStore);
             secureEndpoint.addNotificationListener(observationService);
             observationService.setSecureEndpoint(secureEndpoint);
             coapServer.addEndpoint(secureEndpoint);
@@ -215,6 +227,22 @@ public class LeshanServer implements LwM2mServer {
         // create sender
         requestSender = new CaliforniumLwM2mRequestSender(endpoints, this.observationService, modelProvider, encoder,
                 decoder);
+    }
+
+    /**
+     * Copied from {@link CoapEndpoint#createUDPConnector}
+     */
+    private static Connector createUDPConnector(final InetSocketAddress address, final NetworkConfig config) {
+        UDPConnector c = new UDPConnector(address);
+
+        c.setReceiverThreadCount(config.getInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT));
+        c.setSenderThreadCount(config.getInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT));
+
+        c.setReceiveBufferSize(config.getInt(NetworkConfig.Keys.UDP_CONNECTOR_RECEIVE_BUFFER));
+        c.setSendBufferSize(config.getInt(NetworkConfig.Keys.UDP_CONNECTOR_SEND_BUFFER));
+        c.setReceiverPacketSize(config.getInt(NetworkConfig.Keys.UDP_CONNECTOR_DATAGRAM_SIZE));
+
+        return c;
     }
 
     @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/SimpleMessageIdProvider.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/SimpleMessageIdProvider.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.impl;
+
+import java.net.InetSocketAddress;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.core.network.MessageIdProvider;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
+
+public class SimpleMessageIdProvider implements MessageIdProvider {
+
+    private static final int TOTAL_NB_OF_MIDS = 1 << 16;
+
+    // a cache keeping track of the last use mid for each peer address
+    private final LeastRecentlyUsedCache<InetSocketAddress, AtomicInteger> mids;
+
+    private final NetworkConfig config;
+
+    private static final Random RDM = new Random();
+
+    /**
+     * Creates a new provider for configuration values.
+     * 
+     * @param config the configuration to use.
+     * @throws NullPointerException if the config is {@code null}.
+     */
+    public SimpleMessageIdProvider(final NetworkConfig config) {
+        if (config == null) {
+            throw new NullPointerException("Config must not be null");
+        }
+        this.config = config;
+        mids = new LeastRecentlyUsedCache<>(config.getInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS, 150000),
+                config.getLong(NetworkConfig.Keys.MAX_PEER_INACTIVITY_PERIOD, 10 * 60L)); // 10 minutes
+    }
+
+    @Override
+    public synchronized int getNextMessageId(final InetSocketAddress destination) {
+        AtomicInteger lastMid = mids.get(destination);
+        if (lastMid == null) {
+            // initialize a messageId
+            if (config.getBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START)) {
+                lastMid = new AtomicInteger(RDM.nextInt(TOTAL_NB_OF_MIDS));
+            } else {
+                lastMid = new AtomicInteger(0);
+            }
+            if (!mids.put(destination, lastMid)) {
+                // we have reached the maximum number of active peers
+                // TODO: throw an exception?
+                return -1;
+            }
+        } else {
+            if (lastMid.get() + 1 >= TOTAL_NB_OF_MIDS) {
+                lastMid.set(0);
+            } else {
+                lastMid.incrementAndGet();
+            }
+        }
+
+        return lastMid.get();
+    }
+
+}


### PR DESCRIPTION
A basic MessageIdProvider implementation using a simple counter for each peer to get the next messageId.