### PR TITLE
Update the additionalRegistrationParameters when update messages are received

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/RegistrationEngine.java
@@ -250,7 +250,7 @@ public class RegistrationEngine {
         // Send update
         LOG.info("Trying to update registration to {} ...", dmInfo.getFullUri());
         UpdateResponse response = sender.send(dmInfo.getAddress(), dmInfo.isSecure(),
-                new UpdateRequest(registrationID, null, null, null, null), DEFAULT_TIMEOUT);
+                new UpdateRequest(registrationID, null, null, null, null, null), DEFAULT_TIMEOUT);
         if (response == null) {
             registrationID = null;
             LOG.error("Registration update failed: Timeout.");

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
@@ -15,6 +15,10 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.leshan.Link;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.UpdateResponse;
@@ -30,6 +34,7 @@ public class UpdateRequest implements UplinkRequest<UpdateResponse> {
     private final BindingMode bindingMode;
     private final String registrationId;
     private final Link[] objectLinks;
+    private final Map<String, String> additionalAttributes;
 
     /**
      * Sets all fields.
@@ -42,7 +47,7 @@ public class UpdateRequest implements UplinkRequest<UpdateResponse> {
      * @exception InvalidRequestException if the registrationId is empty.
      */
     public UpdateRequest(String registrationId, Long lifetime, String smsNumber, BindingMode binding,
-            Link[] objectLinks) throws InvalidRequestException {
+            Link[] objectLinks, Map<String, String> additionalAttributes) throws InvalidRequestException {
 
         if (registrationId == null || registrationId.isEmpty())
             throw new InvalidRequestException("registrationId is mandatory");
@@ -52,6 +57,10 @@ public class UpdateRequest implements UplinkRequest<UpdateResponse> {
         this.lifeTimeInSec = lifetime;
         this.bindingMode = binding;
         this.smsNumber = smsNumber;
+        if (additionalAttributes == null)
+            this.additionalAttributes = Collections.emptyMap();
+        else
+            this.additionalAttributes = Collections.unmodifiableMap(new HashMap<>(additionalAttributes));
     }
 
     public String getRegistrationId() {
@@ -72,6 +81,10 @@ public class UpdateRequest implements UplinkRequest<UpdateResponse> {
 
     public BindingMode getBindingMode() {
         return bindingMode;
+    }
+
+    public Map<String, String> getAdditionalAttributes() {
+        return additionalAttributes;
     }
 
     @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -209,6 +209,8 @@ public class RegisterResource extends CoapResource {
         String smsNumber = null;
         BindingMode binding = null;
         Link[] objectLinks = null;
+        Map<String, String> additionalParams = new HashMap<>();
+
         for (String param : request.getOptions().getUriQuery()) {
             if (param.startsWith(QUERY_PARAM_LIFETIME)) {
                 lifetime = Long.valueOf(param.substring(3));
@@ -216,12 +218,18 @@ public class RegisterResource extends CoapResource {
                 smsNumber = param.substring(4);
             } else if (param.startsWith(QUERY_PARAM_BINDING_MODE)) {
                 binding = BindingMode.valueOf(param.substring(2));
+            } else {
+                String[] tokens = param.split("\\=");
+                if (tokens != null && tokens.length == 2) {
+                    additionalParams.put(tokens[0], tokens[1]);
+                }
             }
         }
         if (request.getPayload() != null && request.getPayload().length > 0) {
             objectLinks = Link.parse(request.getPayload());
         }
-        UpdateRequest updateRequest = new UpdateRequest(registrationId, lifetime, smsNumber, binding, objectLinks);
+        UpdateRequest updateRequest = new UpdateRequest(registrationId, lifetime, smsNumber, binding, objectLinks,
+                additionalParams);
 
         // Handle request
         final SendableResponse<UpdateResponse> sendableResponse = registrationHandler.update(sender, updateRequest);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStoreTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStoreTest.java
@@ -56,7 +56,7 @@ public class InMemoryRegistrationStoreTest {
         store.addRegistration(registration);
 
         RegistrationUpdate update = new RegistrationUpdate(registrationId, Identity.unsecure(address, port), null, null,
-                null, null);
+                null, null, null);
         UpdatedRegistration updatedRegistration = store.updateRegistration(update);
         Assert.assertEquals(lifetime, updatedRegistration.getUpdatedRegistration().getLifeTimeInSec());
         Assert.assertSame(binding, updatedRegistration.getUpdatedRegistration().getBindingMode());
@@ -84,7 +84,7 @@ public class InMemoryRegistrationStoreTest {
         Assert.assertFalse(registration.isAlive());
 
         RegistrationUpdate update = new RegistrationUpdate(registrationId, Identity.unsecure(address, port), lifetime,
-                null, null, null);
+                null, null, null, null);
         UpdatedRegistration updatedRegistration = store.updateRegistration(update);
         Assert.assertTrue(updatedRegistration.getUpdatedRegistration().isAlive());
 

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/serialization/RegistrationUpdateSerDes.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/serialization/RegistrationUpdateSerDes.java
@@ -69,6 +69,14 @@ public class RegistrationUpdateSerDes {
             o.add("objLink", links);
         }
 
+        if (u.getAdditionalAttributes() != null) {
+            JsonObject addAttr = Json.object();
+            for (Map.Entry<String, String> e : u.getAdditionalAttributes().entrySet()) {
+                addAttr.add(e.getKey(), e.getValue());
+            }
+            o.add("addAttr", addAttr);
+        }
+
         return o;
     }
 
@@ -126,6 +134,12 @@ public class RegistrationUpdateSerDes {
             }
         }
 
-        return new RegistrationUpdate(regId, identity, lifetime, sms, b, linkObjs);
+        Map<String, String> addAttr = new HashMap<>();
+        JsonObject o = (JsonObject) v.get("addAttr");
+        for (String k : o.names()) {
+            addAttr.put(k, o.getString(k, ""));
+        }
+
+        return new RegistrationUpdate(regId, identity, lifetime, sms, b, linkObjs, addAttr);
     }
 }

--- a/leshan-server-cluster/src/test/java/org/eclipse/leshan/server/cluster/serialization/RegistrationUpdateSerDesTest.java
+++ b/leshan-server-cluster/src/test/java/org/eclipse/leshan/server/cluster/serialization/RegistrationUpdateSerDesTest.java
@@ -40,9 +40,12 @@ public class RegistrationUpdateSerDesTest {
         objs[0] = new Link("/0/1024/2", att);
         objs[1] = new Link("/0/2");
 
+        Map<String, String> additionalAtt = new HashMap<>();
+        additionalAtt.put("at", "5000");
+
         RegistrationUpdate ru = new RegistrationUpdate("myId",
                 Identity.unsecure(Inet4Address.getByName("127.0.0.1"), LwM2m.DEFAULT_COAP_PORT), 60000l, null,
-                BindingMode.U, objs);
+                BindingMode.U, objs, additionalAtt);
 
         byte[] ser = RegistrationUpdateSerDes.bSerialize(ru);
         RegistrationUpdate ru2 = RegistrationUpdateSerDes.deserialize(ser);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -106,7 +106,7 @@ public class RegistrationHandler {
         // Create update
         final RegistrationUpdate update = new RegistrationUpdate(updateRequest.getRegistrationId(), sender,
                 updateRequest.getLifeTimeInSec(), updateRequest.getSmsNumber(), updateRequest.getBindingMode(),
-                updateRequest.getObjectLinks());
+                updateRequest.getObjectLinks(), updateRequest.getAdditionalAttributes());
 
         // update registration
         final UpdatedRegistration updatedRegistration = registrationService.getStore().updateRegistration(update);

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2017 RISE SICS AB.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     RISE SICS AB - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.registration;
+
+import java.net.Inet4Address;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.server.queue.PresenceService;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * tests the implementation of {@link PresenceService}
+ *
+ */
+public class RegistrationUpdateTest {
+
+    @Test
+    public void testAdditionalAttributesUpdate() throws Exception {
+        Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",
+                Identity.unsecure(Inet4Address.getLocalHost(), 1), new InetSocketAddress(212));
+
+        Map<String, String> additionalAttributes = new HashMap<String, String>();
+        additionalAttributes.put("x", "1");
+        additionalAttributes.put("y", "10");
+        additionalAttributes.put("z", "100");
+        builder.additionalRegistrationAttributes(additionalAttributes);
+
+        Registration r = builder.build();
+
+        Map<String, String> updateAdditionalAttributes = new HashMap<String, String>();
+        updateAdditionalAttributes.put("x", "2");
+        updateAdditionalAttributes.put("y", "11");
+        updateAdditionalAttributes.put("z", "101");
+        updateAdditionalAttributes.put("h", "hello");
+
+        RegistrationUpdate updateReg = new RegistrationUpdate(r.getId(), r.getIdentity(), null, null, null, null,
+                updateAdditionalAttributes);
+
+        r = updateReg.update(r);
+
+        Map<String, String> updatedAdditionalAttributes = r.getAdditionalRegistrationAttributes();
+
+        Assert.assertEquals("2", updatedAdditionalAttributes.get("x"));
+        Assert.assertEquals("11", updatedAdditionalAttributes.get("y"));
+        Assert.assertEquals("101", updatedAdditionalAttributes.get("z"));
+        Assert.assertTrue(updatedAdditionalAttributes.containsKey("h"));
+        Assert.assertEquals("hello", updatedAdditionalAttributes.get("h"));
+
+    }
+}


### PR DESCRIPTION
Hi all!

Here I come with a PR to update the `additionalRegistrationParameters` of the registration object when they are included in the update message. This is, among other applications, useful to use with Queue Mode to update the client awake time.

I have basically treated the additional parameters as they are treated regarding the Registration, so the code is very similar to the one present in those classes. Now the Map containing this parameters has changed from the type `Collections.unmodifiableMap` to `Collections.synchronizedMap`. Then, when new parameters arrive in the update message, using the method `putAll()` the already present attributes are updated with the new values, and the new ones are added.

Regarding the serialization used in the cluster, I'm not very familiar with this, but I have implemented the same code as in the serialization of the registration object, and it seems to pass correctly the JUnit test. But please check this in detail.

All feedback is welcomed :-)