### PR TITLE
Enabled ability to force registration update

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -214,4 +214,8 @@ public class LeshanClient implements LwM2mClient {
     public String getRegistrationId() {
         return engine.getRegistrationId();
     }
+    
+    public RegistrationEngine getRegistrationEngine() {
+        return engine;
+    }
 }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -176,6 +176,10 @@ public class LeshanClient implements LwM2mClient {
         LOG.info("Leshan client destroyed.");
     }
 
+    public void triggerRegistrationUpdate() {
+        engine.triggerRegistrationUpdate();
+    }
+    
     @Override
     public Collection<LwM2mObjectEnabler> getObjectEnablers() {
         return Collections.unmodifiableCollection(new ArrayList<>(objectEnablers.values()));
@@ -213,9 +217,5 @@ public class LeshanClient implements LwM2mClient {
      */
     public String getRegistrationId() {
         return engine.getRegistrationId();
-    }
-    
-    public RegistrationEngine getRegistrationEngine() {
-        return engine;
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
@@ -383,10 +383,14 @@ public class RegistrationEngine {
         }
     }
 
-    public void forceUpdate() {
-        cancelUpdateTask(false);
-        LOG.info("Forcing update of registration...");
-        updateFuture = schedExecutor.schedule(new UpdateRegistrationTask(), 100, TimeUnit.MILLISECONDS);
+    public void triggerRegistrationUpdate() {
+        synchronized (this) {
+            if (started) {
+                cancelUpdateTask(true);
+                LOG.info("Triggering registration update...");
+                schedExecutor.submit(new UpdateRegistrationTask());
+            }
+        }
     }
     
     /**

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
@@ -383,6 +383,12 @@ public class RegistrationEngine {
         }
     }
 
+    public void forceUpdate() {
+        cancelUpdateTask(false);
+        LOG.info("Forcing update of registration...");
+        updateFuture = schedExecutor.schedule(new UpdateRegistrationTask(), 100, TimeUnit.MILLISECONDS);
+    }
+    
     /**
      * @return the current registration Id or <code>null</code> if the client is not registered.
      */


### PR DESCRIPTION
For a LwM2m Server instance to be able to react on a Registration Update execute request, there needs to be a mechanism that can reschedule the update registration to occur immediately.

Signed-off-by: Daniel Persson <daniel.p.persson@husqvarnagroup.com>