### PR TITLE
Remove optimization for encoding single instance object

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
@@ -22,7 +22,6 @@ import java.util.Date;
 import java.util.Map.Entry;
 
 import org.eclipse.leshan.core.model.LwM2mModel;
-import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mNode;
@@ -78,20 +77,14 @@ public class LwM2mNodeTlvEncoder {
 
             Tlv[] tlvs;
 
-            ObjectModel objectModel = model.getObjectModel(object.getId());
-            if (objectModel != null && !objectModel.multiple) {
-                // single instance object, the instance is level is not needed
-                tlvs = encodeResources(object.getInstance(0).getResources().values(), new LwM2mPath(object.getId(), 0));
-            } else {
-                // encoded as an array of instances
-                tlvs = new Tlv[object.getInstances().size()];
-                int i = 0;
-                for (Entry<Integer, LwM2mObjectInstance> instance : object.getInstances().entrySet()) {
-                    Tlv[] resources = encodeResources(instance.getValue().getResources().values(),
-                            new LwM2mPath(object.getId(), instance.getKey()));
-                    tlvs[i] = new Tlv(TlvType.OBJECT_INSTANCE, resources, null, instance.getKey());
-                    i++;
-                }
+            // encoded as an array of instances
+            tlvs = new Tlv[object.getInstances().size()];
+            int i = 0;
+            for (Entry<Integer, LwM2mObjectInstance> instance : object.getInstances().entrySet()) {
+                Tlv[] resources = encodeResources(instance.getValue().getResources().values(),
+                        new LwM2mPath(object.getId(), instance.getKey()));
+                tlvs[i] = new Tlv(TlvType.OBJECT_INSTANCE, resources, null, instance.getKey());
+                i++;
             }
 
             try {

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeEncoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeEncoderTest.java
@@ -169,7 +169,7 @@ public class LwM2mNodeEncoderTest {
         byte[] encoded = encoder.encode(object, ContentFormat.TLV, new LwM2mPath("/3"), model);
 
         // encoded as an array of resource TLVs
-        Assert.assertArrayEquals(ENCODED_DEVICE_WITHOUT_INSTANCE, encoded);
+        Assert.assertArrayEquals(ENCODED_DEVICE_WITH_INSTANCE, encoded);
     }
 
     @Test


### PR DESCRIPTION
This optimization was removed from the specification.
The spec say now :
For simplicity and to prevent any ambiguity on Object Instance Identity,
when the Object Instance ID is not specified in the request, the Object
Instance TLV MUST be used, whatever the number of Object Instances (1 or
more) to return to the LwM2M Server.

So this should fix issue #463.