### PR TITLE
Add some flexibility in the way we handle response code

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/BootstrapResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/BootstrapResource.java
@@ -16,7 +16,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
-import static org.eclipse.leshan.core.californium.ResponseCodeUtil.fromLwM2mCode;
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toCoapResponseCode;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.server.resources.CoapExchange;
@@ -41,7 +41,7 @@ public class BootstrapResource extends CoapResource {
     public void handlePOST(CoapExchange exchange) {
         ServerIdentity identity = ResourceUtil.extractServerIdentity(exchange, bootstrapHandler);
         BootstrapFinishResponse response = bootstrapHandler.finished(identity, new BootstrapFinishRequest());
-        exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+        exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
     }
 
 }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/LwM2mClientResponseBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/LwM2mClientResponseBuilder.java
@@ -43,67 +43,60 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
 
     @Override
     public void visit(RegisterRequest request) {
-        switch (coapResponse.getCode()) {
-        case CREATED:
-            lwM2mresponse = RegisterResponse.success(coapResponse.getOptions().getLocationString());
-            break;
-        case BAD_REQUEST:
-        case FORBIDDEN:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new RegisterResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
                     coapResponse.getPayloadString());
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CREATED) {
+            // handle success response:
+            lwM2mresponse = RegisterResponse.success(coapResponse.getOptions().getLocationString());
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(request, coapResponse);
         }
     }
 
     @Override
     public void visit(DeregisterRequest request) {
-        switch (coapResponse.getCode()) {
-        case DELETED:
-            lwM2mresponse = DeregisterResponse.success();
-            break;
-        case BAD_REQUEST:
-        case NOT_FOUND:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new DeregisterResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString());
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.DELETED) {
+            // handle success response:
+            lwM2mresponse = DeregisterResponse.success();
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(request, coapResponse);
         }
     }
 
     @Override
     public void visit(UpdateRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            lwM2mresponse = UpdateResponse.success();
-            break;
-        case BAD_REQUEST:
-        case NOT_FOUND:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new UpdateResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString());
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
+            lwM2mresponse = UpdateResponse.success();
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(request, coapResponse);
         }
     }
 
     @Override
     public void visit(BootstrapRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            lwM2mresponse = BootstrapResponse.success();
-            break;
-        case BAD_REQUEST:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new BootstrapResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString());
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
+            lwM2mresponse = BootstrapResponse.success();
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(request, coapResponse);
         }
     }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/LwM2mClientResponseBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/LwM2mClientResponseBuilder.java
@@ -50,7 +50,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
         case BAD_REQUEST:
         case FORBIDDEN:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new RegisterResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new RegisterResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
                     coapResponse.getPayloadString());
             break;
         default:
@@ -67,7 +67,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
         case BAD_REQUEST:
         case NOT_FOUND:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new DeregisterResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new DeregisterResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString());
             break;
         default:
@@ -84,7 +84,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
         case BAD_REQUEST:
         case NOT_FOUND:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new UpdateResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new UpdateResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString());
             break;
         default:
@@ -100,7 +100,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
             break;
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString());
             break;
         default:

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/LwM2mClientResponseBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/LwM2mClientResponseBuilder.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
-import static org.eclipse.leshan.core.californium.ResponseCodeUtil.fromCoapCode;
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toLwM2mResponseCode;
 
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.leshan.core.request.BootstrapRequest;
@@ -50,7 +50,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
         case BAD_REQUEST:
         case FORBIDDEN:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new RegisterResponse(fromCoapCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new RegisterResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
                     coapResponse.getPayloadString());
             break;
         default:
@@ -67,7 +67,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
         case BAD_REQUEST:
         case NOT_FOUND:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new DeregisterResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new DeregisterResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString());
             break;
         default:
@@ -84,7 +84,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
         case BAD_REQUEST:
         case NOT_FOUND:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new UpdateResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new UpdateResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString());
             break;
         default:
@@ -100,7 +100,7 @@ public class LwM2mClientResponseBuilder<T extends LwM2mResponse> implements Upli
             break;
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString());
             break;
         default:

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ObjectResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/ObjectResource.java
@@ -20,7 +20,7 @@
 package org.eclipse.leshan.client.californium.impl;
 
 import static org.eclipse.leshan.client.californium.impl.ResourceUtil.extractServerIdentity;
-import static org.eclipse.leshan.core.californium.ResponseCodeUtil.fromLwM2mCode;
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toCoapResponseCode;
 
 import java.util.List;
 
@@ -119,9 +119,9 @@ public class ObjectResource extends CoapResource implements NotifySender {
         if (exchange.getRequestOptions().getAccept() == MediaTypeRegistry.APPLICATION_LINK_FORMAT) {
             DiscoverResponse response = nodeEnabler.discover(identity, new DiscoverRequest(URI));
             if (response.getCode().isError()) {
-                exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+                exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
             } else {
-                exchange.respond(fromLwM2mCode(response.getCode()), Link.serialize(response.getObjectLinks()),
+                exchange.respond(toCoapResponseCode(response.getCode()), Link.serialize(response.getObjectLinks()),
                         MediaTypeRegistry.APPLICATION_LINK_FORMAT);
             }
         } else {
@@ -146,7 +146,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
                             format.getCode());
                     return;
                 } else {
-                    exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+                    exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
                     return;
                 }
             }
@@ -161,7 +161,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
                             format.getCode());
                     return;
                 } else {
-                    exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+                    exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
                     return;
                 }
             }
@@ -184,7 +184,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
         if (spec != null) {
             WriteAttributesResponse response = nodeEnabler.writeAttributes(identity,
                     new WriteAttributesRequest(URI, spec));
-            coapExchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+            coapExchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
             return;
         }
         // Manage Write and Bootstrap Write Request (replace)
@@ -208,11 +208,11 @@ public class ObjectResource extends CoapResource implements NotifySender {
                 if (identity.isLwm2mBootstrapServer()) {
                     BootstrapWriteResponse response = nodeEnabler.write(identity,
                             new BootstrapWriteRequest(path, lwM2mNode, contentFormat));
-                    coapExchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+                    coapExchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
                 } else {
                     WriteResponse response = nodeEnabler.write(identity,
                             new WriteRequest(Mode.REPLACE, contentFormat, URI, lwM2mNode));
-                    coapExchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+                    coapExchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
                 }
 
                 return;
@@ -237,7 +237,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
             byte[] payload = exchange.getRequestPayload();
             ExecuteResponse response = nodeEnabler.execute(identity,
                     new ExecuteRequest(URI, payload != null ? new String(payload) : null));
-            exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+            exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
             return;
         }
 
@@ -260,7 +260,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
                 LwM2mNode lwM2mNode = decoder.decode(exchange.getRequestPayload(), contentFormat, path, model);
                 WriteResponse response = nodeEnabler.write(identity,
                         new WriteRequest(Mode.UPDATE, contentFormat, URI, lwM2mNode));
