### PR TITLE
LwM2m Request Sender for Queue Mode

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/QueueModeLwM2mRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/QueueModeLwM2mRequestSender.java
@@ -15,9 +15,6 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.impl;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.eclipse.leshan.core.request.DownlinkRequest;
 import org.eclipse.leshan.core.request.exception.TimeoutException;
 import org.eclipse.leshan.core.response.ErrorCallback;
@@ -55,26 +52,45 @@ public class QueueModeLwM2mRequestSender implements LwM2mRequestSender {
     public <T extends LwM2mResponse> T send(final Registration destination, DownlinkRequest<T> request, long timeout)
             throws InterruptedException {
 
+        // If the client does not use Q-Mode, just send
+        if (!destination.usesQueueMode()) {
+            return delegatedSender.send(destination, request, timeout);
+        }
+
+        // If the client uses Q-Mode...
+
         // If the client is sleeping, warn the user and return
         if (!presenceService.isClientAwake(destination)) {
             LOG.info("The destination client is sleeping, request couldn't been sent.");
             return null;
         }
 
-        // Create a response callback to use the asynchronous send method in a synchronous way
-        ResponseCallbackQueueModeSynchronous<T> synchronousResponseCallback = new ResponseCallbackQueueModeSynchronous<T>(
-                presenceService, destination);
-
         // Use delegation to send the request
-        delegatedSender.send(destination, request, timeout, synchronousResponseCallback, synchronousResponseCallback);
+        T response = delegatedSender.send(destination, request, timeout);
+        if (response != null) {
 
+            // Set the client awake. This will restart the timer.
+            presenceService.setAwake(destination);
+        } else {
+
+            // If the timeout expires, this means the client does not respond.
+            presenceService.clientNotResponding(destination);
+        }
         // Wait for response, then return it
-        return synchronousResponseCallback.waitForResponse(timeout);
+        return response;
     }
 
     @Override
     public <T extends LwM2mResponse> void send(final Registration destination, DownlinkRequest<T> request, long timeout,
             final ResponseCallback<T> responseCallback, final ErrorCallback errorCallback) {
+
+        // If the client does not use Q-Mode, just send
+        if (!destination.usesQueueMode()) {
+            delegatedSender.send(destination, request, timeout, responseCallback, errorCallback);
+            return;
+        }
+
+        // If the client uses Q-Mode...
 
         // If the client is sleeping, warn the user and return
         if (!presenceService.isClientAwake(destination)) {
@@ -111,54 +127,4 @@ public class QueueModeLwM2mRequestSender implements LwM2mRequestSender {
     public void cancelPendingRequests(Registration registration) {
         delegatedSender.cancelPendingRequests(registration);
     }
-
-    /**
-     * Callback to use the asynchronous method of {@link CaliforniumLwM2mRequestSender} in a synchronous way
-     */
-    public class ResponseCallbackQueueModeSynchronous<T extends LwM2mResponse>
-            implements ResponseCallback<T>, ErrorCallback {
-
-        /**
-         * @param presenceService the presence service object for setting the client into {@link Presence#SLEEPING} when
-         *        request Timeout expires and into {@link Presence#Awake} when a response arrives.
-         * @param delegatedSender internal sender that it is used for sending the requests, using delegation.
-         */
-        private PresenceServiceImpl presenceService;
-        private Registration destination;
-        private final CountDownLatch latch;
-        private T response;
-
-        public ResponseCallbackQueueModeSynchronous(PresenceServiceImpl presenceService, Registration destination) {
-            this.presenceService = presenceService;
-            this.destination = destination;
-            this.response = null;
-            latch = new CountDownLatch(1);
-        }
-
-        @Override
-        public void onResponse(T response) {
-            presenceService.setAwake(destination);
-            this.response = response;
-            latch.countDown();
-        }
-
-        @Override
-        public void onError(Exception e) {
-            latch.countDown();
-            if (e instanceof TimeoutException) {
-                presenceService.clientNotResponding(destination);
-            }
-        }
-
-        public T waitForResponse(Long timeout) throws InterruptedException {
-            if (timeout != null) {
-                latch.await(timeout, TimeUnit.MILLISECONDS);
-            } else {
-                latch.await();
-            }
-            return this.response;
-        }
-
-    }
-
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/QueueModeLwM2mRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/QueueModeLwM2mRequestSender.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2017 RISE SICS AB.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     RISE SICS AB - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.impl;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.exception.TimeoutException;
+import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.server.queue.Presence;
+import org.eclipse.leshan.server.queue.PresenceServiceImpl;
+import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.server.request.LwM2mRequestSender;
+import org.eclipse.leshan.util.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QueueModeLwM2mRequestSender implements LwM2mRequestSender {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueueModeLwM2mRequestSender.class);
+
+    private PresenceServiceImpl presenceService;
+    private LwM2mRequestSender delegatedSender;
+
+    /**
+     * @param presenceService the presence service object for setting the client into {@link Presence#SLEEPING} when
+     *        request Timeout expires and into {@link Presence#Awake} when a response arrives.
+     * @param delegatedSender internal sender that it is used for sending the requests, using delegation.
+     */
+    public QueueModeLwM2mRequestSender(PresenceServiceImpl presenceService, LwM2mRequestSender delegatedSender) {
+        Validate.notNull(presenceService);
+        Validate.notNull(delegatedSender);
+
+        this.presenceService = presenceService;
+        this.delegatedSender = delegatedSender;
+    }
+
+    @Override
+    public <T extends LwM2mResponse> T send(final Registration destination, DownlinkRequest<T> request, long timeout)
+            throws InterruptedException {
+
+        // If the client is sleeping, warn the user and return
+        if (!presenceService.isClientAwake(destination)) {
+            LOG.info("The destination client is sleeping, request couldn't been sent.");
+            return null;
+        }
+
+        // Create a response callback to use the asynchronous send method in a synchronous way
+        ResponseCallbackQueueModeSynchronous<T> synchronousResponseCallback = new ResponseCallbackQueueModeSynchronous<T>(
+                presenceService, destination);
+
+        // Use delegation to send the request
+        delegatedSender.send(destination, request, timeout, synchronousResponseCallback, synchronousResponseCallback);
+
+        // Wait for response, then return it
+        return synchronousResponseCallback.waitForResponse(timeout);
+    }
+
+    @Override
+    public <T extends LwM2mResponse> void send(final Registration destination, DownlinkRequest<T> request, long timeout,
+            final ResponseCallback<T> responseCallback, final ErrorCallback errorCallback) {
+
+        // If the client is sleeping, warn the user and return
+        if (!presenceService.isClientAwake(destination)) {
+            LOG.info("The destination client is sleeping, request couldn't been sent.");
+            return;
+        }
+
+        // Use delegation to send the request, with specific callbacks to perform Queue Mode operation
+        delegatedSender.send(destination, request, timeout, new ResponseCallback<T>() {
+            @Override
+            public void onResponse(T response) {
+                // Set the client awake. This will restart the timer.
+                presenceService.setAwake(destination);
+
+                // Call the user's callback
+                responseCallback.onResponse(response);
+            }
+        }, new ErrorCallback() {
+            @Override
+            public void onError(Exception e) {
+                if (e instanceof TimeoutException) {
+                    // If the timeout expires, this means the client does not respond.
+                    presenceService.clientNotResponding(destination);
+                }
+
+                // Call the user's callback
+                errorCallback.onError(e);
+            }
+        });
+
+    }
+
+    @Override
+    public void cancelPendingRequests(Registration registration) {
+        delegatedSender.cancelPendingRequests(registration);
+    }
+
+    /**
+     * Callback to use the asynchronous method of {@link CaliforniumLwM2mRequestSender} in a synchronous way
+     */
+    public class ResponseCallbackQueueModeSynchronous<T extends LwM2mResponse>
+            implements ResponseCallback<T>, ErrorCallback {
+
+        /**
+         * @param presenceService the presence service object for setting the client into {@link Presence#SLEEPING} when
+         *        request Timeout expires and into {@link Presence#Awake} when a response arrives.
+         * @param delegatedSender internal sender that it is used for sending the requests, using delegation.
+         */
+        private PresenceServiceImpl presenceService;
+        private Registration destination;
+        private final CountDownLatch latch;
+        private T response;
+
+        public ResponseCallbackQueueModeSynchronous(PresenceServiceImpl presenceService, Registration destination) {
+            this.presenceService = presenceService;
+            this.destination = destination;
+            this.response = null;
+            latch = new CountDownLatch(1);
+        }
+
+        @Override
+        public void onResponse(T response) {
+            presenceService.setAwake(destination);
+            this.response = response;
+            latch.countDown();
+        }
+
+        @Override
+        public void onError(Exception e) {
+            latch.countDown();
+            if (e instanceof TimeoutException) {
+                presenceService.clientNotResponding(destination);
+            }
+        }
+
+        public T waitForResponse(Long timeout) throws InterruptedException {
+            if (timeout != null) {
+                latch.await(timeout, TimeUnit.MILLISECONDS);
+            } else {
+                latch.await();
+            }
+            return this.response;
+        }
+
+    }
+
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceServiceImpl.java
@@ -71,12 +71,17 @@ public final class PresenceServiceImpl implements PresenceService {
             if (!clientStatusList.containsKey(reg.getEndpoint())) {
                 createPresenceStatusObject(reg);
             }
+
+            boolean stateChanged = false;
             synchronized (this) {
-                clientStatusList.get(reg.getEndpoint()).setAwake();
+                stateChanged = clientStatusList.get(reg.getEndpoint()).setAwake();
                 startClientAwakeTimer(reg);
             }
-            for (PresenceListener listener : listeners) {
-                listener.onAwake(reg);
+
+            if (stateChanged) {
+                for (PresenceListener listener : listeners) {
+                    listener.onAwake(reg);
+                }
             }
         }
     }
@@ -89,12 +94,16 @@ public final class PresenceServiceImpl implements PresenceService {
      */
     public void setSleeping(Registration reg) {
         if (reg.usesQueueMode()) {
+
+            boolean stateChanged = false;
             synchronized (this) {
-                clientStatusList.get(reg.getEndpoint()).setSleeping();
+                stateChanged = clientStatusList.get(reg.getEndpoint()).setSleeping();
                 stopClientAwakeTimer(reg);
             }
-            for (PresenceListener listener : listeners) {
-                listener.onSleeping(reg);
+            if (stateChanged) {
+                for (PresenceListener listener : listeners) {
+                    listener.onSleeping(reg);
+                }
             }
         }
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceStatus.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceStatus.java
@@ -46,11 +46,15 @@ public class PresenceStatus {
     /**
      * Set the client state to awake. This should be called when an update message is received from the server. It
      * starts the client awake timer.
+     * 
+     * @return true if the state was changed (previous state was {@link Presence#SLEEPING}
      */
-    public void setAwake() {
+    public boolean setAwake() {
         if (state == Presence.SLEEPING) {
             state = Presence.AWAKE;
+            return true;
         }
+        return false;
     }
 
     /**
@@ -58,10 +62,20 @@ public class PresenceStatus {
      * expires, or when the client is not responding. It also notifies the listeners inside the {@link PresenceService}.
      * It stops the client awake timer.
      */
-    public void setSleeping() {
+
+    /**
+     * Set the client state to sleeping. This should be called when the the time the client waits before going to sleep
+     * expires, or when the client is not responding. It also notifies the listeners inside the {@link PresenceService}.
+     * It stops the client awake timer.
+     * 
+     * @return true if the state was changed (previous state was {@link Presence#AWAKE}
+     */
+    public boolean setSleeping() {
         if (state == Presence.AWAKE) {
             state = Presence.SLEEPING;
+            return true;
         }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Here comes a new PR to continue the implementation of Queue Mode :-)

In this case, a new request sender is created, that uses methods from the `CaliforniumRequestSender` forming a delegation pattern. The tasks that the Queue Mode Request sender does are:

1. Before sending, checks if the client is sleeping, in that case it returns immediately and warns the user.
2. Set the client to `AWAKE` (this restarts the timer internally) when a response arrives. 
3. Set the client to `SLEEPING` if a timeout occurs, which means that the client does not respond so it is sleeping.

For delegation, the asynchronous method of `CalifornoumRequestSender` is used for both synchronous and asynchronous metods of the `QueueModeRequestSender`. This allows to reuse the code, because for using the synchronous method, the message observer should be changed to overwrite onResponse() and onTimeout(). For doing it synchronous, a new `ResponseCallback` class is created with an internal latch that stops the execution until a response arrives or a timeout occurs.

I have also a question regarding the approximation we have been discussing in #455 about when to restart the timer.
1. Should we consider to restart the timer in `onResponse()` with a time slightly smaller? The client restarts its timer when it gets the request, so if the server restarts it on a response, there will be a time in the future when the server will consider that the client is awake when it's actually not. Maybe the request sender can measure the round trip time and subtract half of it to the timer, or something like that... 

Maybe that is too complicated and not so important, it's just an idea to improve the approximation. 