### PR TITLE
Make redis data format compatibility break less painfull 

### DIFF
--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
@@ -75,12 +75,21 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisRegistrationStore.class);
 
+    // This prefix to handle compatibility break in the way we serialize registration/observation in store
+    private static final String NAMESPACE = "LSNRS"; // a namespace to easily identify Leshan Registration Store Key.
+    private static final String VERSION = "1"; // a version to increment when, compatibility is broken.
+    private static final String PREFIX = NAMESPACE + VERSION + ":";
+    // If version is incremented meaning there is a compatibility break, old registrations/observations will not be
+    // available in Leshan anymore. This will be like if there was removed. So device will need to register again.
+    // Old keys will stay in redis. You should remove it manually or wait until their expiration if you're using it.
+
     // Redis key prefixes
-    private static final String REG_EP = "REG:EP:";
-    private static final String REG_EP_REGID_IDX = "EP:REGID:"; // secondary index key (registration)
-    private static final String LOCK_EP = "LOCK:EP:";
-    private static final byte[] OBS_TKN = "OBS:TKN:".getBytes(UTF_8);
-    private static final String OBS_TKNS_REGID_IDX = "TKNS:REGID:"; // secondary index (token list by registration)
+    private static final String REG_EP = PREFIX + "REG:EP:";
+    private static final String REG_EP_REGID_IDX = PREFIX + "EP:REGID:"; // secondary index key (registration)
+    private static final String LOCK_EP = PREFIX + "LOCK:EP:";
+    private static final byte[] OBS_TKN = (PREFIX + "OBS:TKN:").getBytes(UTF_8);
+    private static final String OBS_TKNS_REGID_IDX = PREFIX + "TKNS:REGID:"; // secondary index
+                                                                             // (token list by registration)
 
     private final Pool<Jedis> pool;
 


### PR DESCRIPTION
In #440 we change the format using to serialize registration and observation in RedisRegistrationStore.

We already warn that RedisRegistrationStore is just an experimental works, so this kind of break would happen again.

I propose this PR to limit the migration painfulness.
The idea is that registration and observation are kind of "session" data. So for the rare case where this break occurred. Just ignoring old key could be acceptable.
That's why I introduce key prefix for RedisRegistrationStore in 2nd commit.
The first one add "optional" expiration for all redis key, this avoid to remove keys manually.

I'm aware this is not so great, but I think this could help.