### PR TITLE
Registration listener API changes

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -165,14 +165,16 @@ public class IntegrationTestHelper {
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
+                    Registration newReg) {
                 if (registration.getEndpoint().equals(currentEndpointIdentifier)) {
                     deregisterLatch.countDown();
                 }
             }
 
             @Override
-            public void registered(Registration registration) {
+            public void registered(Registration registration, Registration previousReg,
+                    Collection<Observation> previousObsersations) {
                 if (registration.getEndpoint().equals(currentEndpointIdentifier)) {
                     last_registration = registration;
                     registerLatch.countDown();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisIntegrationTestHelper.java
@@ -66,14 +66,16 @@ public class RedisIntegrationTestHelper extends IntegrationTestHelper {
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
+                    Registration newReg) {
                 if (registration.getEndpoint().equals(getCurrentEndpoint())) {
                     deregisterLatch.countDown();
                 }
             }
 
             @Override
-            public void registered(Registration registration) {
+            public void registered(Registration registration, Registration previousReg,
+                    Collection<Observation> previousObsersations) {
                 if (registration.getEndpoint().equals(getCurrentEndpoint())) {
                     last_registration = registration;
                     registerLatch.countDown();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecureIntegrationTestHelper.java
@@ -67,14 +67,16 @@ public class RedisSecureIntegrationTestHelper extends SecureIntegrationTestHelpe
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
+                    Registration newReg) {
                 if (registration.getEndpoint().equals(getCurrentEndpoint())) {
                     deregisterLatch.countDown();
                 }
             }
 
             @Override
-            public void registered(Registration registration) {
+            public void registered(Registration registration, Registration previousReg,
+                    Collection<Observation> previousObsersations) {
                 if (registration.getEndpoint().equals(getCurrentEndpoint())) {
                     last_registration = registration;
                     registerLatch.countDown();

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -152,12 +152,14 @@ public class LeshanServer implements LwM2mServer {
             }
 
             @Override
-            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
+            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
+                    Registration newReg) {
                 requestSender.cancelPendingRequests(registration);
             }
 
             @Override
-            public void registered(Registration registration) {
+            public void registered(Registration registration, Registration previousReg,
+                    Collection<Observation> previousObsersations) {
             }
         });
 

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationEventPublisher.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationEventPublisher.java
@@ -44,7 +44,8 @@ public class RedisRegistrationEventPublisher implements RegistrationListener {
     }
 
     @Override
-    public void registered(Registration registration) {
+    public void registered(Registration registration, Registration previousReg,
+            Collection<Observation> previousObsersations) {
         String payload = RegistrationSerDes.sSerialize(registration);
         try (Jedis j = pool.getResource()) {
             j.publish(REGISTER_EVENT, payload);
@@ -64,7 +65,8 @@ public class RedisRegistrationEventPublisher implements RegistrationListener {
     }
 
     @Override
-    public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
+    public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
+            Registration newReg) {
         String payload = RegistrationSerDes.sSerialize(registration);
         try (Jedis j = pool.getResource()) {
             j.publish(DEREGISTER_EVENT, payload);

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisTokenHandler.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisTokenHandler.java
@@ -46,7 +46,8 @@ public class RedisTokenHandler implements RegistrationListener {
     }
 
     @Override
-    public void registered(Registration registration) {
+    public void registered(Registration registration, Registration previousReg,
+            Collection<Observation> previousObsersations) {
         try (Jedis j = pool.getResource()) {
             // create registration entry
             byte[] k = (EP_UID + registration.getEndpoint()).getBytes();
@@ -67,7 +68,8 @@ public class RedisTokenHandler implements RegistrationListener {
     }
 
     @Override
-    public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
+    public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
+            Registration newReg) {
         try (Jedis j = pool.getResource()) {
             // create registration entry
             j.del((EP_UID + registration.getEndpoint()).getBytes());

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/impl/RegistrationServiceImpl.java
@@ -70,19 +70,20 @@ public class RegistrationServiceImpl implements RegistrationService, ExpirationL
     @Override
     public void registrationExpired(Registration registration, Collection<Observation> observations) {
         for (RegistrationListener l : listeners) {
-            l.unregistered(registration, observations, true);
+            l.unregistered(registration, observations, true, null);
         }
     }
 
-    public void fireRegistered(Registration registration) {
+    public void fireRegistered(Registration registration, Registration previousReg,
+            Collection<Observation> previousObsersations) {
         for (RegistrationListener l : listeners) {
-            l.registered(registration);
+            l.registered(registration, previousReg, previousObsersations);
         }
     }
 
-    public void fireUnregistered(Registration registration, Collection<Observation> observations) {
+    public void fireUnregistered(Registration registration, Collection<Observation> observations, Registration newReg) {
         for (RegistrationListener l : listeners) {
-            l.unregistered(registration, observations, false);
+            l.unregistered(registration, observations, false, newReg);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -77,9 +77,12 @@ public class RegistrationHandler {
             public void run() {
                 if (deregistration != null) {
                     registrationService.fireUnregistered(deregistration.getRegistration(),
-                            deregistration.getObservations());
+                            deregistration.getObservations(), registration);
+                    registrationService.fireRegistered(registration, deregistration.registration,
+                            deregistration.observations);
+                } else {
+                    registrationService.fireRegistered(registration, null, null);
                 }
-                registrationService.fireRegistered(registration);
             }
         };
 
@@ -148,7 +151,7 @@ public class RegistrationHandler {
                 @Override
                 public void run() {
                     registrationService.fireUnregistered(deregistration.getRegistration(),
-                            deregistration.getObservations());
+                            deregistration.getObservations(), null);
                 };
             };
             return new SendableResponse<>(DeregisterResponse.success(), whenSent);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationListener.java
@@ -25,28 +25,35 @@ import org.eclipse.leshan.core.observation.Observation;
 public interface RegistrationListener {
 
     /**
-     * Invoked when a new client has been registered on the server.
+     * Invoked when a new registration is created.
      *
-     * @param registration
+     * @param registration the new registration
+     * @param previousReg the previous registration if the client was already registered (same endpoint).
+     *        <code>null</code> for a brand-new registration.
+     * @param previousObsersations all the observations linked to the previous registration which have been passively
+     *        cancelled. <code>null</code> for a brand-new registration.
      */
-    void registered(Registration registration);
+    void registered(Registration reg, Registration previousReg, Collection<Observation> previousObsersations);
 
     /**
-     * Invoked when a client updated its registration.
+     * Invoked when a client updates its registration.
      *
      * @param update the registration properties to update
-     * @param updatedRegistration the registration after the update
-     * @param previousRegistration the registration before the update
+     * @param updatedReg the registration after the update
+     * @param previousReg the registration before the update
      */
-    void updated(RegistrationUpdate update, Registration updatedRegistration, Registration previousRegistration);
+    void updated(RegistrationUpdate update, Registration updatedReg, Registration previousReg);
 
     /**
-     * Invoked when a client has been unregistered from the server.
+     * Invoked when a registration is removed from the server.
      *
-     * @param registration
-     * @param observations all the observations linked to this registration which has been passively cancelled
+     * @param reg the deleted registration
+     * @param observations all the observations linked to the deleted registration which has been passively cancelled
      * @param expired <code>true</code> if the client has been unregistered because of its lifetime expiration and
      *        <code>false</code> otherwise
+     * @param newReg the new registration when the registration is deleted because the client was already registered
+     *        (same endpoint). <code>null</code> if the registration is deleted because of a Deregister request or an
+     *        expiration.
      */
-    void unregistered(Registration registration, Collection<Observation> observations, boolean expired);
+    void unregistered(Registration reg, Collection<Observation> observations, boolean expired, Registration newReg);
 }

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
@@ -73,7 +73,8 @@ public class EventServlet extends EventSourceServlet {
     private final RegistrationListener registrationListener = new RegistrationListener() {
 
         @Override
-        public void registered(Registration registration) {
+        public void registered(Registration registration, Registration previousReg,
+                Collection<Observation> previousObsersations) {
             String jReg = EventServlet.this.gson.toJson(registration);
             sendEvent(EVENT_REGISTRATION, jReg, registration.getEndpoint());
         }
@@ -86,7 +87,8 @@ public class EventServlet extends EventSourceServlet {
         }
 
         @Override
-        public void unregistered(Registration registration, Collection<Observation> observations, boolean expired) {
+        public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
+                Registration newReg) {
             String jReg = EventServlet.this.gson.toJson(registration);
             sendEvent(EVENT_DEREGISTRATION, jReg, registration.getEndpoint());
         }


### PR DESCRIPTION
Changes the registered() and unregistered() signature to have the information that a registration is replaced by a new one (new registration for the same endpoint).