### PR TITLE
Add values id de-serialization of multi-instance resource in leshan-server-demo.

### DIFF
--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/LwM2mNodeDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/LwM2mNodeDeserializer.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.server.demo.servlet.json;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mNode;
@@ -81,14 +82,11 @@ public class LwM2mNodeDeserializer implements JsonDeserializer<LwM2mNode> {
             } else if (object.has("values")) {
                 // multi-instances resource
                 Map<Integer, Object> values = new HashMap<>();
-                // TODO handle id for multiple resource
-                int i = 0;
                 org.eclipse.leshan.core.model.ResourceModel.Type expectedType = null;
-                for (JsonElement val : object.get("values").getAsJsonArray()) {
-                    JsonPrimitive pval = val.getAsJsonPrimitive();
+                for (Entry<String, JsonElement> entry : object.get("values").getAsJsonObject().entrySet()) {
+                    JsonPrimitive pval = entry.getValue().getAsJsonPrimitive();
                     expectedType = getTypeFor(pval);
-                    values.put(i, deserializeValue(pval, expectedType));
-                    i++;
+                    values.put(Integer.valueOf(entry.getKey()), deserializeValue(pval, expectedType));
                 }
                 // use string by default;
                 if (expectedType == null)


### PR DESCRIPTION
This should allow to write and create multi-instance resource via the demo REST API.

e.g. for ACL (object 2): 
create
```
   POST /api/clients/yourendpoint/2?format=TLV
   Content-Type:application/json
     {"id':"1",
      "resources":[
           {"id":2,"values":{"3":1}},
           {"id":3,"value":1}]}
```
write 
```
     PUT /api/clients/yourendpoint/2/1?format=TLV
     Content-Type:application/json
     {"id":"1",
      "resources":[
           {"id":2,"values":{"3":1, "4":3}},
           {"id":3,"value":1}]}
```