### PR TITLE
Security store no more mandatory for secured endpoint + javadoc

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -164,8 +164,9 @@ public class LeshanServerBuilder {
      * <p>
      * Set your {@link SecurityStore} implementation which stores {@link SecurityInfo}.
      * </p>
-     * By default no security store is set and the secure CoAP Server is not launched. An {@link InMemorySecurityStore}
-     * is provided to start using secured connection.
+     * By default no security store is set. It is needed for secured connection if you are using the defaultAuthorizer
+     * or if you want PSK feature activated. An {@link InMemorySecurityStore} is provided to start using secured
+     * connection.
      * 
      */
     public LeshanServerBuilder setSecurityStore(SecurityStore securityStore) {
@@ -177,8 +178,8 @@ public class LeshanServerBuilder {
      * <p>
      * Set your {@link Authorizer} implementation to define if a device if authorize to register to this server.
      * </p>
-     * By default the {@link DefaultAuthorizer} implementation is used, if a security store is set.
-     * 
+     * By default the {@link DefaultAuthorizer} implementation is used, it needs a security store to accept secured
+     * connection.
      */
     public LeshanServerBuilder setAuthorizer(Authorizer authorizer) {
         this.authorizer = authorizer;
@@ -329,85 +330,81 @@ public class LeshanServerBuilder {
 
         // handle dtlsConfig
         DtlsConnectorConfig dtlsConfig = null;
-        if (securityStore != null && dtlsConfigBuilder == null) {
+        if (dtlsConfigBuilder == null) {
             dtlsConfigBuilder = new DtlsConnectorConfig.Builder();
             // TODO remove 2 lines below when we will integrate the californium v2.0.0-M5/RC1
             dtlsConfigBuilder.setMaxConnections(coapConfig.getInt(Keys.MAX_ACTIVE_PEERS));
             dtlsConfigBuilder.setStaleConnectionThreshold(coapConfig.getLong(Keys.MAX_PEER_INACTIVITY_PERIOD));
         }
-
-        if (dtlsConfigBuilder != null) {
-            DtlsConnectorConfig incompleteConfig = dtlsConfigBuilder.getIncompleteConfig();
-            // Handle PSK Store
-            if (incompleteConfig.getPskStore() == null) {
-                dtlsConfigBuilder.setPskStore(new LwM2mPskStore(this.securityStore, registrationStore));
-            } else {
-                LOG.warn(
-                        "PskStore should be automatically set by Leshan. Using a custom implementation is not advised.");
-            }
-
-            // Handle secure address
-            if (incompleteConfig.getAddress() == null) {
-                if (localSecureAddress == null) {
-                    localSecureAddress = new InetSocketAddress(LwM2m.DEFAULT_COAP_SECURE_PORT);
-                }
-                dtlsConfigBuilder.setAddress(localSecureAddress);
-            } else if (localSecureAddress != null && !localSecureAddress.equals(incompleteConfig.getAddress())) {
-                throw new IllegalStateException(String.format(
-                        "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for secure address: %s != %s",
-                        localSecureAddress, incompleteConfig.getAddress()));
-            }
-
-            // Handle active peers
-            if (incompleteConfig.getMaxConnections() == null)
-                dtlsConfigBuilder.setMaxConnections(coapConfig.getInt(Keys.MAX_ACTIVE_PEERS));
-            if (incompleteConfig.getStaleConnectionThreshold() == null)
-                dtlsConfigBuilder.setStaleConnectionThreshold(coapConfig.getLong(Keys.MAX_PEER_INACTIVITY_PERIOD));
-
-            // handle trusted certificates
-            if (trustedCertificates != null) {
-                if (incompleteConfig.getTrustStore() == null) {
-                    dtlsConfigBuilder.setTrustStore(trustedCertificates);
-                } else if (!Arrays.equals(trustedCertificates, incompleteConfig.getTrustStore())) {
-                    throw new IllegalStateException(String.format(
-                            "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for trusted Certificates (trustStore) : \n%s != \n%s",
-                            Arrays.toString(trustedCertificates), Arrays.toString(incompleteConfig.getTrustStore())));
-                }
-            }
-
-            // check conflict for private key
-            if (privateKey != null) {
-                if (incompleteConfig.getPrivateKey() != null && !incompleteConfig.getPrivateKey().equals(privateKey)) {
-                    throw new IllegalStateException(String.format(
-                            "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for private key: %s != %s",
-                            privateKey, incompleteConfig.getPrivateKey()));
-                }
-
-                // if in raw key mode and not in X.509 set the raw keys
-                if (certificateChain == null && publicKey != null) {
-                    if (incompleteConfig.getPublicKey() != null && !incompleteConfig.getPublicKey().equals(publicKey)) {
-                        throw new IllegalStateException(String.format(
-                                "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for public key: %s != %s",
-                                publicKey, incompleteConfig.getPublicKey()));
-                    }
-
-                    dtlsConfigBuilder.setIdentity(privateKey, publicKey);
-                }
-                // if in X.509 mode set the private key, certificate chain, public key is extracted from the certificate
-                if (certificateChain != null && certificateChain.length > 0) {
-                    if (incompleteConfig.getCertificateChain() != null
-                            && !Arrays.equals(incompleteConfig.getCertificateChain(), certificateChain)) {
-                        throw new IllegalStateException(String.format(
-                                "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for certificate chain: %s != %s",
-                                certificateChain, incompleteConfig.getCertificateChain()));
-                    }
-
-                    dtlsConfigBuilder.setIdentity(privateKey, certificateChain, false);
-                }
-
-            }
-            dtlsConfig = dtlsConfigBuilder.build();
+        // set default DTLS setting for Leshan unless user change it.
+        DtlsConnectorConfig incompleteConfig = dtlsConfigBuilder.getIncompleteConfig();
+        // Handle PSK Store
+        if (incompleteConfig.getPskStore() == null && securityStore != null) {
+            dtlsConfigBuilder.setPskStore(new LwM2mPskStore(this.securityStore, registrationStore));
+        } else {
+            LOG.warn("PskStore should be automatically set by Leshan. Using a custom implementation is not advised.");
         }
+
+        // Handle secure address
+        if (incompleteConfig.getAddress() == null) {
+            if (localSecureAddress == null) {
+                localSecureAddress = new InetSocketAddress(LwM2m.DEFAULT_COAP_SECURE_PORT);
+            }
+            dtlsConfigBuilder.setAddress(localSecureAddress);
+        } else if (localSecureAddress != null && !localSecureAddress.equals(incompleteConfig.getAddress())) {
+            throw new IllegalStateException(String.format(
+                    "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for secure address: %s != %s",
+                    localSecureAddress, incompleteConfig.getAddress()));
+        }
+
+        // Handle active peers
+        if (incompleteConfig.getMaxConnections() == null)
+            dtlsConfigBuilder.setMaxConnections(coapConfig.getInt(Keys.MAX_ACTIVE_PEERS));
+        if (incompleteConfig.getStaleConnectionThreshold() == null)
+            dtlsConfigBuilder.setStaleConnectionThreshold(coapConfig.getLong(Keys.MAX_PEER_INACTIVITY_PERIOD));
+
+        // handle trusted certificates
+        if (trustedCertificates != null) {
+            if (incompleteConfig.getTrustStore() == null) {
+                dtlsConfigBuilder.setTrustStore(trustedCertificates);
+            } else if (!Arrays.equals(trustedCertificates, incompleteConfig.getTrustStore())) {
+                throw new IllegalStateException(String.format(
+                        "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for trusted Certificates (trustStore) : \n%s != \n%s",
+                        Arrays.toString(trustedCertificates), Arrays.toString(incompleteConfig.getTrustStore())));
+            }
+        }
+
+        // check conflict for private key
+        if (privateKey != null) {
+            if (incompleteConfig.getPrivateKey() != null && !incompleteConfig.getPrivateKey().equals(privateKey)) {
+                throw new IllegalStateException(String.format(
+                        "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for private key: %s != %s",
+                        privateKey, incompleteConfig.getPrivateKey()));
+            }
+
+            // if in raw key mode and not in X.509 set the raw keys
+            if (certificateChain == null && publicKey != null) {
+                if (incompleteConfig.getPublicKey() != null && !incompleteConfig.getPublicKey().equals(publicKey)) {
+                    throw new IllegalStateException(String.format(
+                            "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for public key: %s != %s",
+                            publicKey, incompleteConfig.getPublicKey()));
+                }
+
+                dtlsConfigBuilder.setIdentity(privateKey, publicKey);
+            }
+            // if in X.509 mode set the private key, certificate chain, public key is extracted from the certificate
+            if (certificateChain != null && certificateChain.length > 0) {
+                if (incompleteConfig.getCertificateChain() != null
+                        && !Arrays.equals(incompleteConfig.getCertificateChain(), certificateChain)) {
+                    throw new IllegalStateException(String.format(
+                            "Configuration conflict between LeshanBuilder and DtlsConnectorConfig.Builder for certificate chain: %s != %s",
+                            certificateChain, incompleteConfig.getCertificateChain()));
+                }
+
+                dtlsConfigBuilder.setIdentity(privateKey, certificateChain, false);
+            }
+        }
+        dtlsConfig = dtlsConfigBuilder.build();
 
         // create endpoints
         CoapEndpoint unsecuredEndpoint = null;
@@ -421,7 +418,7 @@ public class LeshanServerBuilder {
         }
 
         CoapEndpoint securedEndpoint = null;
-        if (!noSecuredEndpoint && securityStore != null) {
+        if (!noSecuredEndpoint && dtlsConfig.getSupportedCipherSuites().length > 0) {
             if (endpointFactory != null) {
                 securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, registrationStore);
             } else {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mPskStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mPskStore.java
@@ -41,6 +41,9 @@ public class LwM2mPskStore implements PskStore {
 
     @Override
     public byte[] getKey(String identity) {
+        if (securityStore == null)
+            return null;
+
         SecurityInfo info = securityStore.getByIdentity(identity);
         if (info == null || info.getPreSharedKey() == null) {
             return null;


### PR DESCRIPTION
#378 comments ask for more javadoc about we need to provide a security store for secure connection.

I remove this constraint and add some javadocs