### PR TITLE
Added version and urn to ObjectModel

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModel.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModel.java
@@ -31,23 +31,41 @@ public class ObjectModel {
 
     private static final Logger LOG = LoggerFactory.getLogger(ObjectModel.class);
 
+	private static final String DEFAULT_VERSION = "1.0";
+
     public final int id;
     public final String name;
+    public final String version;
+    public final String urn;
     public final String description;
     public final boolean multiple;
     public final boolean mandatory;
 
     public final Map<Integer, ResourceModel> resources; // resources by ID
 
+    @Deprecated
     public ObjectModel(int id, String name, String description, boolean multiple, boolean mandatory,
             ResourceModel... resources) {
         this(id, name, description, multiple, mandatory, Arrays.asList(resources));
     }
 
+    @Deprecated
     public ObjectModel(int id, String name, String description, boolean multiple, boolean mandatory,
+            Collection<ResourceModel> resources) {
+    	this(id, name, DEFAULT_VERSION, null, description, multiple, mandatory, resources);
+    }
+
+    public ObjectModel(int id, String name, String version, String urn, String description, boolean multiple, boolean mandatory,
+            ResourceModel... resources) {
+    	this(id, name, version, urn, description, multiple, mandatory, Arrays.asList(resources));
+    }
+    
+    public ObjectModel(int id, String name, String version, String urn, String description, boolean multiple, boolean mandatory,
             Collection<ResourceModel> resources) {
         this.id = id;
         this.name = name;
+        this.version = version;
+        this.urn = urn;
         this.description = description;
         this.multiple = multiple;
         this.mandatory = mandatory;


### PR DESCRIPTION
We are in need of versioning and URN info on object models, since we're building a client and server that needs to be able to handle multiple Lwm2m object versions simultaneously. This pull request just displays what we need in the ObjectModel class, this will of course have effects on other code as well, e.g. including version attribute in Link objects when building a LeshanClient etc.

I still haven't come very far in this. What are the implications? Is somebody else working on it?