-                exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+                exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
             } catch (CodecException e) {
                 LOG.warn("Unable to decode payload to write", e);
                 exchange.respond(ResponseCode.BAD_REQUEST);
@@ -287,10 +287,10 @@ public class ObjectResource extends CoapResource implements NotifySender {
             CreateResponse response = nodeEnabler.create(identity, createRequest);
             if (response.getCode() == org.eclipse.leshan.ResponseCode.CREATED) {
                 exchange.setLocationPath(response.getLocation());
-                exchange.respond(fromLwM2mCode(response.getCode()));
+                exchange.respond(toCoapResponseCode(response.getCode()));
                 return;
             } else {
-                exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+                exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
                 return;
             }
         } catch (CodecException e) {
@@ -307,7 +307,7 @@ public class ObjectResource extends CoapResource implements NotifySender {
         ServerIdentity identity = extractServerIdentity(coapExchange, bootstrapHandler);
 
         DeleteResponse response = nodeEnabler.delete(identity, new DeleteRequest(URI));
-        coapExchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+        coapExchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
     }
 
     @Override

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/RootResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/RootResource.java
@@ -16,7 +16,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.impl;
 
-import static org.eclipse.leshan.core.californium.ResponseCodeUtil.fromLwM2mCode;
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toCoapResponseCode;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -47,6 +47,6 @@ public class RootResource extends CoapResource {
 
         ServerIdentity identity = ResourceUtil.extractServerIdentity(exchange, bootstrapHandler);
         BootstrapDeleteResponse response = bootstrapHandler.delete(identity, new BootstrapDeleteRequest());
-        exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+        exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
     }
 }

--- a/leshan-core-cf/pom.xml
+++ b/leshan-core-cf/pom.xml
@@ -40,6 +40,12 @@ Contributors:
             <groupId>org.eclipse.californium</groupId>
             <artifactId>scandium</artifactId>
         </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
@@ -28,11 +28,7 @@ public class ResponseCodeUtil {
 
     public static ResponseCode toLwM2mResponseCode(
             org.eclipse.californium.core.coap.CoAP.ResponseCode coapResponseCode) {
-        ResponseCode lwm2mResponseCode = ResponseCode.fromCode(toLwM2mCode(coapResponseCode));
-        if (lwm2mResponseCode == null)
-            throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + coapResponseCode);
-
-        return lwm2mResponseCode;
+        return ResponseCode.fromCode(toLwM2mCode(coapResponseCode));
     }
 
     public static int toLwM2mCode(int coapCode) {
@@ -42,11 +38,7 @@ public class ResponseCodeUtil {
     }
 
     public static ResponseCode toLwM2mResponseCode(int coapCode) {
-        ResponseCode lwm2mResponseCode = ResponseCode.fromCode(toLwM2mCode(coapCode));
-        if (lwm2mResponseCode == null)
-            throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + coapCode);
-
-        return lwm2mResponseCode;
+        return ResponseCode.fromCode(toLwM2mCode(coapCode));
     }
 
     public static int toCoapCode(int lwm2mCode) {

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
@@ -26,6 +26,15 @@ public class ResponseCodeUtil {
         return coapResponseCode.codeClass * 100 + coapResponseCode.codeDetail;
     }
 
+    public static ResponseCode toLwM2mResponseCode(
+            org.eclipse.californium.core.coap.CoAP.ResponseCode coapResponseCode) {
+        ResponseCode lwm2mResponseCode = ResponseCode.fromCode(toLwM2mCode(coapResponseCode));
+        if (lwm2mResponseCode == null)
+            throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + coapResponseCode);
+
+        return lwm2mResponseCode;
+    }
+
     public static int toLwM2mCode(int coapCode) {
         int codeClass = CoAP.getCodeClass(coapCode);
         int codeDetail = CoAP.getCodeDetail(coapCode);

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.californium;
 
+import static org.eclipse.leshan.ResponseCode.*;
+
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.leshan.ResponseCode;
 import org.eclipse.leshan.util.Validate;
@@ -56,26 +58,26 @@ public class ResponseCodeUtil {
     public static org.eclipse.californium.core.coap.CoAP.ResponseCode fromLwM2mCode(ResponseCode code) {
         Validate.notNull(code);
 
-        switch (code) {
-        case CREATED:
+        switch (code.getCode()) {
+        case CREATED_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.CREATED;
-        case DELETED:
+        case DELETED_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.DELETED;
-        case CHANGED:
+        case CHANGED_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED;
-        case CONTENT:
+        case CONTENT_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT;
-        case BAD_REQUEST:
+        case BAD_REQUEST_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.BAD_REQUEST;
-        case UNAUTHORIZED:
+        case UNAUTHORIZED_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.UNAUTHORIZED;
-        case NOT_FOUND:
+        case NOT_FOUND_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.NOT_FOUND;
-        case METHOD_NOT_ALLOWED:
+        case METHOD_NOT_ALLOWED_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.METHOD_NOT_ALLOWED;
-        case FORBIDDEN:
+        case FORBIDDEN_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.FORBIDDEN;
-        case INTERNAL_SERVER_ERROR:
+        case INTERNAL_SERVER_ERROR_CODE:
             return org.eclipse.californium.core.coap.CoAP.ResponseCode.INTERNAL_SERVER_ERROR;
         default:
             throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + code);

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/ResponseCodeUtil.java
@@ -32,10 +32,10 @@ public class ResponseCodeUtil {
         return codeClass * 100 + codeDetail;
     }
 
-    public static ResponseCode fromCoapCode(int code) {
-        ResponseCode lwm2mResponseCode = ResponseCode.fromCode(toLwM2mCode(code));
+    public static ResponseCode toLwM2mResponseCode(int coapCode) {
+        ResponseCode lwm2mResponseCode = ResponseCode.fromCode(toLwM2mCode(coapCode));
         if (lwm2mResponseCode == null)
-            throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + code);
+            throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + coapCode);
 
         return lwm2mResponseCode;
     }
@@ -49,12 +49,13 @@ public class ResponseCodeUtil {
         return codeClass << 5 | codeDetail;
     }
 
-    public static org.eclipse.californium.core.coap.CoAP.ResponseCode fromLwM2mCode(ResponseCode code) {
-        Validate.notNull(code);
+    public static org.eclipse.californium.core.coap.CoAP.ResponseCode toCoapResponseCode(
+            ResponseCode Lwm2mResponseCode) {
+        Validate.notNull(Lwm2mResponseCode);
         try {
-            return org.eclipse.californium.core.coap.CoAP.ResponseCode.valueOf(toCoapCode(code.getCode()));
+            return org.eclipse.californium.core.coap.CoAP.ResponseCode.valueOf(toCoapCode(Lwm2mResponseCode.getCode()));
         } catch (MessageFormatException e) {
-            throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + code);
+            throw new IllegalArgumentException("Invalid CoAP code for LWM2M response: " + Lwm2mResponseCode);
         }
     }
 }

--- a/leshan-core-cf/src/test/java/org/eclipse/leshan/core/californium/ResponseCodeUtilTest.java
+++ b/leshan-core-cf/src/test/java/org/eclipse/leshan/core/californium/ResponseCodeUtilTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.californium;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResponseCodeUtilTest {
+
+    @Test
+    public void known_coap_code_to_known_lwm2m_Code() {
+        org.eclipse.leshan.ResponseCode lwM2mResponseCode = ResponseCodeUtil.toLwM2mResponseCode(ResponseCode.CREATED);
+
+        Assert.assertEquals(org.eclipse.leshan.ResponseCode.CREATED, lwM2mResponseCode);
+        Assert.assertEquals("CREATED", lwM2mResponseCode.toString());
+    }
+
+    @Test
+    public void known_coap_code_to_unknown_lwm2m_code() {
+        org.eclipse.leshan.ResponseCode lwM2mResponseCode = ResponseCodeUtil
+                .toLwM2mResponseCode(ResponseCode.GATEWAY_TIMEOUT);
+
+        Assert.assertEquals(504, lwM2mResponseCode.getCode());
+        Assert.assertEquals(org.eclipse.leshan.ResponseCode.UNKNOWN, lwM2mResponseCode.getName());
+        Assert.assertEquals("UNKNOWN(504)", lwM2mResponseCode.toString());
+    }
+
+    @Test
+    public void known_lwm2m_code_to_known_coap_code() {
+        ResponseCode coapResponseCode = ResponseCodeUtil
+                .toCoapResponseCode(org.eclipse.leshan.ResponseCode.BAD_REQUEST);
+
+        Assert.assertEquals(ResponseCode.BAD_REQUEST, coapResponseCode);
+    }
+
+    @Test
+    public void unknown_lwm2m_code_to_known_coap_code() {
+        ResponseCode coapResponseCode = ResponseCodeUtil.toCoapResponseCode(new org.eclipse.leshan.ResponseCode(503));
+
+        Assert.assertEquals(ResponseCode.SERVICE_UNAVAILABLE, coapResponseCode);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void unknown_lwm2m_code_to_invalid_coap_code() {
+        ResponseCodeUtil.toCoapResponseCode(new org.eclipse.leshan.ResponseCode(301));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void unknown_lwm2m_code_to_invalid_coap_code2() {
+        ResponseCodeUtil.toCoapResponseCode(new org.eclipse.leshan.ResponseCode(441));
+    }
+
+    @Test
+    public void unknown_lwm2m_code_to_unknown_coap_code() {
+        // californium behavior is not really consistent
+
+        // for success : code value is lost but we know we use an unknown code
+        ResponseCode coapResponseCode = ResponseCodeUtil.toCoapResponseCode(new org.eclipse.leshan.ResponseCode(206));
+        Assert.assertEquals(ResponseCode._UNKNOWN_SUCCESS_CODE, coapResponseCode);
+
+        // for client error,: unknown code is replace by BAD REQUEST ...
+        coapResponseCode = ResponseCodeUtil.toCoapResponseCode(new org.eclipse.leshan.ResponseCode(425));
+        Assert.assertEquals(ResponseCode.BAD_REQUEST, coapResponseCode);
+
+        // for server error : unknown code is replace by INTERNAL SERVER ERROR ...
+        coapResponseCode = ResponseCodeUtil.toCoapResponseCode(new org.eclipse.leshan.ResponseCode(509));
+        Assert.assertEquals(ResponseCode.INTERNAL_SERVER_ERROR, coapResponseCode);
+
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
@@ -18,45 +18,83 @@ package org.eclipse.leshan;
 /**
  * Response codes defined for LWM2M enabler
  */
-public enum ResponseCode {
+public class ResponseCode {
     /** Resource correctly created */
-    CREATED,
+    public final static int CREATED_CODE = 201;
     /** Resource correctly deleted */
-    DELETED,
+    public final static int DELETED_CODE = 202;
     /** Resource correctly changed */
-    CHANGED,
+    public final static int CHANGED_CODE = 204;
     /** Content correctly delivered */
-    CONTENT,
+    public final static int CONTENT_CODE = 205;
     /** Access Right Permission Denied */
-    UNAUTHORIZED,
+    public final static int UNAUTHORIZED_CODE = 401;
     /** Bad request format (missing parameters, bad encoding ...) */
-    BAD_REQUEST,
+    public final static int BAD_REQUEST_CODE = 400;
     /** This method (GET/PUT/POST/DELETE) is not allowed on this resource */
-    METHOD_NOT_ALLOWED,
+    public final static int METHOD_NOT_ALLOWED_CODE = 405;
     /** The Endpoint Client Name registration in the LWM2M Server is not allowed */
-    FORBIDDEN,
+    public final static int FORBIDDEN_CODE = 403;
     /** Resource not found */
-    NOT_FOUND,
+    public final static int NOT_FOUND_CODE = 404;
     /** None of the preferred Content-Formats can be returned */
-    NOT_ACCEPTABLE,
+    public final static int NOT_ACCEPTABLE_CODE = 406;
     /** The specified format is not supported */
-    UNSUPPORTED_CONTENT_FORMAT,
+    public final static int UNSUPPORTED_CONTENT_FORMAT_CODE = 415;
     /** generic response code for unexpected error */
-    INTERNAL_SERVER_ERROR;
+    public final static int INTERNAL_SERVER_ERROR_CODE = 500;
+
+    // LwM2m Response codes
+    public final static ResponseCode CREATED = new ResponseCode(CREATED_CODE, "CREATED");
+    public final static ResponseCode DELETED = new ResponseCode(DELETED_CODE, "DELETED");
+    public final static ResponseCode CHANGED = new ResponseCode(CHANGED_CODE, "CHANGED");
+    public final static ResponseCode CONTENT = new ResponseCode(CONTENT_CODE, "CONTENT");
+    public final static ResponseCode UNAUTHORIZED = new ResponseCode(UNAUTHORIZED_CODE, "UNAUTHORIZED");
+    public final static ResponseCode BAD_REQUEST = new ResponseCode(BAD_REQUEST_CODE, "BAD_REQUEST");
+    public final static ResponseCode METHOD_NOT_ALLOWED = new ResponseCode(METHOD_NOT_ALLOWED_CODE,
+            "METHOD_NOT_ALLOWED");
+    public final static ResponseCode FORBIDDEN = new ResponseCode(FORBIDDEN_CODE, "FORBIDDEN");
+    public final static ResponseCode NOT_FOUND = new ResponseCode(NOT_FOUND_CODE, "NOT_FOUND");
+    public final static ResponseCode NOT_ACCEPTABLE = new ResponseCode(NOT_ACCEPTABLE_CODE, "NOT_ACCEPTABLE");
+    public final static ResponseCode UNSUPPORTED_CONTENT_FORMAT = new ResponseCode(UNSUPPORTED_CONTENT_FORMAT_CODE,
+            "UNSUPPORTED_CONTENT_FORMAT");
+    public final static ResponseCode INTERNAL_SERVER_ERROR = new ResponseCode(INTERNAL_SERVER_ERROR_CODE, "CREATED");
+
+    private static final ResponseCode knownResponseCode[] = new ResponseCode[] { CREATED, DELETED, CHANGED, CONTENT,
+                            UNAUTHORIZED, BAD_REQUEST, METHOD_NOT_ALLOWED, FORBIDDEN, NOT_FOUND, NOT_ACCEPTABLE,
+                            UNSUPPORTED_CONTENT_FORMAT, INTERNAL_SERVER_ERROR };
+
+    private int code;
+    private String name;
+
+    public ResponseCode(int code, String name) {
+        this.code = code;
+        this.name = name;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
 
     public boolean isError() {
-        switch (this) {
-        case UNAUTHORIZED:
-        case BAD_REQUEST:
-        case METHOD_NOT_ALLOWED:
-        case FORBIDDEN:
-        case NOT_FOUND:
-        case INTERNAL_SERVER_ERROR:
-        case UNSUPPORTED_CONTENT_FORMAT:
-        case NOT_ACCEPTABLE:
-            return true;
-        default:
-            return false;
+        return code >= 400;
+    }
+
+    public static ResponseCode fromName(String name) {
+        for (ResponseCode c : knownResponseCode) {
+            if (c.getName().equals(name)) {
+                return c;
+            }
         }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
@@ -15,10 +15,16 @@
  *******************************************************************************/
 package org.eclipse.leshan;
 
+import org.eclipse.leshan.util.Validate;
+
 /**
  * Response codes defined for LWM2M enabler
  */
 public class ResponseCode {
+
+    /** Common name for unknown response code. That means "not explicitly" defined in the LWM2M specification */
+    public final static String UNKNOWN = "UNKNOWN";
+
     /** Resource correctly created */
     public final static int CREATED_CODE = 201;
     /** Resource correctly deleted */
@@ -68,8 +74,13 @@ public class ResponseCode {
     private String name;
 
     public ResponseCode(int code, String name) {
+        Validate.notNull(name);
         this.code = code;
         this.name = name;
+    }
+
+    public ResponseCode(int code) {
+        this(code, UNKNOWN);
     }
 
     public int getCode() {
@@ -99,11 +110,14 @@ public class ResponseCode {
                 return c;
             }
         }
-        return null;
+        return new ResponseCode(code);
     }
 
     @Override
     public String toString() {
-        return name;
+        if (UNKNOWN.equals(name))
+            return String.format("%s(%d)", name, code);
+        else
+            return name;
     }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
@@ -93,6 +93,15 @@ public class ResponseCode {
         return null;
     }
 
+    public static ResponseCode fromCode(int code) {
+        for (ResponseCode c : knownResponseCode) {
+            if (c.getCode() == code) {
+                return c;
+            }
+        }
+        return null;
+    }
+
     @Override
     public String toString() {
         return name;

--- a/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
@@ -33,10 +33,10 @@ public class ResponseCode {
     public final static int CHANGED_CODE = 204;
     /** Content correctly delivered */
     public final static int CONTENT_CODE = 205;
-    /** Access Right Permission Denied */
-    public final static int UNAUTHORIZED_CODE = 401;
     /** Bad request format (missing parameters, bad encoding ...) */
     public final static int BAD_REQUEST_CODE = 400;
+    /** Access Right Permission Denied */
+    public final static int UNAUTHORIZED_CODE = 401;
     /** This method (GET/PUT/POST/DELETE) is not allowed on this resource */
     public final static int METHOD_NOT_ALLOWED_CODE = 405;
     /** The Endpoint Client Name registration in the LWM2M Server is not allowed */
@@ -45,6 +45,12 @@ public class ResponseCode {
     public final static int NOT_FOUND_CODE = 404;
     /** None of the preferred Content-Formats can be returned */
     public final static int NOT_ACCEPTABLE_CODE = 406;
+    /** None of the preferred Content-Formats can be returned */
+    public final static int REQUEST_ENTITY_INCOMPLETE_CODE = 408;
+    /** Supported LwM2M Versions of the Server and the Client are not compatible */
+    public final static int PRECONDITION_FAILED_CODE = 412;
+    /** None of the preferred Content-Formats can be returned */
+    public final static int REQUEST_ENTITY_TOO_LARGE_CODE = 413;
     /** The specified format is not supported */
     public final static int UNSUPPORTED_CONTENT_FORMAT_CODE = 415;
     /** generic response code for unexpected error */
@@ -55,19 +61,26 @@ public class ResponseCode {
     public final static ResponseCode DELETED = new ResponseCode(DELETED_CODE, "DELETED");
     public final static ResponseCode CHANGED = new ResponseCode(CHANGED_CODE, "CHANGED");
     public final static ResponseCode CONTENT = new ResponseCode(CONTENT_CODE, "CONTENT");
-    public final static ResponseCode UNAUTHORIZED = new ResponseCode(UNAUTHORIZED_CODE, "UNAUTHORIZED");
     public final static ResponseCode BAD_REQUEST = new ResponseCode(BAD_REQUEST_CODE, "BAD_REQUEST");
+    public final static ResponseCode UNAUTHORIZED = new ResponseCode(UNAUTHORIZED_CODE, "UNAUTHORIZED");
     public final static ResponseCode METHOD_NOT_ALLOWED = new ResponseCode(METHOD_NOT_ALLOWED_CODE,
             "METHOD_NOT_ALLOWED");
     public final static ResponseCode FORBIDDEN = new ResponseCode(FORBIDDEN_CODE, "FORBIDDEN");
     public final static ResponseCode NOT_FOUND = new ResponseCode(NOT_FOUND_CODE, "NOT_FOUND");
     public final static ResponseCode NOT_ACCEPTABLE = new ResponseCode(NOT_ACCEPTABLE_CODE, "NOT_ACCEPTABLE");
+    public final static ResponseCode REQUEST_ENTITY_INCOMPLETE = new ResponseCode(REQUEST_ENTITY_INCOMPLETE_CODE,
+            "REQUEST_ENTITY_INCOMPLETE");
+    public final static ResponseCode PRECONDITION_FAILED = new ResponseCode(PRECONDITION_FAILED_CODE,
+            "PRECONDITION_FAILED");
+    public final static ResponseCode REQUEST_ENTITY_TOO_LARGE = new ResponseCode(REQUEST_ENTITY_TOO_LARGE_CODE,
+            "REQUEST_ENTITY_TOO_LARGE");
     public final static ResponseCode UNSUPPORTED_CONTENT_FORMAT = new ResponseCode(UNSUPPORTED_CONTENT_FORMAT_CODE,
             "UNSUPPORTED_CONTENT_FORMAT");
     public final static ResponseCode INTERNAL_SERVER_ERROR = new ResponseCode(INTERNAL_SERVER_ERROR_CODE, "CREATED");
 
     private static final ResponseCode knownResponseCode[] = new ResponseCode[] { CREATED, DELETED, CHANGED, CONTENT,
-                            UNAUTHORIZED, BAD_REQUEST, METHOD_NOT_ALLOWED, FORBIDDEN, NOT_FOUND, NOT_ACCEPTABLE,
+                            BAD_REQUEST, UNAUTHORIZED, METHOD_NOT_ALLOWED, FORBIDDEN, NOT_FOUND, NOT_ACCEPTABLE,
+                            REQUEST_ENTITY_INCOMPLETE, PRECONDITION_FAILED, REQUEST_ENTITY_TOO_LARGE,
                             UNSUPPORTED_CONTENT_FORMAT, INTERNAL_SERVER_ERROR };
 
     private int code;

--- a/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/ResponseCode.java
@@ -92,7 +92,19 @@ public class ResponseCode {
     }
 
     public boolean isError() {
-        return code >= 400;
+        return isClientError() || isServerError();
+    }
+
+    public boolean isSuccess() {
+        return (code / 100) == 2;
+    }
+
+    public boolean isClientError() {
+        return (code / 100) == 4;
+    }
+
+    public boolean isServerError() {
+        return (code / 100) == 5;
     }
 
     public static ResponseCode fromName(String name) {
@@ -119,5 +131,27 @@ public class ResponseCode {
             return String.format("%s(%d)", name, code);
         else
             return name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + code;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ResponseCode other = (ResponseCode) obj;
+        if (code != other.code)
+            return false;
+        return true;
     }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapDeleteResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapDeleteResponse.java
@@ -36,6 +36,18 @@ public class BootstrapDeleteResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.DELETED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("BootstrapDeleteResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapFinishResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapFinishResponse.java
@@ -36,6 +36,19 @@ public class BootstrapFinishResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CHANGED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.NOT_ACCEPTABLE_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("BootstrapFinishResponse [code=%s, errormessage=%s]", code, errorMessage);
@@ -51,6 +64,10 @@ public class BootstrapFinishResponse extends AbstractLwM2mResponse {
 
     public static BootstrapFinishResponse badRequest(String errorMessage) {
         return new BootstrapFinishResponse(ResponseCode.BAD_REQUEST, errorMessage);
+    }
+
+    public static BootstrapFinishResponse notAcceptable(String errorMessage) {
+        return new BootstrapFinishResponse(ResponseCode.NOT_ACCEPTABLE, errorMessage);
     }
 
     public static BootstrapFinishResponse internalServerError(String errorMessage) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapResponse.java
@@ -36,6 +36,18 @@ public class BootstrapResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CHANGED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("BootstrapResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapWriteResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapWriteResponse.java
@@ -36,6 +36,19 @@ public class BootstrapWriteResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CHANGED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNSUPPORTED_CONTENT_FORMAT_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("BootstrapWriteResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/CreateResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/CreateResponse.java
@@ -40,6 +40,22 @@ public class CreateResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CREATED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNAUTHORIZED_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
+        case ResponseCode.UNSUPPORTED_CONTENT_FORMAT_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("CreateResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/DeleteResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/DeleteResponse.java
@@ -19,7 +19,7 @@ import org.eclipse.leshan.ResponseCode;
 
 public class DeleteResponse extends AbstractLwM2mResponse {
 
-    public DeleteResponse(ResponseCode code, String errorMessage){
+    public DeleteResponse(ResponseCode code, String errorMessage) {
         this(code, errorMessage, null);
     }
 
@@ -30,6 +30,21 @@ public class DeleteResponse extends AbstractLwM2mResponse {
     @Override
     public boolean isSuccess() {
         return getCode() == ResponseCode.DELETED;
+    }
+
+    @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.DELETED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNAUTHORIZED_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
     }
 
     @Override

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/DeregisterResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/DeregisterResponse.java
@@ -33,6 +33,19 @@ public class DeregisterResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.DELETED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("DeregisterResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/DiscoverResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/DiscoverResponse.java
@@ -55,6 +55,21 @@ public class DiscoverResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CONTENT_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNAUTHORIZED_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("DiscoverResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/ExecuteResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/ExecuteResponse.java
@@ -33,6 +33,21 @@ public class ExecuteResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CHANGED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNAUTHORIZED_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("ExecuteResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/LwM2mResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/LwM2mResponse.java
@@ -55,4 +55,9 @@ public interface LwM2mResponse {
      * @return true if we get an error or unexpected code.
      */
     boolean isFailure();
+
+    /**
+     * @return true if we get a valid response code, a code expected by the LWM2M spec.
+     */
+    boolean isValid();
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/ObserveResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/ObserveResponse.java
@@ -21,6 +21,7 @@ import org.eclipse.leshan.ResponseCode;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
 import org.eclipse.leshan.core.observation.Observation;
+import org.eclipse.leshan.core.request.exception.InvalidResponseException;
 
 /**
  * Specialized ReadResponse to a Observe request, with the corresponding Observation.
@@ -42,6 +43,12 @@ public class ObserveResponse extends ReadResponse {
         super(code, timestampedValues != null && !timestampedValues.isEmpty() ? timestampedValues.get(0).getNode()
                 : content, errorMessage, coapResponse);
 
+        // CHANGED is out of spec but is supported for backward compatibility. (previous draft version)
+        if (ResponseCode.CHANGED.equals(code)) {
+            if (content == null)
+                throw new InvalidResponseException("Content is mandatory for successful response");
+        }
+
         this.observation = observation;
         this.timestampedValues = timestampedValues;
     }
@@ -52,7 +59,8 @@ public class ObserveResponse extends ReadResponse {
 
     @Override
     public boolean isSuccess() {
-        return getCode() == ResponseCode.CONTENT;
+        // CHANGED is out of spec but is supported for backward compatibility. (previous draft version)
+        return getCode().equals(ResponseCode.CONTENT) || getCode().equals(ResponseCode.CHANGED);
     }
 
     @Override

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/ReadResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/ReadResponse.java
@@ -49,6 +49,22 @@ public class ReadResponse extends AbstractLwM2mResponse {
         return getCode() == ResponseCode.CONTENT;
     }
 
+    @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CONTENT_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNAUTHORIZED_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
+        case ResponseCode.NOT_ACCEPTABLE_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     /**
      * Get the {@link LwM2mNode} value returned as response payload.
      *

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/RegisterResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/RegisterResponse.java
@@ -43,6 +43,20 @@ public class RegisterResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CREATED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.FORBIDDEN_CODE:
+        case ResponseCode.PRECONDITION_FAILED_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("RegisterResponse [code=%s, errormessage=%s]", code, errorMessage);
@@ -62,6 +76,10 @@ public class RegisterResponse extends AbstractLwM2mResponse {
 
     public static RegisterResponse forbidden(String errorMessage) {
         return new RegisterResponse(ResponseCode.FORBIDDEN, null, errorMessage);
+    }
+
+    public static RegisterResponse preconditionFailed(String errorMessage) {
+        return new RegisterResponse(ResponseCode.PRECONDITION_FAILED, null, errorMessage);
     }
 
     public static RegisterResponse internalServerError(String errorMessage) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/UpdateResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/UpdateResponse.java
@@ -33,6 +33,19 @@ public class UpdateResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CHANGED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("UpdateResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/WriteAttributesResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/WriteAttributesResponse.java
@@ -33,6 +33,21 @@ public class WriteAttributesResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CHANGED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNAUTHORIZED_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("WriteAttributesResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/WriteResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/WriteResponse.java
@@ -33,6 +33,24 @@ public class WriteResponse extends AbstractLwM2mResponse {
     }
 
     @Override
+    public boolean isValid() {
+        switch (code.getCode()) {
+        case ResponseCode.CHANGED_CODE:
+        case ResponseCode.BAD_REQUEST_CODE:
+        case ResponseCode.UNAUTHORIZED_CODE:
+        case ResponseCode.NOT_FOUND_CODE:
+        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
+        case ResponseCode.REQUEST_ENTITY_INCOMPLETE_CODE:
+        case ResponseCode.REQUEST_ENTITY_TOO_LARGE_CODE:
+        case ResponseCode.UNSUPPORTED_CONTENT_FORMAT_CODE:
+        case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
     public String toString() {
         if (errorMessage != null)
             return String.format("WriteResponse [code=%s, errormessage=%s]", code, errorMessage);

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/BootstrapResource.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.impl;
 
-import static org.eclipse.leshan.core.californium.ResponseCodeUtil.fromLwM2mCode;
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toCoapResponseCode;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -81,9 +81,9 @@ public class BootstrapResource extends CoapResource {
         // handle bootstrap request
         BootstrapResponse response = bootstrapHandler.bootstrap(clientIdentity, new BootstrapRequest(endpoint));
         if (response.isSuccess()) {
-            exchange.respond(fromLwM2mCode(response.getCode()));
+            exchange.respond(toCoapResponseCode(response.getCode()));
         } else {
-            exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+            exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
         }
     }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
@@ -84,30 +84,29 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
 
     @Override
     public void visit(ReadRequest request) {
-        switch (coapResponse.getCode()) {
-        case CONTENT:
+        if (coapResponse.isError()) {
+            // handle error response:
+            lwM2mresponse = new ReadResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
+                    coapResponse.getPayloadString(), coapResponse);
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT) {
+            // handle success response:
             LwM2mNode content = decodeCoapResponse(request.getPath(), coapResponse, request,
                     registration.getEndpoint());
             lwM2mresponse = new ReadResponse(ResponseCode.CONTENT, content, null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case UNAUTHORIZED:
-        case NOT_FOUND:
-        case METHOD_NOT_ALLOWED:
-        case NOT_ACCEPTABLE:
-        case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ReadResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
-                    coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(DiscoverRequest request) {
-        switch (coapResponse.getCode()) {
-        case CONTENT:
+        if (coapResponse.isError()) {
+            // handle error response:
+            lwM2mresponse = new DiscoverResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
+                    coapResponse.getPayloadString(), coapResponse);
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT) {
+            // handle success response:
             Link[] links;
             if (MediaTypeRegistry.APPLICATION_LINK_FORMAT != coapResponse.getOptions().getContentFormat()) {
                 LOG.debug("Expected LWM2M Client [{}] to return application/link-format [{}] content but got [{}]",
@@ -118,128 +117,98 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
                 links = Link.parse(coapResponse.getPayload());
             }
             lwM2mresponse = new DiscoverResponse(ResponseCode.CONTENT, links, null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case NOT_FOUND:
-        case UNAUTHORIZED:
-        case METHOD_NOT_ALLOWED:
-        case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new DiscoverResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
-                    coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(WriteRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            lwM2mresponse = new WriteResponse(ResponseCode.CHANGED, null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case NOT_FOUND:
-        case UNAUTHORIZED:
-        case METHOD_NOT_ALLOWED:
-        case UNSUPPORTED_CONTENT_FORMAT:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new WriteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
+            lwM2mresponse = new WriteResponse(ResponseCode.CHANGED, null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(WriteAttributesRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            lwM2mresponse = new WriteAttributesResponse(ResponseCode.CHANGED, null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case NOT_FOUND:
-        case UNAUTHORIZED:
-        case METHOD_NOT_ALLOWED:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new WriteAttributesResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
+            lwM2mresponse = new WriteAttributesResponse(ResponseCode.CHANGED, null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(ExecuteRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            lwM2mresponse = new ExecuteResponse(ResponseCode.CHANGED, null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case UNAUTHORIZED:
-        case NOT_FOUND:
-        case METHOD_NOT_ALLOWED:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new ExecuteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
+            lwM2mresponse = new ExecuteResponse(ResponseCode.CHANGED, null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
-
     }
 
     @Override
     public void visit(CreateRequest request) {
-        switch (coapResponse.getCode()) {
-        case CREATED:
-            lwM2mresponse = new CreateResponse(ResponseCode.CREATED, coapResponse.getOptions().getLocationPathString(),
-                    null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case UNAUTHORIZED:
-        case NOT_FOUND:
-        case METHOD_NOT_ALLOWED:
-        case UNSUPPORTED_CONTENT_FORMAT:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new CreateResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CREATED) {
+            // handle success response:
+            lwM2mresponse = new CreateResponse(ResponseCode.CREATED, coapResponse.getOptions().getLocationPathString(),
+                    null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(DeleteRequest request) {
-        switch (coapResponse.getCode()) {
-        case DELETED:
-            lwM2mresponse = new DeleteResponse(ResponseCode.DELETED, null, coapResponse);
-            break;
-        case UNAUTHORIZED:
-        case NOT_FOUND:
-        case METHOD_NOT_ALLOWED:
-        case BAD_REQUEST:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new DeleteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.DELETED) {
+            // handle success response:
+            lwM2mresponse = new DeleteResponse(ResponseCode.DELETED, null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(ObserveRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            // TODO now the spec say that NOTIFY should use 2.05 content so we should remove this.
-            // ignore changed response (this is probably a NOTIFY)
-            lwM2mresponse = null;
-            break;
-        case CONTENT:
+        if (coapResponse.isError()) {
+            // handle error response:
+            lwM2mresponse = new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode()), null, null, null,
+                    coapResponse.getPayloadString(), coapResponse);
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT
+                // This is for backward compatibility, when the spec say notification used CHANGED code
+                || coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
             LwM2mNode content = decodeCoapResponse(request.getPath(), coapResponse, request,
                     registration.getEndpoint());
             if (coapResponse.getOptions().hasObserve()) {
@@ -253,66 +222,53 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
             } else {
                 lwM2mresponse = new ObserveResponse(ResponseCode.CONTENT, content, null, null, null, coapResponse);
             }
-            break;
-        case BAD_REQUEST:
-        case UNAUTHORIZED:
-        case NOT_FOUND:
-        case METHOD_NOT_ALLOWED:
-        case NOT_ACCEPTABLE:
-        case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode()), null, null, null,
-                    coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(BootstrapWriteRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            lwM2mresponse = new BootstrapWriteResponse(ResponseCode.CHANGED, null, coapResponse);
-            break;
-        case UNSUPPORTED_CONTENT_FORMAT:
-        case BAD_REQUEST:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new BootstrapWriteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
+            lwM2mresponse = new BootstrapWriteResponse(ResponseCode.CHANGED, null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(BootstrapDeleteRequest request) {
-        switch (coapResponse.getCode()) {
-        case DELETED:
-            lwM2mresponse = new BootstrapDeleteResponse(ResponseCode.DELETED, null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new BootstrapDeleteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.DELETED) {
+            // handle success response:
+            lwM2mresponse = new BootstrapDeleteResponse(ResponseCode.DELETED, null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }
 
     @Override
     public void visit(BootstrapFinishRequest request) {
-        switch (coapResponse.getCode()) {
-        case CHANGED:
-            lwM2mresponse = new BootstrapFinishResponse(ResponseCode.CHANGED, null, coapResponse);
-            break;
-        case BAD_REQUEST:
-        case INTERNAL_SERVER_ERROR:
+        if (coapResponse.isError()) {
+            // handle error response:
             lwM2mresponse = new BootstrapFinishResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
-            break;
-        default:
+        } else if (coapResponse.getCode() == org.eclipse.californium.core.coap.CoAP.ResponseCode.CHANGED) {
+            // handle success response:
+            lwM2mresponse = new BootstrapFinishResponse(ResponseCode.CHANGED, null, coapResponse);
+        } else {
+            // handle unexpected response:
             handleUnexpectedResponseCode(registration.getEndpoint(), request, coapResponse);
         }
     }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
@@ -96,7 +96,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case NOT_ACCEPTABLE:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ReadResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new ReadResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -124,7 +124,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case UNAUTHORIZED:
         case METHOD_NOT_ALLOWED:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new DiscoverResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new DiscoverResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -144,7 +144,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case UNSUPPORTED_CONTENT_FORMAT:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new WriteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new WriteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -163,7 +163,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case UNAUTHORIZED:
         case METHOD_NOT_ALLOWED:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new WriteAttributesResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new WriteAttributesResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -182,7 +182,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case NOT_FOUND:
         case METHOD_NOT_ALLOWED:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ExecuteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new ExecuteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -204,7 +204,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case UNSUPPORTED_CONTENT_FORMAT:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new CreateResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new CreateResponse(toLwM2mResponseCode(coapResponse.getCode()), null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -223,7 +223,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new DeleteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new DeleteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -260,7 +260,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case NOT_ACCEPTABLE:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode().value), null, null, null,
+            lwM2mresponse = new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode()), null, null, null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -277,7 +277,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case UNSUPPORTED_CONTENT_FORMAT:
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapWriteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapWriteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -293,7 +293,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
             break;
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapDeleteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapDeleteResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -309,7 +309,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
             break;
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapFinishResponse(toLwM2mResponseCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapFinishResponse(toLwM2mResponseCode(coapResponse.getCode()),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
@@ -217,10 +217,11 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
                         request.getPath(), request.getContext());
                 observationService.addObservation(registration, observation);
                 // add the observation to an ObserveResponse instance
-                lwM2mresponse = new ObserveResponse(ResponseCode.CONTENT, content, null, observation, null,
-                        coapResponse);
+                lwM2mresponse = new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode()), content, null,
+                        observation, null, coapResponse);
             } else {
-                lwM2mresponse = new ObserveResponse(ResponseCode.CONTENT, content, null, null, null, coapResponse);
+                lwM2mresponse = new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode()), content, null, null,
+                        null, coapResponse);
             }
         } else {
             // handle unexpected response:

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LwM2mResponseBuilder.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.impl;
 
-import static org.eclipse.leshan.core.californium.ResponseCodeUtil.fromCoapCode;
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toLwM2mResponseCode;
 
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
@@ -96,7 +96,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case NOT_ACCEPTABLE:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ReadResponse(fromCoapCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new ReadResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -124,7 +124,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case UNAUTHORIZED:
         case METHOD_NOT_ALLOWED:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new DiscoverResponse(fromCoapCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new DiscoverResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -144,7 +144,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case UNSUPPORTED_CONTENT_FORMAT:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new WriteResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new WriteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -163,7 +163,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case UNAUTHORIZED:
         case METHOD_NOT_ALLOWED:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new WriteAttributesResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new WriteAttributesResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -182,7 +182,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case NOT_FOUND:
         case METHOD_NOT_ALLOWED:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ExecuteResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new ExecuteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -204,7 +204,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case UNSUPPORTED_CONTENT_FORMAT:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new CreateResponse(fromCoapCode(coapResponse.getCode().value), null,
+            lwM2mresponse = new CreateResponse(toLwM2mResponseCode(coapResponse.getCode().value), null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -223,7 +223,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new DeleteResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new DeleteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -260,7 +260,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case METHOD_NOT_ALLOWED:
         case NOT_ACCEPTABLE:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new ObserveResponse(fromCoapCode(coapResponse.getCode().value), null, null, null,
+            lwM2mresponse = new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode().value), null, null, null,
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -277,7 +277,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
         case UNSUPPORTED_CONTENT_FORMAT:
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapWriteResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapWriteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -293,7 +293,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
             break;
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapDeleteResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapDeleteResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:
@@ -309,7 +309,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
             break;
         case BAD_REQUEST:
         case INTERNAL_SERVER_ERROR:
-            lwM2mresponse = new BootstrapFinishResponse(fromCoapCode(coapResponse.getCode().value),
+            lwM2mresponse = new BootstrapFinishResponse(toLwM2mResponseCode(coapResponse.getCode().value),
                     coapResponse.getPayloadString(), coapResponse);
             break;
         default:

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/ObservationServiceImpl.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/ObservationServiceImpl.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.impl;
 
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toLwM2mResponseCode;
 import static org.eclipse.leshan.server.californium.impl.CoapRequestBuilder.CTX_REGID;
 
 import java.util.Collection;
@@ -30,7 +31,6 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObservationStore;
-import org.eclipse.leshan.ResponseCode;
 import org.eclipse.leshan.core.model.LwM2mModel;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
@@ -252,7 +252,7 @@ public class ObservationServiceImpl implements ObservationService, NotificationL
     }
 
     private ObserveResponse createObserveResponse(Observation observation, LwM2mModel model, Response coapResponse) {
-        // // We handle CONTENT and CHANGED response only
+        // CHANGED response is supported for backward compatibility with old spec.
         if (coapResponse.getCode() != CoAP.ResponseCode.CHANGED
                 && coapResponse.getCode() != CoAP.ResponseCode.CONTENT) {
             throw new InvalidResponseException("Unexpected response code [%s] for %s", coapResponse.getCode(),
@@ -272,11 +272,11 @@ public class ObservationServiceImpl implements ObservationService, NotificationL
 
             // create lwm2m response
             if (timestampedNodes.size() == 1 && !timestampedNodes.get(0).isTimestamped()) {
-                return new ObserveResponse(ResponseCode.CONTENT, timestampedNodes.get(0).getNode(), null, observation,
-                        null, coapResponse);
+                return new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode()),
+                        timestampedNodes.get(0).getNode(), null, observation, null, coapResponse);
             } else {
-                return new ObserveResponse(ResponseCode.CONTENT, null, timestampedNodes, observation, null,
-                        coapResponse);
+                return new ObserveResponse(toLwM2mResponseCode(coapResponse.getCode()), null, timestampedNodes,
+                        observation, null, coapResponse);
             }
         } catch (CodecException e) {
             if (LOG.isDebugEnabled()) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -16,7 +16,7 @@
 package org.eclipse.leshan.server.californium.impl;
 
 import static org.eclipse.leshan.core.californium.ExchangeUtil.extractIdentity;
-import static org.eclipse.leshan.core.californium.ResponseCodeUtil.fromLwM2mCode;
+import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toCoapResponseCode;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
@@ -195,7 +195,7 @@ public class RegisterResource extends CoapResource {
             exchange.setLocationPath(RESOURCE_NAME + "/" + response.getRegistrationID());
             exchange.respond(ResponseCode.CREATED);
         } else {
-            exchange.respond(fromLwM2mCode(response.getCode()), response.getErrorMessage());
+            exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
         }
         sendableResponse.sent();
     }
@@ -228,7 +228,7 @@ public class RegisterResource extends CoapResource {
         UpdateResponse updateResponse = sendableResponse.getResponse();
 
         // Create CoAP Response from LwM2m request
-        exchange.respond(fromLwM2mCode(updateResponse.getCode()), updateResponse.getErrorMessage());
+        exchange.respond(toCoapResponseCode(updateResponse.getCode()), updateResponse.getErrorMessage());
         sendableResponse.sent();
     }
 
@@ -245,7 +245,7 @@ public class RegisterResource extends CoapResource {
         DeregisterResponse deregisterResponse = sendableResponse.getResponse();
 
         // Create CoAP Response from LwM2m request
-        exchange.respond(fromLwM2mCode(deregisterResponse.getCode()), deregisterResponse.getErrorMessage());
+        exchange.respond(toCoapResponseCode(deregisterResponse.getCode()), deregisterResponse.getErrorMessage());
         sendableResponse.sent();
     }
 

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/serialization/ResponseSerDes.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/serialization/ResponseSerDes.java
@@ -82,7 +82,7 @@ public class ResponseSerDes {
         String sCode = o.getString("code", null);
         if (sCode == null)
             throw new IllegalStateException("Invalid response missing code attribute");
-        ResponseCode code = Enum.valueOf(ResponseCode.class, sCode);
+        ResponseCode code = ResponseCode.fromName(sCode);
 
         String errorMessage = o.getString("errorMessage", null);
 

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/ResponseSerializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/ResponseSerializer.java
@@ -33,12 +33,14 @@ public class ResponseSerializer implements JsonSerializer<LwM2mResponse> {
         JsonObject element = new JsonObject();
 
         element.addProperty("status", src.getCode().toString());
+        element.addProperty("valid", src.isValid());
+        element.addProperty("success", src.isSuccess());
+        element.addProperty("failure", src.isFailure());
 
         if (typeOfSrc instanceof Class<?>) {
             if (ReadResponse.class.isAssignableFrom((Class<?>) typeOfSrc)) {
                 element.add("content", context.serialize(((ReadResponse) src).getContent()));
-            }
-            else if (DiscoverResponse.class.isAssignableFrom((Class<?>) typeOfSrc)) {
+            } else if (DiscoverResponse.class.isAssignableFrom((Class<?>) typeOfSrc)) {
                 element.add("objectLinks", context.serialize(((DiscoverResponse) src).getObjectLinks()));
             }
         }

--- a/leshan-server-demo/src/main/resources/webapp/index.html
+++ b/leshan-server-demo/src/main/resources/webapp/index.html
@@ -25,6 +25,7 @@
     <script src="js/resource-directives.js"></script>
     <script src="js/resource-form-directives.js"></script>
     <script src="js/ui-dialog-services.js"></script>
+    <script src="js/helper-services.js"></script>
 </head>
 
 <body>

--- a/leshan-server-demo/src/main/resources/webapp/js/app.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/app.js
@@ -30,6 +30,7 @@ var leshanApp = angular.module('leshanApp',[
         'uiDialogServices',
         'modalInstanceControllers',
         'ui.bootstrap',
+        'helperServices',
 ]);
 
 leshanApp.config(['$routeProvider', '$locationProvider', function($routeProvider, $locationProvider) {

--- a/leshan-server-demo/src/main/resources/webapp/js/helper-services.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/helper-services.js
@@ -22,8 +22,18 @@ myModule.factory('helper', ["$filter", function($filter) {
   serviceInstance.handleResponse = function (response, lwm2mNode, successCallback) {
 	  lwm2mNode.date = new Date();
       var formattedDate = $filter('date')(lwm2mNode.date, 'HH:mm:ss.sss');
-      lwm2mNode.status = response.status;
-      lwm2mNode.tooltip = formattedDate + "<br/>" + lwm2mNode.status;
+      if (!response.valid){
+    	  lwm2mNode.status = "INVALID";  
+      }else if (response.success){
+    	  lwm2mNode.status = "SUCCESS";
+      }else {
+    	  lwm2mNode.status = "ERROR";
+      }
+      
+      if (response.valid)
+    	  lwm2mNode.tooltip = formattedDate + "<br/>" + response.status ;
+      else
+    	  lwm2mNode.tooltip = formattedDate + "<br/> Not LWM2M Code <br/>" + response.status;
       
       if (successCallback && response.success) {
     	  successCallback(formattedDate);

--- a/leshan-server-demo/src/main/resources/webapp/js/helper-services.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/helper-services.js
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+
+var myModule = angular.module('helperServices', []);
+
+myModule.factory('helper', ["$filter", function($filter) {
+  var serviceInstance = {};
+  
+  serviceInstance.handleResponse = function (response, lwm2mNode, successCallback) {
+	  lwm2mNode.date = new Date();
+      var formattedDate = $filter('date')(lwm2mNode.date, 'HH:mm:ss.sss');
+      lwm2mNode.status = response.status;
+      lwm2mNode.tooltip = formattedDate + "<br/>" + lwm2mNode.status;
+      
+      if (successCallback && response.success) {
+    	  successCallback(formattedDate);
+      }
+  };
+  return serviceInstance;
+}]);

--- a/leshan-server-demo/src/main/resources/webapp/js/instance-directives.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/instance-directives.js
@@ -41,7 +41,7 @@ angular.module('instanceDirectives', [])
                 $http.get(uri, {params:{format:format}})
                 .success(function(data, status, headers, config) {
                 	helper.handleResponse(data, scope.instance.read, function (formattedDate){
-	                    if (data.status == "CONTENT" && data.content) {
+	                    if (data.success && data.content) {
 	                        for(var i in data.content.resources) {
 	                            var tlvresource = data.content.resources[i];
 	                            resource = lwResources.addResource(scope.parent, scope.instance, tlvresource.id, null);
@@ -76,7 +76,7 @@ angular.module('instanceDirectives', [])
                 .success(function(data, status, headers, config) {
                 	helper.handleResponse(data, scope.instance.del, function (formattedDate){
 	                    // manage delete instance in resource tree.
-	                    if (data.status == "DELETED") {
+	                    if (data.success) {
 	                        scope.parent.instances.splice(scope.instance,1);
 	                    }
                 	});
@@ -117,7 +117,7 @@ angular.module('instanceDirectives', [])
                     $http({method: 'PUT', url: "api/clients/" + $routeParams.clientId + scope.instance.path, data: payload, headers:{'Content-Type': 'application/json'}, params:{format:format}})
                     .success(function(data, status, headers, config) {
                     	helper.handleResponse(data, scope.instance.write, function (formattedDate) {
-	                        if (data.status == "CHANGED") {
+	                        if (data.success) {
 	                            for (var i in payload.resources) {
 	                                var tlvresource = payload.resources[i];
 	                                resource = lwResources.addResource(scope.parent, scope.instance, tlvresource.id, null);
@@ -142,7 +142,7 @@ angular.module('instanceDirectives', [])
                 $http.post(uri, null, {params:{format:format}})
                 .success(function(data, status, headers, config) {
                 	helper.handleResponse(data, scope.instance.observe, function (formattedDate) {
-	                    if (data.status == "CONTENT") {
+	                    if (data.success) {
 	                        scope.instance.observed = true;
 	
 	                        for(var i in data.content.resources) {

--- a/leshan-server-demo/src/main/resources/webapp/js/instance-directives.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/instance-directives.js
@@ -77,7 +77,10 @@ angular.module('instanceDirectives', [])
                 	helper.handleResponse(data, scope.instance.del, function (formattedDate){
 	                    // manage delete instance in resource tree.
 	                    if (data.success) {
-	                        scope.parent.instances.splice(scope.instance,1);
+	                    	var i = scope.parent.instances.indexOf(scope.instance);
+	                    	if(i != -1) {
+	                    		scope.parent.instances.splice(i, 1);
+	                    	}
 	                    }
                 	});
                 }).error(function(data, status, headers, config) {

--- a/leshan-server-demo/src/main/resources/webapp/js/object-directives.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/object-directives.js
@@ -64,7 +64,7 @@ angular.module('objectDirectives', [])
                     $http({method: 'POST', url: "api/clients/" + $routeParams.clientId + instancepath, data: payload, headers:{'Content-Type': 'application/json'}, params:{format:format}})
                     .success(function(data, status, headers, config) {
                     	helper.handleResponse(data, scope.object.create, function (formattedDate) {
-	                        if (data.status == "CREATED") {
+	                        if (data.success) {
 	                            var newinstance = lwResources.addInstance(scope.object, instance.id, null);
 	                            for (var i in payload.resources) {
 	                                var tlvresource = payload.resources[i];

--- a/leshan-server-demo/src/main/resources/webapp/js/object-directives.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/object-directives.js
@@ -16,7 +16,7 @@
 
 angular.module('objectDirectives', [])
 
-.directive('object', function ($compile, $routeParams, $http, dialog,$filter,$modal,lwResources) {
+.directive('object', function ($compile, $routeParams, $http, dialog, $filter, $modal, lwResources, helper) {
     return {
         restrict: "E",
         replace: true,
@@ -63,22 +63,18 @@ angular.module('objectDirectives', [])
                     var instancepath  = scope.object.path;
                     $http({method: 'POST', url: "api/clients/" + $routeParams.clientId + instancepath, data: payload, headers:{'Content-Type': 'application/json'}, params:{format:format}})
                     .success(function(data, status, headers, config) {
-                        create = scope.object.create;
-                        create.date = new Date();
-                        var formattedDate = $filter('date')(create.date, 'HH:mm:ss.sss');
-                        create.status = data.status;
-                        create.tooltip = formattedDate + "<br/>" + create.status;
-                        
-                        if (data.status == "CREATED") {
-                            var newinstance = lwResources.addInstance(scope.object, instance.id, null);
-                            for (var i in payload.resources) {
-                                var tlvresource = payload.resources[i];
-                                resource = lwResources.addResource(scope.object, newinstance, tlvresource.id, null);
-                                resource.value = tlvresource.value;
-                                resource.valuesupposed = true;
-                                resource.tooltip = formattedDate;
-                            }
-                        }
+                    	helper.handleResponse(data, scope.object.create, function (formattedDate) {
+	                        if (data.status == "CREATED") {
+	                            var newinstance = lwResources.addInstance(scope.object, instance.id, null);
+	                            for (var i in payload.resources) {
+	                                var tlvresource = payload.resources[i];
+	                                resource = lwResources.addResource(scope.object, newinstance, tlvresource.id, null);
+	                                resource.value = tlvresource.value;
+	                                resource.valuesupposed = true;
+	                                resource.tooltip = formattedDate;
+	                            }
+	                        }
+                    	});
                     }).error(function(data, status, headers, config) {
                         errormessage = "Unable to create instance " + instancepath + " for "+ $routeParams.clientId + " : " + status +" "+ data;
                         dialog.open(errormessage);

--- a/leshan-server-demo/src/main/resources/webapp/js/resource-directives.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/resource-directives.js
@@ -65,7 +65,7 @@ angular.module('resourceDirectives', [])
                 $http.post(uri, null,{params:{format:format}})
                 .success(function(data, status, headers, config) {
                 	helper.handleResponse(data, scope.resource.observe, function (formattedDate){
-                		if (data.status == "CONTENT") {
+                		if (data.success) {
                             scope.resource.observed = true;
                             if("value" in data.content) {
                                 // single value
@@ -111,7 +111,7 @@ angular.module('resourceDirectives', [])
                 .success(function(data, status, headers, config) {
                     // manage request information
                 	helper.handleResponse(data, scope.resource.read, function (formattedDate){
-                		if (data.status == "CONTENT" && data.content) {
+                		if (data.success && data.content) {
                             if("value" in data.content) {
                                 // single value
                                 scope.resource.value = data.content.value;
@@ -155,7 +155,7 @@ angular.module('resourceDirectives', [])
                         $http({method: 'PUT', url: "api/clients/" + $routeParams.clientId + scope.resource.path, data: rsc, headers:{'Content-Type': 'application/json'},params:{format:format}})
                         .success(function(data, status, headers, config) {
                         	helper.handleResponse(data, scope.resource.write, function (formattedDate){
-                        		if (data.status == "CHANGED") {
+                        		if (data.success) {
                                     scope.resource.value = value;
                                     scope.resource.valuesupposed = true;
                                     scope.resource.tooltip = formattedDate;

--- a/leshan-server-demo/src/main/resources/webapp/partials/instance.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/instance.html
@@ -12,8 +12,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': instance.observe.status == null,
-								'btn-danger': instance.observe.status != null && instance.observe.status != 'CONTENT',
-								'btn-success': instance.observe.status == 'CONTENT' }">Observe <span class="glyphicon glyphicon-play"></span></button>
+								'btn-danger': instance.observe.status == 'ERROR',
+								'btn-warning': instance.observe.status == 'INVALID',
+								'btn-success': instance.observe.status == 'SUCCESS'}">Observe <span class="glyphicon glyphicon-play"></span></button>
 					<button type="button" ng-click="stopObserve()"
 							ng-class="{
 								'btn': true,
@@ -28,8 +29,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': instance.read.status == null,
-								'btn-danger': instance.read.status != null && instance.read.status != 'CONTENT',
-								'btn-success': instance.read.status == 'CONTENT' }">Read</button>
+								'btn-danger': instance.read.status == 'ERROR',
+								'btn-warning': instance.read.status == 'INVALID',
+								'btn-success': instance.read.status == 'SUCCESS'}">Read</button>
 				</div>
 				<div class="btn-group">
 					<button type="button" ng-click="instance.write.status = null; write()"
@@ -38,8 +40,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': instance.write.status == null,
-								'btn-danger': instance.write.status != null && instance.write.status != 'CHANGED',
-								'btn-success': instance.write.status == 'CHANGED' }">Write</button>
+								'btn-danger': instance.write.status == 'ERROR',
+								'btn-warning': instance.write.status == 'INVALID',
+								'btn-success': instance.write.status == 'SUCCESS'}">Write</button>
 				</div>
 				<div class="btn-group">
 					<button type="button" ng-click="instance.del.status = null; del()"
@@ -48,8 +51,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': instance.del.status == null,
-								'btn-danger': instance.del.status != null && instance.del.status != 'DELETED',
-								'btn-success': instance.del.status == 'DELETED' }">Delete</button>
+								'btn-danger': instance.del.status == 'ERROR',
+								'btn-warning': instance.del.status == 'INVALID',
+								'btn-success': instance.del.status == 'SUCCESS'}">Delete</button>
 				</div>
 			</div>
 		</div>

--- a/leshan-server-demo/src/main/resources/webapp/partials/object.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/object.html
@@ -19,8 +19,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': object.create.status == null,
-								'btn-danger': object.create.status != null && object.create.status != 'CREATED',
-								'btn-success': object.create.status == 'CREATED' }">Create New Instance</button>
+								'btn-danger': object.create.status == 'ERROR',
+								'btn-warning': object.create.status == 'INVALID',
+								'btn-success': object.create.status == 'SUCCESS' }">Create New Instance</button>
 				</div>
 			</div>
 		</div>

--- a/leshan-server-demo/src/main/resources/webapp/partials/resource.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/resource.html
@@ -12,8 +12,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': resource.observe.status == null,
-								'btn-danger': resource.observe.status != null && resource.observe.status != 'CONTENT',
-								'btn-success': resource.observe.status == 'CONTENT' }">Observe <span class="glyphicon glyphicon-play"></span></button>
+								'btn-danger': resource.observe.status == 'ERROR',
+								'btn-warning': resource.observe.status == 'INVALID',
+								'btn-success': resource.observe.status == 'SUCCESS' }">Observe <span class="glyphicon glyphicon-play"></span></button>
 					<button type="button" ng-click="stopObserve()"
 							ng-class="{
 								'btn': true,
@@ -28,8 +29,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': resource.read.status == null,
-								'btn-danger': resource.read.status != null && resource.read.status != 'CONTENT',
-								'btn-success': resource.read.status == 'CONTENT' }">Read</button>
+								'btn-danger': resource.read.status == 'ERROR',
+								'btn-warning': resource.read.status == 'INVALID',
+								'btn-success': resource.read.status == 'SUCCESS' }">Read</button>
 				</div>
 				<div ng-show="writable()" class="btn-group">
 					<button type="button" ng-click="resource.write.status = null; write()"
@@ -38,8 +40,9 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': resource.write.status == null,
-								'btn-danger': resource.write.status != null && resource.write.status != 'CHANGED',
-								'btn-success': resource.write.status == 'CHANGED' }">Write</button>
+								'btn-danger': resource.write.status == 'ERROR',
+								'btn-warning': resource.write.status == 'INVALID',
+								'btn-success': resource.write.status == 'SUCCESS' }">Write</button>
 				</div>
 				<div ng-show="executable()" class="btn-group">
 					<button type="button" ng-click="resource.exec.status = null; exec();"
@@ -48,16 +51,18 @@
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': resource.exec.status == null,
-								'btn-danger':  resource.exec.status != null && resource.exec.status != 'CHANGED',
-								'btn-success': resource.exec.status == 'CHANGED' }">Exec</button>
+								'btn-danger': resource.exec.status == 'ERROR',
+								'btn-warning': resource.exec.status == 'INVALID',
+								'btn-success': resource.exec.status == 'SUCCESS' }">Exec</button>
 					<button type="button" ng-click="resource.exec.status = null; execWithParams();"
 							tooltip-html-unsafe={{resource.execwithparams.tooltip}} tooltip-placement="right" tooltip-animation="false" tooltip-append-to-body="true"
 							ng-class="{
 								'btn': true,
 								'btn-xs': true,
 								'btn-default': resource.exec.status == null,
-								'btn-danger':  resource.exec.status != null && resource.exec.status != 'CHANGED',
-								'btn-success': resource.exec.status == 'CHANGED' }"><span class="glyphicon glyphicon-cog"></span></button>
+								'btn-danger': resource.exec.status == 'ERROR',
+								'btn-warning': resource.exec.status == 'INVALID',
+								'btn-success': resource.exec.status == 'SUCCESS' }"><span class="glyphicon glyphicon-cog"></span></button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
It is now possible to use response codes which are not explicitly defined in the lwm2m specification.

We are still strict on success response expected, if we don't receive the good one an `InvalidResponseException` is still raised.

But now any error codes (accepted by californium) is accepted.

Generally for interoperability, we aim **lenient on input, strict on output** but it seems that [nowadays this make no more consensus](https://softwareengineering.stackexchange.com/questions/152533/should-a-server-be-lenient-in-what-it-accepts-and-discard-faulty-input-silent).   

So I'm still asking myself if this tolerance at  leshan-server-demo is a good thing. Accepting silently not compliant response from the client is maybe not a good idea. 