### PR TITLE
Observe support in object and instance enablers

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
@@ -63,10 +63,13 @@ public class BaseInstanceEnabler implements LwM2mInstanceEnabler {
 
     @Override
     public ObserveResponse observe(int resourceid) {
-        return ObserveResponse.notFound();
+        // Perform a read by default
+        ReadResponse readResponse = this.read(resourceid);
+        return ObserveResponse.success(readResponse.getContent());
     }
 
     @Override
     public void reset(int resourceid) {
+        // No default behavior
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
 
@@ -61,7 +62,11 @@ public class BaseInstanceEnabler implements LwM2mInstanceEnabler {
     }
 
     @Override
-    public void reset(int resourceid) {
+    public ObserveResponse observe(int resourceid) {
+        return ObserveResponse.notFound();
     }
 
+    @Override
+    public void reset(int resourceid) {
+    }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -348,8 +348,9 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     protected ObserveResponse doObserve(ServerIdentity identity, ObserveRequest request) {
-        // This should be a not implemented error, but this is not defined in the spec.
-        return ObserveResponse.internalServerError("not implemented");
+        ReadResponse readResponse = this.read(identity, new ReadRequest(request.getPath().toString()));
+        return new ObserveResponse(readResponse.getCode(), readResponse.getContent(), null, null,
+                   readResponse.getErrorMessage());
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
@@ -20,6 +20,7 @@ package org.eclipse.leshan.client.resource;
 
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
 
@@ -88,6 +89,15 @@ public interface LwM2mInstanceEnabler {
      *         execute the operation.
      */
     ExecuteResponse execute(int resourceid, String params);
+
+    /**
+     * Performs an observe register or deregister on one of this LWM2M object
+     * instance's resources.
+     *
+     * @param resourceid
+     *            the ID of the resource to set the value for
+     */
+    ObserveResponse observe(int resourceid);
 
     /**
      * Reset the current value of one of this LWM2M object instance's resources. Only used for implementation of REPLACE

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -36,6 +36,7 @@ import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.CreateRequest;
 import org.eclipse.leshan.core.request.DeleteRequest;
 import org.eclipse.leshan.core.request.ExecuteRequest;
+import org.eclipse.leshan.core.request.ObserveRequest;
 import org.eclipse.leshan.core.request.ReadRequest;
 import org.eclipse.leshan.core.request.WriteRequest;
 import org.eclipse.leshan.core.request.WriteRequest.Mode;
@@ -43,6 +44,7 @@ import org.eclipse.leshan.core.response.BootstrapWriteResponse;
 import org.eclipse.leshan.core.response.CreateResponse;
 import org.eclipse.leshan.core.response.DeleteResponse;
 import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
 
@@ -128,6 +130,30 @@ public class ObjectEnabler extends BaseObjectEnabler {
 
         // Manage Resource case
         return instance.read(path.getResourceId());
+    }
+
+    @Override
+    protected ObserveResponse doObserve(final ServerIdentity identity, final ObserveRequest request) {
+        final LwM2mPath path = request.getPath();
+
+        // Manage Object case
+        if (path.isObject()) {
+            // TODO Enable object level observe support (if ever necessary)
+            return ObserveResponse.internalServerError("not implemented");
+        }
+
+        // Manage Instance case
+        final LwM2mInstanceEnabler instance = instances.get(path.getObjectInstanceId());
+        if (instance == null)
+            return ObserveResponse.notFound();
+
+        if (path.getResourceId() == null) {
+            // TODO Enable instance level observe support
+            return ObserveResponse.internalServerError("not implemented");
+        }
+
+        // Manage Resource case
+        return instance.observe(path.getResourceId());
     }
 
     LwM2mObjectInstance getLwM2mObjectInstance(int instanceid, LwM2mInstanceEnabler instance, ServerIdentity identity) {
@@ -243,6 +269,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
 
     private void listenInstance(LwM2mInstanceEnabler instance, final int instanceId) {
         instance.addResourceChangedListener(new ResourceChangedListener() {
+
             @Override
             public void resourcesChanged(int... resourceIds) {
                 NotifySender sender = getNotifySender();


### PR DESCRIPTION
These changes add an observe method to the LwM2mInstanceEnabler interface, and default behavior to the base classes that implement it.

Signed-off-by: Daniel Persson <daniel.p.persson@husqvarnagroup.com>