### PR TITLE
Queue Mode Integration Tests

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
@@ -20,18 +20,14 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.Collection;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.leshan.LwM2mId;
-import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
@@ -39,57 +35,24 @@ import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.model.LwM2mModel;
-import org.eclipse.leshan.core.model.ObjectLoader;
-import org.eclipse.leshan.core.model.ObjectModel;
-import org.eclipse.leshan.core.model.ResourceModel;
-import org.eclipse.leshan.core.model.ResourceModel.Operations;
-import org.eclipse.leshan.core.model.ResourceModel.Type;
-import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
-import org.eclipse.leshan.server.californium.impl.LeshanServer;
 import org.eclipse.leshan.server.impl.InMemorySecurityStore;
-import org.eclipse.leshan.server.impl.RegistrationServiceImpl;
 import org.eclipse.leshan.server.model.StaticModelProvider;
 import org.eclipse.leshan.server.queue.PresenceListener;
 import org.eclipse.leshan.server.queue.StaticClientAwakeTimeProvider;
 import org.eclipse.leshan.server.registration.Registration;
-import org.eclipse.leshan.server.registration.RegistrationListener;
-import org.eclipse.leshan.server.registration.RegistrationUpdate;
 
 /**
  * Helper for running a server and executing a client against it.
  * 
  */
