### PR TITLE
Add snapcraft build files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,32 @@
+name: leshan
+version: '1.0.0'
+summary: Eclipse Leshan is an OMA Lightweight M2M server and client Java implementation
+description: |
+  Leshan provides libraries which help people to develop their own Lightweight M2M server and client.
+  The project also provides a client, a server and a bootstrap server demonstration as an example of 
+  the Leshan API and for testing purpose.
+
+grade: stable
+confinement: strict
+
+apps:
+  server:
+    command: bin/server.sh
+    plugs: [network-bind, network]
+  bootstrap:
+    command: bin/bootstrap.sh
+    plugs: [network-bind, network]
+  client:
+    command: bin/client.sh
+    plugs: [network]
+
+parts:
+  leshan:
+    plugin: maven
+    maven-options: [-Pall]
+    maven-targets: [leshan-server-demo, leshan-bsserver-demo, leshan-client-demo]
+  bin:
+    source: snap/bin
+    plugin: dump
+    organize:
+      "*": bin/


### PR DESCRIPTION
Adding the build files to create a snap that can be installed on multiple platforms (see [snapcraft.io](http://snapcraft.io)). This will make Leshan simpler for users to try out. Once the snap is built and installed it provides three commands:

```
leshan.server
leshan.bootstrap
leshan.client
```
Which are the demo server, bootstrap server and client.

The snap can be built and published on the Ubuntu Snap Store, which will make it available to install on any system that has snapd installed via:
```
snap install leshan
```

Signed-off-by: James Jesudason <james.jesudason@gmail.com>