-public class QueueModeIntegrationTestHelper {
-    public static final Random r = new Random();
-
-    static final String MODEL_NUMBER = "IT-TEST-123";
-    public static final long SLEEPTIME = 10; // seconds
-    public static final long AWAKETIME = 2; // seconds
+public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
+    public final long sleeptime = 0; // seconds
+    public final long awaketime = 1; // seconds
     public static final long LIFETIME = 3600; // Updates are manually triggered with a timer
-
-    public static final int TEST_OBJECT_ID = 2000;
-    public static final int STRING_RESOURCE_ID = 0;
-    public static final int BOOLEAN_RESOURCE_ID = 1;
-    public static final int INTEGER_RESOURCE_ID = 2;
-    public static final int FLOAT_RESOURCE_ID = 3;
-    public static final int TIME_RESOURCE_ID = 4;
-    public static final int OPAQUE_RESOURCE_ID = 5;
-    public static final int OBJLNK_MULTI_INSTANCE_RESOURCE_ID = 6;
-    public static final int OBJLNK_SINGLE_INSTANCE_RESOURCE_ID = 7;
-
-    LeshanServer server;
-
-    LeshanClient client;
-    AtomicReference<String> currentEndpointIdentifier = new AtomicReference<String>();
-
-    CountDownLatch registerLatch;
-    Registration last_registration;
-    CountDownLatch deregisterLatch;
-    CountDownLatch updateLatch;
     CountDownLatch awakeLatch;
 
     private final ScheduledExecutorService sleepTimerExecutor = Executors.newSingleThreadScheduledExecutor();
@@ -97,41 +60,7 @@ public class QueueModeIntegrationTestHelper {
 
     int awakeNotifications = 0;
 
-    protected List<ObjectModel> createObjectModels() {
-        // load default object from the spec
-        List<ObjectModel> objectModels = ObjectLoader.loadDefault();
-        // define custom model for testing purpose
-        ResourceModel stringfield = new ResourceModel(STRING_RESOURCE_ID, "stringres", Operations.RW, false, false,
-                Type.STRING, null, null, null);
-        ResourceModel booleanfield = new ResourceModel(BOOLEAN_RESOURCE_ID, "booleanres", Operations.RW, false, false,
-                Type.BOOLEAN, null, null, null);
-        ResourceModel integerfield = new ResourceModel(INTEGER_RESOURCE_ID, "integerres", Operations.RW, false, false,
-                Type.INTEGER, null, null, null);
-        ResourceModel floatfield = new ResourceModel(FLOAT_RESOURCE_ID, "floatres", Operations.RW, false, false,
-                Type.FLOAT, null, null, null);
-        ResourceModel timefield = new ResourceModel(TIME_RESOURCE_ID, "timeres", Operations.RW, false, false, Type.TIME,
-                null, null, null);
-        ResourceModel opaquefield = new ResourceModel(OPAQUE_RESOURCE_ID, "opaque", Operations.RW, false, false,
-                Type.OPAQUE, null, null, null);
-        ResourceModel objlnkfield = new ResourceModel(OBJLNK_MULTI_INSTANCE_RESOURCE_ID, "objlnk", Operations.RW, true,
-                false, Type.OBJLNK, null, null, null);
-        ResourceModel objlnkSinglefield = new ResourceModel(OBJLNK_SINGLE_INSTANCE_RESOURCE_ID, "objlnk", Operations.RW,
-                false, false, Type.OBJLNK, null, null, null);
-        objectModels.add(new ObjectModel(TEST_OBJECT_ID, "testobject", null, ObjectModel.DEFAULT_VERSION, false, false,
-                stringfield, booleanfield, integerfield, floatfield, timefield, opaquefield, objlnkfield,
-                objlnkSinglefield));
-
-        return objectModels;
-    }
-
-    public void initialize() {
-        currentEndpointIdentifier.set("leshan_integration_test_" + r.nextInt());
-    }
-
-    public String getCurrentEndpoint() {
-        return currentEndpointIdentifier.get();
-    }
-
+    @Override
     public void createClient() {
         // Create objects Enabler
         ObjectsInitializer initializer = new ObjectsInitializer(new LwM2mModel(createObjectModels()));
@@ -174,7 +103,7 @@ public class QueueModeIntegrationTestHelper {
             public void onSleeping(Registration registration) {
                 awakeNotifications = 0;
                 awakeLatch.countDown();
-                scheduleUpdateAfterSleeping((int) SLEEPTIME);
+                scheduleUpdateAfterSleeping((int) sleeptime);
             }
 
         });
@@ -192,36 +121,7 @@ public class QueueModeIntegrationTestHelper {
         return builder;
     }
 
-    protected void setupRegistrationMonitoring() {
-        resetLatch();
-        server.getRegistrationService().addListener(new RegistrationListener() {
-            @Override
-            public void updated(RegistrationUpdate update, Registration updatedRegistration,
-                    Registration previousRegistration) {
-                if (updatedRegistration.getEndpoint().equals(currentEndpointIdentifier.get())) {
-                    updateLatch.countDown();
-                }
-            }
-
-            @Override
-            public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
-                    Registration newReg) {
-                if (registration.getEndpoint().equals(currentEndpointIdentifier.get())) {
-                    deregisterLatch.countDown();
-                }
-            }
-
-            @Override
-            public void registered(Registration registration, Registration previousReg,
-                    Collection<Observation> previousObsersations) {
-                if (registration.getEndpoint().equals(currentEndpointIdentifier.get())) {
-                    last_registration = registration;
-                    registerLatch.countDown();
-                }
-            }
-        });
-    }
-
+    @Override
     public void resetLatch() {
         registerLatch = new CountDownLatch(1);
         deregisterLatch = new CountDownLatch(1);
@@ -231,30 +131,6 @@ public class QueueModeIntegrationTestHelper {
 
     public void resetAwakeLatch() {
         awakeLatch = new CountDownLatch(1);
-    }
-
-    public void waitForRegistration(long timeInSeconds) {
-        try {
-            assertTrue(registerLatch.await(timeInSeconds, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void ensureNoRegistration(long timeInSeconds) {
-        try {
-            assertFalse(registerLatch.await(timeInSeconds, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void waitForUpdate(long timeInSeconds) {
-        try {
-            assertTrue(updateLatch.await(timeInSeconds, TimeUnit.MILLISECONDS));
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     public void waitForAwakeTime(long timeInSeconds) {
@@ -267,53 +143,6 @@ public class QueueModeIntegrationTestHelper {
 
     public void ensureOneAwakeNotification() {
         assertEquals(1, awakeNotifications);
-    }
-
-    public void ensureNoUpdate(long timeInSeconds) {
-        try {
-            assertFalse(updateLatch.await(timeInSeconds, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void waitForDeregistration(long timeInSeconds) {
-        try {
-            assertTrue(deregisterLatch.await(timeInSeconds, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void ensureNoDeregistration(long timeInSeconds) {
-        try {
-            assertFalse(deregisterLatch.await(timeInSeconds, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Registration getCurrentRegistration() {
-        return server.getRegistrationService().getByEndpoint(currentEndpointIdentifier.get());
-    }
-
-    public void deregisterClient() {
-        Registration r = getCurrentRegistration();
-        if (r != null)
-            ((RegistrationServiceImpl) server.getRegistrationService()).getStore().removeRegistration(r.getId());
-    }
-
-    public void dispose() {
-        deregisterClient();
-        currentEndpointIdentifier.set(null);
-    }
-
-    public void assertClientRegisterered() {
-        assertNotNull(getCurrentRegistration());
-    }
-
-    public void assertClientNotRegisterered() {
-        assertNull(getCurrentRegistration());
     }
 
     public void ensureClientAwake() {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
@@ -16,7 +16,6 @@
 
 package org.eclipse.leshan.integration.tests;
 
-import static org.eclipse.leshan.integration.tests.QueueModeIntegrationTestHelper.*;
 import static org.junit.Assert.assertArrayEquals;
 
 import org.eclipse.leshan.Link;
@@ -33,7 +32,7 @@ public class QueueModeTest {
     @Before
     public void start() {
         queueModeHelper.initialize();
-        queueModeHelper.createServer((int) AWAKETIME * 1000);
+        queueModeHelper.createServer((int) queueModeHelper.awaketime * 1000);
         queueModeHelper.server.start();
         queueModeHelper.createClient();
     }
@@ -63,20 +62,24 @@ public class QueueModeTest {
         queueModeHelper.ensureClientAwake();
 
         // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
 
         // Check that client is sleeping
         queueModeHelper.ensureClientSleeping();
 
         // Wait for update when waking up (1% margin)
-        queueModeHelper.waitForUpdate(SLEEPTIME * 1010);
+        if (queueModeHelper.sleeptime != 0) {
+            queueModeHelper.waitForUpdate(queueModeHelper.sleeptime * 1010);
+        } else {
+            queueModeHelper.waitForUpdate(1);
+        }
 
         // Check that client is awake
         queueModeHelper.ensureClientAwake();
         queueModeHelper.resetAwakeLatch();
 
         // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
 
         // Check that client is sleeping
         queueModeHelper.ensureClientSleeping();
@@ -111,13 +114,17 @@ public class QueueModeTest {
         queueModeHelper.ensureOneAwakeNotification();
 
         // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
 
         // Check that client is sleeping
         queueModeHelper.ensureClientSleeping();
 
         // Wait for update when waking up (1% margin)
-        queueModeHelper.waitForUpdate(SLEEPTIME * 1010);
+        if (queueModeHelper.sleeptime != 0) {
+            queueModeHelper.waitForUpdate(queueModeHelper.sleeptime * 1010);
+        } else {
+            queueModeHelper.waitForUpdate(1);
+        }
 
         // Check that client is awake
         queueModeHelper.ensureClientAwake();
@@ -181,13 +188,17 @@ public class QueueModeTest {
         queueModeHelper.ensureReceivedRequest(response);
 
         // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
 
         // Check that client is sleeping
         queueModeHelper.ensureClientSleeping();
 
         // Wait for update when waking up (1% margin)
-        queueModeHelper.waitForUpdate(SLEEPTIME * 1010);
+        if (queueModeHelper.sleeptime != 0) {
+            queueModeHelper.waitForUpdate(queueModeHelper.sleeptime * 1010);
+        } else {
+            queueModeHelper.waitForUpdate(1);
+        }
 
         // Check that client is awake
         queueModeHelper.ensureClientAwake();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
@@ -27,187 +27,180 @@ import org.junit.Test;
 
 public class QueueModeTest {
 
-    protected QueueModeIntegrationTestHelper queueModeHelper = new QueueModeIntegrationTestHelper();
+	protected QueueModeIntegrationTestHelper queueModeHelper = new QueueModeIntegrationTestHelper();
+	private final long awaketime = 1; // seconds
 
-    @Before
-    public void start() {
-        queueModeHelper.initialize();
-        queueModeHelper.createServer((int) queueModeHelper.awaketime * 1000);
-        queueModeHelper.server.start();
-        queueModeHelper.createClient();
-    }
+	@Before
+	public void start() {
+		queueModeHelper.initialize();
+		queueModeHelper.createServer((int) awaketime * 1000);
+		queueModeHelper.server.start();
+		queueModeHelper.createClient();
+	}
 
-    @After
-    public void stop() throws InterruptedException {
-        queueModeHelper.client.destroy(true);
-        queueModeHelper.server.destroy();
-        queueModeHelper.dispose();
-    }
+	@After
+	public void stop() throws InterruptedException {
+		queueModeHelper.client.destroy(true);
+		queueModeHelper.server.destroy();
+		queueModeHelper.dispose();
+	}
 
-    @Test
-    public void awake_sleeping_awake_sleeping() {
-        // Check client is not registered
-        queueModeHelper.assertClientNotRegisterered();
+	@Test
+	public void awake_sleeping_awake_sleeping() {
+		// Check client is not registered
+		queueModeHelper.assertClientNotRegisterered();
 
-        // Start it and wait for registration
-        queueModeHelper.client.start();
-        queueModeHelper.waitForRegistration(1);
+		// Start it and wait for registration
+		queueModeHelper.client.start();
+		queueModeHelper.waitForRegistration(1);
 
-        // Check client is well registered
-        queueModeHelper.assertClientRegisterered();
-        assertArrayEquals(Link.parse("</>;rt=\"oma.lwm2m\",</1/0>,</2>,</3/0>,</2000/0>".getBytes()),
-                queueModeHelper.getCurrentRegistration().getObjectLinks());
+		// Check client is well registered
+		queueModeHelper.assertClientRegisterered();
+		assertArrayEquals(Link.parse("</>;rt=\"oma.lwm2m\",</1/0>,</2>,</3/0>,</2000/0>".getBytes()),
+				queueModeHelper.getCurrentRegistration().getObjectLinks());
 
-        // Check that client is awake and only one notification
-        queueModeHelper.ensureClientAwake();
+		// Check that client is awake
+		queueModeHelper.ensureClientAwake();
 
-        // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
+		// Wait for client awake time expiration (1% margin)
+		queueModeHelper.waitForAwakeTime(awaketime * 1010);
 
-        // Check that client is sleeping
-        queueModeHelper.ensureClientSleeping();
+		// Check that client is sleeping
+		queueModeHelper.ensureClientSleeping();
 
-        // Wait for update when waking up (1% margin)
-        if (queueModeHelper.sleeptime != 0) {
-            queueModeHelper.waitForUpdate(queueModeHelper.sleeptime * 1010);
-        } else {
-            queueModeHelper.waitForUpdate(1);
-        }
+		// Trigger update manually for waking up
+		queueModeHelper.client.triggerRegistrationUpdate();
+		queueModeHelper.waitForUpdate(1);
 
-        // Check that client is awake
-        queueModeHelper.ensureClientAwake();
-        queueModeHelper.resetAwakeLatch();
+		// Check that client is awake
+		queueModeHelper.ensureClientAwake();
+		queueModeHelper.resetAwakeLatch();
 
-        // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
+		// Wait for client awake time expiration (1% margin)
+		queueModeHelper.waitForAwakeTime(awaketime * 1010);
 
-        // Check that client is sleeping
-        queueModeHelper.ensureClientSleeping();
+		// Check that client is sleeping
+		queueModeHelper.ensureClientSleeping();
 
-        // Stop client with out de-registration
-        queueModeHelper.client.stop(false);
-    }
+		// Stop client with out de-registration
+		queueModeHelper.client.stop(false);
+	}
 
-    @Test
-    public void one_awake_notification() {
+	@Test
+	public void one_awake_notification() {
 
-        // Check client is not registered
-        queueModeHelper.assertClientNotRegisterered();
+		// Check client is not registered
+		queueModeHelper.assertClientNotRegisterered();
 
-        // Start it and wait for registration
-        queueModeHelper.client.start();
-        queueModeHelper.waitForRegistration(1);
+		// Start it and wait for registration
+		queueModeHelper.client.start();
+		queueModeHelper.waitForRegistration(1);
 
-        // Check client is well registered
-        queueModeHelper.assertClientRegisterered();
+		// Check client is well registered
+		queueModeHelper.assertClientRegisterered();
 
-        // Check that client is awake and only one awake notification
-        queueModeHelper.ensureClientAwake();
-        queueModeHelper.ensureOneAwakeNotification();
+		// Check that client is awake and only one awake notification
+		queueModeHelper.ensureClientAwake();
+		queueModeHelper.ensureOneAwakeNotification();
 
-        // Triggers one update
-        queueModeHelper.client.triggerRegistrationUpdate();
-        queueModeHelper.waitForUpdate(1000);
-        queueModeHelper.resetLatch();
+		// Triggers one update
+		queueModeHelper.client.triggerRegistrationUpdate();
+		queueModeHelper.waitForUpdate(1);
+		queueModeHelper.resetLatch();
 
-        // Check only one notification
-        queueModeHelper.ensureOneAwakeNotification();
+		// Check only one notification
+		queueModeHelper.ensureOneAwakeNotification();
 
-        // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
+		// Wait for client awake time expiration (1% margin)
+		queueModeHelper.waitForAwakeTime(awaketime * 1010);
 
-        // Check that client is sleeping
-        queueModeHelper.ensureClientSleeping();
+		// Check that client is sleeping
+		queueModeHelper.ensureClientSleeping();
 
-        // Wait for update when waking up (1% margin)
-        if (queueModeHelper.sleeptime != 0) {
-            queueModeHelper.waitForUpdate(queueModeHelper.sleeptime * 1010);
-        } else {
-            queueModeHelper.waitForUpdate(1);
-        }
+		// Trigger update manually for waking up
+		queueModeHelper.client.triggerRegistrationUpdate();
+		queueModeHelper.waitForUpdate(1);
+		queueModeHelper.resetLatch();
 
-        // Check that client is awake
-        queueModeHelper.ensureClientAwake();
-        queueModeHelper.resetAwakeLatch();
+		// Check that client is awake
+		queueModeHelper.ensureClientAwake();
+		queueModeHelper.resetAwakeLatch();
 
-        // Triggers two updates
-        queueModeHelper.client.triggerRegistrationUpdate();
-        queueModeHelper.waitForUpdate(1010);
-        queueModeHelper.resetLatch();
-        queueModeHelper.client.triggerRegistrationUpdate();
-        queueModeHelper.waitForUpdate(1010);
-        queueModeHelper.resetLatch();
+		// Triggers two updates
+		queueModeHelper.client.triggerRegistrationUpdate();
+		queueModeHelper.waitForUpdate(1);
+		queueModeHelper.resetLatch();
+		queueModeHelper.client.triggerRegistrationUpdate();
+		queueModeHelper.waitForUpdate(1);
+		queueModeHelper.resetLatch();
 
-        // Check only one notification
-        queueModeHelper.ensureOneAwakeNotification();
+		// Check only one notification
+		queueModeHelper.ensureOneAwakeNotification();
 
-    }
+	}
 
-    @Test
-    public void sleeping_if_timeout() throws InterruptedException {
+	@Test
+	public void sleeping_if_timeout() throws InterruptedException {
 
-        // Check client is not registered
-        queueModeHelper.assertClientNotRegisterered();
+		// Check client is not registered
+		queueModeHelper.assertClientNotRegisterered();
 
-        // Start it and wait for registration
-        queueModeHelper.client.start();
-        queueModeHelper.waitForRegistration(1);
+		// Start it and wait for registration
+		queueModeHelper.client.start();
+		queueModeHelper.waitForRegistration(1);
 
-        // Check client is well registered and awake
-        queueModeHelper.assertClientRegisterered();
-        queueModeHelper.ensureClientAwake();
+		// Check client is well registered and awake
+		queueModeHelper.assertClientRegisterered();
+		queueModeHelper.ensureClientAwake();
 
-        // Stop the client to ensure that TimeOut exception is thrown
-        queueModeHelper.client.stop(false);
-        // Send a response with very short timeout
-        ReadResponse response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(),
-                new ReadRequest(3, 0, 1), 1);
+		// Stop the client to ensure that TimeOut exception is thrown
+		queueModeHelper.client.stop(false);
+		// Send a response with very short timeout
+		ReadResponse response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(),
+				new ReadRequest(3, 0, 1), 1);
 
-        // Check that a timeout occurs
-        queueModeHelper.ensureTimeoutException(response);
+		// Check that a timeout occurs
+		queueModeHelper.ensureTimeoutException(response);
 
-        // Check that the client is sleeping
-        queueModeHelper.ensureClientSleeping();
-    }
+		// Check that the client is sleeping
+		queueModeHelper.ensureClientSleeping();
+	}
 
-    @Test
-    public void correct_sending_when_awake() throws InterruptedException {
-        ReadResponse response;
+	@Test
+	public void correct_sending_when_awake() throws InterruptedException {
+		ReadResponse response;
 
-        // Check client is not registered
-        queueModeHelper.assertClientNotRegisterered();
+		// Check client is not registered
+		queueModeHelper.assertClientNotRegisterered();
 
-        // Start it and wait for registration
-        queueModeHelper.client.start();
-        queueModeHelper.waitForRegistration(1);
+		// Start it and wait for registration
+		queueModeHelper.client.start();
+		queueModeHelper.waitForRegistration(1);
 
-        // Check client is well registered and awake
-        queueModeHelper.assertClientRegisterered();
-        queueModeHelper.ensureClientAwake();
+		// Check client is well registered and awake
+		queueModeHelper.assertClientRegisterered();
+		queueModeHelper.ensureClientAwake();
 
-        // Send a response a check that it is received correctly
-        response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(), new ReadRequest(3, 0, 1));
-        queueModeHelper.ensureReceivedRequest(response);
+		// Send a response a check that it is received correctly
+		response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(), new ReadRequest(3, 0, 1));
+		queueModeHelper.ensureReceivedRequest(response);
 
-        // Wait for client awake time expiration (1% margin)
-        queueModeHelper.waitForAwakeTime(queueModeHelper.awaketime * 1010);
+		// Wait for client awake time expiration (1% margin)
+		queueModeHelper.waitForAwakeTime(awaketime * 1010);
 
-        // Check that client is sleeping
-        queueModeHelper.ensureClientSleeping();
+		// Check that client is sleeping
+		queueModeHelper.ensureClientSleeping();
 
-        // Wait for update when waking up (1% margin)
-        if (queueModeHelper.sleeptime != 0) {
-            queueModeHelper.waitForUpdate(queueModeHelper.sleeptime * 1010);
-        } else {
-            queueModeHelper.waitForUpdate(1);
-        }
+		// Trigger update manually for waking up
+		queueModeHelper.client.triggerRegistrationUpdate();
+		queueModeHelper.waitForUpdate(1);
 
-        // Check that client is awake
-        queueModeHelper.ensureClientAwake();
+		// Check that client is awake
+		queueModeHelper.ensureClientAwake();
 
-        // Send a response a check that it is received correctly
-        response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(), new ReadRequest(3, 0, 1));
-        queueModeHelper.ensureReceivedRequest(response);
-    }
+		// Send a response a check that it is received correctly
+		response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(), new ReadRequest(3, 0, 1));
+		queueModeHelper.ensureReceivedRequest(response);
+	}
 
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2017 RISE SICS AB.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     RISE SICS AB - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.leshan.integration.tests;
+
+import static org.eclipse.leshan.integration.tests.QueueModeIntegrationTestHelper.*;
+import static org.junit.Assert.assertArrayEquals;
+
+import org.eclipse.leshan.Link;
+import org.eclipse.leshan.core.request.ReadRequest;
+import org.eclipse.leshan.core.response.ReadResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueueModeTest {
+
+    protected QueueModeIntegrationTestHelper queueModeHelper = new QueueModeIntegrationTestHelper();
+
+    @Before
+    public void start() {
+        queueModeHelper.initialize();
+        queueModeHelper.createServer((int) AWAKETIME * 1000);
+        queueModeHelper.server.start();
+        queueModeHelper.createClient();
+    }
+
+    @After
+    public void stop() throws InterruptedException {
+        queueModeHelper.client.destroy(true);
+        queueModeHelper.server.destroy();
+        queueModeHelper.dispose();
+    }
+
+    @Test
+    public void awake_sleeping_awake_sleeping() {
+        // Check client is not registered
+        queueModeHelper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        queueModeHelper.client.start();
+        queueModeHelper.waitForRegistration(1);
+
+        // Check client is well registered
+        queueModeHelper.assertClientRegisterered();
+        assertArrayEquals(Link.parse("</>;rt=\"oma.lwm2m\",</1/0>,</2>,</3/0>,</2000/0>".getBytes()),
+                queueModeHelper.getCurrentRegistration().getObjectLinks());
+
+        // Check that client is awake and only one notification
+        queueModeHelper.ensureClientAwake();
+
+        // Wait for client awake time expiration (1% margin)
+        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+
+        // Check that client is sleeping
+        queueModeHelper.ensureClientSleeping();
+
+        // Wait for update when waking up (1% margin)
+        queueModeHelper.waitForUpdate(SLEEPTIME * 1010);
+
+        // Check that client is awake
+        queueModeHelper.ensureClientAwake();
+        queueModeHelper.resetAwakeLatch();
+
+        // Wait for client awake time expiration (1% margin)
+        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+
+        // Check that client is sleeping
+        queueModeHelper.ensureClientSleeping();
+
+        // Stop client with out de-registration
+        queueModeHelper.client.stop(false);
+    }
+
+    @Test
+    public void one_awake_notification() {
+
+        // Check client is not registered
+        queueModeHelper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        queueModeHelper.client.start();
+        queueModeHelper.waitForRegistration(1);
+
+        // Check client is well registered
+        queueModeHelper.assertClientRegisterered();
+
+        // Check that client is awake and only one awake notification
+        queueModeHelper.ensureClientAwake();
+        queueModeHelper.ensureOneAwakeNotification();
+
+        // Triggers one update
+        queueModeHelper.client.triggerRegistrationUpdate();
+        queueModeHelper.waitForUpdate(1000);
+        queueModeHelper.resetLatch();
+
+        // Check only one notification
+        queueModeHelper.ensureOneAwakeNotification();
+
+        // Wait for client awake time expiration (1% margin)
+        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+
+        // Check that client is sleeping
+        queueModeHelper.ensureClientSleeping();
+
+        // Wait for update when waking up (1% margin)
+        queueModeHelper.waitForUpdate(SLEEPTIME * 1010);
+
+        // Check that client is awake
+        queueModeHelper.ensureClientAwake();
+        queueModeHelper.resetAwakeLatch();
+
+        // Triggers two updates
+        queueModeHelper.client.triggerRegistrationUpdate();
+        queueModeHelper.waitForUpdate(1010);
+        queueModeHelper.resetLatch();
+        queueModeHelper.client.triggerRegistrationUpdate();
+        queueModeHelper.waitForUpdate(1010);
+        queueModeHelper.resetLatch();
+
+        // Check only one notification
+        queueModeHelper.ensureOneAwakeNotification();
+
+    }
+
+    @Test
+    public void sleeping_if_timeout() throws InterruptedException {
+
+        // Check client is not registered
+        queueModeHelper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        queueModeHelper.client.start();
+        queueModeHelper.waitForRegistration(1);
+
+        // Check client is well registered and awake
+        queueModeHelper.assertClientRegisterered();
+        queueModeHelper.ensureClientAwake();
+
+        // Send a response with very short timeout so that exception is thrown
+        ReadResponse response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(),
+                new ReadRequest(3, 0, 1), 1);
+
+        // Check that a timeout occurs
+        queueModeHelper.ensureTimeoutException(response);
+
+        // Check that the client is sleeping
+        queueModeHelper.ensureClientSleeping();
+    }
+
+    @Test
+    public void correct_sending_when_awake() throws InterruptedException {
+        ReadResponse response;
+
+        // Check client is not registered
+        queueModeHelper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        queueModeHelper.client.start();
+        queueModeHelper.waitForRegistration(1);
+
+        // Check client is well registered and awake
+        queueModeHelper.assertClientRegisterered();
+        queueModeHelper.ensureClientAwake();
+
+        // Send a response a check that it is received correctly
+        response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(), new ReadRequest(3, 0, 1));
+        queueModeHelper.ensureReceivedRequest(response);
+
+        // Wait for client awake time expiration (1% margin)
+        queueModeHelper.waitForAwakeTime(AWAKETIME * 1010);
+
+        // Check that client is sleeping
+        queueModeHelper.ensureClientSleeping();
+
+        // Wait for update when waking up (1% margin)
+        queueModeHelper.waitForUpdate(SLEEPTIME * 1010);
+
+        // Check that client is awake
+        queueModeHelper.ensureClientAwake();
+
+        // Send a response a check that it is received correctly
+        response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(), new ReadRequest(3, 0, 1));
+        queueModeHelper.ensureReceivedRequest(response);
+    }
+
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
@@ -157,7 +157,9 @@ public class QueueModeTest {
         queueModeHelper.assertClientRegisterered();
         queueModeHelper.ensureClientAwake();
 
-        // Send a response with very short timeout so that exception is thrown
+        // Stop the client to ensure that TimeOut exception is thrown
+        queueModeHelper.client.stop(false);
+        // Send a response with very short timeout
         ReadResponse response = queueModeHelper.server.send(queueModeHelper.getCurrentRegistration(),
                 new ReadRequest(3, 0, 1), 1);
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceServiceImpl.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/PresenceServiceImpl.java
@@ -84,7 +84,9 @@ public final class PresenceServiceImpl implements PresenceService {
 
                 // Every time we set the clientAwakeTime, in case it changes dynamically
                 stateChanged = status.setAwake();
-                startClientAwakeTimer(reg, status, awakeTimeProvider.getClientAwakeTime(reg));
+                if (stateChanged) {
+                    startClientAwakeTimer(reg, status, awakeTimeProvider.getClientAwakeTime(reg));
+                }
             }
 
             if (stateChanged) {


### PR DESCRIPTION
In this PR I have implemented some integration tests for the Queue Mode. For it, I have created the class `QueueModeIntegrationTestHelper` which is similar to the already present `IntegrationTestHelper`, but creates a client that registers with binding mode UQ and also triggers an update according to its sleeping time (and not its lifetime). This is done with a timer that it's started when `onSleeping()` is called. The class also starts a server with the corresponding `StaticClientAwakeTimerProvider`.

Then, using this class I've created four different tests:

- Normal awake/sleeping behaviour
- Check that if an update message arrives when the client is already awake, only one notification is done. Here I realized that the awake timer was restarted on every update message before, without checking if the state has actually changed. I have updated this wrong behavior.
- Check that if a response timeout occurs, the client state changes to sleeping
- Check that the server can make requests when the client is awake.

All feedback on this implementation is welcomed, cause as I've already mentioned, I'm not really familiar with these integration tests. Also feel free to suggest more test, and even implement them. 