### PR TITLE
Spring cleaning of maven configuration

### DIFF
--- a/leshan-all/pom.xml
+++ b/leshan-all/pom.xml
@@ -40,7 +40,6 @@ Contributors:
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <includeDependencySources>true</includeDependencySources>
@@ -50,7 +49,6 @@ Contributors:
                 </configuration>
             </plugin> 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>

--- a/leshan-all/pom.xml
+++ b/leshan-all/pom.xml
@@ -50,7 +50,6 @@ Contributors:
             </plugin> 
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <createSourcesJar>true</createSourcesJar>

--- a/leshan-bsserver-demo/pom.xml
+++ b/leshan-bsserver-demo/pom.xml
@@ -74,7 +74,6 @@ Contributors:
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>

--- a/leshan-bsserver-demo/pom.xml
+++ b/leshan-bsserver-demo/pom.xml
@@ -75,7 +75,6 @@ Contributors:
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -99,7 +98,6 @@ Contributors:
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/leshan-client-cf/pom.xml
+++ b/leshan-client-cf/pom.xml
@@ -68,7 +68,7 @@ Contributors:
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <_exportcontents>!*.impl.*, !*.internal.*, *</_exportcontents>
+                        <_exportcontents>*</_exportcontents>
                         <Import-Package>*</Import-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>

--- a/leshan-client-core/pom.xml
+++ b/leshan-client-core/pom.xml
@@ -56,7 +56,7 @@ Contributors:
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <_exportcontents>!*.impl.*, !*.internal.*, *</_exportcontents>
+                        <_exportcontents>*</_exportcontents>
                         <Import-Package>*</Import-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>

--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -48,7 +48,6 @@ Contributors:
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -47,7 +47,6 @@ Contributors:
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>

--- a/leshan-core-cf/pom.xml
+++ b/leshan-core-cf/pom.xml
@@ -40,6 +40,7 @@ Contributors:
             <groupId>org.eclipse.californium</groupId>
             <artifactId>scandium</artifactId>
         </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/leshan-core-cf/pom.xml
+++ b/leshan-core-cf/pom.xml
@@ -57,7 +57,7 @@ Contributors:
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <_exportcontents>!*.impl.*, !*.internal.*, *</_exportcontents>
+                        <_exportcontents>*</_exportcontents>
                         <Import-Package>*</Import-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>

--- a/leshan-core/pom.xml
+++ b/leshan-core/pom.xml
@@ -60,7 +60,7 @@ Contributors:
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <_exportcontents>!models.*, !*.impl.*, !*.internal.*, *</_exportcontents>
+                        <_exportcontents>*</_exportcontents>
                         <Import-Package>*</Import-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>

--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -27,7 +27,6 @@ Contributors:
 
 
     <dependencies>
-
         <dependency>
             <groupId>org.eclipse.leshan</groupId>
             <artifactId>leshan-server-cf</artifactId>

--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -75,6 +75,18 @@ Contributors:
         </testResources>
         <plugins>
             <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <skipIfEmpty>true</skipIfEmpty>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludes>

--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -75,7 +75,6 @@ Contributors:
         </testResources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludes>

--- a/leshan-server-cf/pom.xml
+++ b/leshan-server-cf/pom.xml
@@ -67,7 +67,7 @@ Contributors:
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <_exportcontents>!*.impl.*, !*.internal.*, *</_exportcontents>
+                        <_exportcontents>*</_exportcontents>
                         <Import-Package>*</Import-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>

--- a/leshan-server-cluster/pom.xml
+++ b/leshan-server-cluster/pom.xml
@@ -82,7 +82,6 @@ Contributors:
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/leshan-server-cluster/pom.xml
+++ b/leshan-server-cluster/pom.xml
@@ -81,7 +81,6 @@ Contributors:
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>

--- a/leshan-server-demo/pom.xml
+++ b/leshan-server-demo/pom.xml
@@ -92,7 +92,6 @@ Contributors:
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -116,7 +115,6 @@ Contributors:
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/leshan-server-demo/pom.xml
+++ b/leshan-server-demo/pom.xml
@@ -91,7 +91,6 @@ Contributors:
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>

--- a/leshan-server-demo/pom.xml
+++ b/leshan-server-demo/pom.xml
@@ -27,13 +27,11 @@ Contributors:
     <description>A LWM2M demonstration server running an embedded Jetty server</description>
 
     <dependencies>
-
         <dependency>
             <groupId>org.jmdns</groupId>
             <artifactId>jmdns</artifactId>
             <version>3.5.2</version>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.leshan</groupId>
             <artifactId>leshan-server-cf</artifactId>
@@ -66,7 +64,6 @@ Contributors:
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-continuation</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -86,6 +83,7 @@ Contributors:
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,10 @@ Contributors:
                     <version>2.4</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.7</version>
@@ -355,6 +359,24 @@ Contributors:
                      </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.5</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                     </execution>
+                 </executions>
+             </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,6 @@ Contributors:
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.6</version>
                         <executions>
@@ -162,7 +161,6 @@ Contributors:
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>
@@ -174,7 +172,6 @@ Contributors:
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
                             <execution>
@@ -205,7 +202,6 @@ Contributors:
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.4</version>
                 <executions>
@@ -222,7 +218,6 @@ Contributors:
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.3</version>
                     <configuration>
@@ -235,7 +230,6 @@ Contributors:
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.19</version>
                     <configuration>
@@ -261,7 +255,6 @@ Contributors:
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.3</version>
                     <configuration>
@@ -269,7 +262,6 @@ Contributors:
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-eclipse-plugin</artifactId>
                     <configuration>
                         <downloadSources>true</downloadSources>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,6 @@ Contributors:
                 <plugins>
                     <plugin>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -185,7 +184,6 @@ Contributors:
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -200,23 +198,58 @@ Contributors:
     </profiles>
 
     <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>2.0-beta-4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.google.code.maven-replacer-plugin</groupId>
+                    <artifactId>replacer</artifactId>
+                    <version>1.5.3</version>
+                </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.3</version>
@@ -234,8 +267,8 @@ Contributors:
                     <version>2.19</version>
                     <configuration>
                         <systemPropertyVariables>
-                         	<logback.configurationFile>logback-test.xml</logback.configurationFile>
-                    	</systemPropertyVariables>
+                             <logback.configurationFile>logback-test.xml</logback.configurationFile>
+                        </systemPropertyVariables>
                         <parallel>classes</parallel>
                         <threadCount>4</threadCount>
                         <excludes>
@@ -263,6 +296,7 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-eclipse-plugin</artifactId>
+                    <version>2.2</version>
                     <configuration>
                         <downloadSources>true</downloadSources>
                         <downloadJavadocs>false</downloadJavadocs>
@@ -308,6 +342,20 @@ Contributors:
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                     </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -202,11 +202,11 @@ Contributors:
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.8.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -214,11 +214,11 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>2.0-beta-4</version>
+                    <version>3.7</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
@@ -226,7 +226,7 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>
@@ -234,11 +234,11 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
@@ -247,7 +247,7 @@ Contributors:
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.7</version>
+                    <version>1.6.8</version>
                 </plugin>
                 <plugin>
                     <groupId>com.google.code.maven-replacer-plugin</groupId>
@@ -256,7 +256,7 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.7.0</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
                         <source>1.7</source>
@@ -268,7 +268,7 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19</version>
+                    <version>2.20.1</version>
                     <configuration>
                         <systemPropertyVariables>
                              <logback.configurationFile>logback-test.xml</logback.configurationFile>
@@ -282,7 +282,7 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.0.2</version>
                     <configuration>
                         <archive>
                             <manifestEntries>
@@ -293,7 +293,7 @@ Contributors:
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <excludePackageNames>org.eclipse.leshan.util</excludePackageNames>
                     </configuration>
@@ -327,7 +327,7 @@ Contributors:
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,13 @@ Contributors:
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <test.exclusion.pattern>**/Redis*.java</test.exclusion.pattern>
+
+        <!-- dependencies version -->
         <californium.version>2.0.0-M9</californium.version>
         <logback.version>1.2.3</logback.version>
         <slf4j.api.version>1.7.25</slf4j.api.version>
         <jetty.version>9.1.4.v20140401</jetty.version>
-        <test.exclusion.pattern>**/Redis*.java</test.exclusion.pattern>
     </properties>
 
     <distributionManagement>
@@ -131,10 +133,11 @@ Contributors:
             </modules>
         </profile>
         <profile>
-          <id>redis</id>
-          <properties>
+            <!-- This profile launch all redis integration tests -->
+            <id>redis</id>
+            <properties>
                 <test.exclusion.pattern>nothing</test.exclusion.pattern>
-          </properties>
+            </properties>
         </profile>
         <profile>
             <!-- this profile generate all the needed artifact and signatures needed, then release it on maven central -->
@@ -317,6 +320,7 @@ Contributors:
 
     <dependencyManagement>
         <dependencies>
+            <!-- Leshan Libraries -->
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>leshan-core</artifactId>
@@ -339,17 +343,7 @@ Contributors:
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>leshan-bs-server</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
                 <artifactId>leshan-server-cf</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${project.groupId}</groupId>
-                <artifactId>leshan-server-cluster</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -358,13 +352,15 @@ Contributors:
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.api.version}</version>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>leshan-server-cluster</artifactId>
+                <version>${project.version}</version>
             </dependency>
+            
+             <!-- Leshan library dependencies -->
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
+                <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.api.version}</version>
             </dependency>
             <dependency>
@@ -383,14 +379,26 @@ Contributors:
                 <version>${californium.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>2.2.4</version>
-            </dependency>
-            <dependency>
                 <groupId>com.eclipsesource.minimal-json</groupId>
                 <artifactId>minimal-json</artifactId>
                 <version>0.9.5</version>
+            </dependency>
+
+            <!-- Demos, examples and tests dependencies -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.2.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
@@ -423,12 +431,6 @@ Contributors:
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.11</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${logback.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Inspired by works I have already done in californium. (https://github.com/eclipse/californium/pull/562)

About OSGI, I asked if it is using on the [mailing list](https://dev.eclipse.org/mhonarc/lists/leshan-dev/msg00969.html) and no feedback until now.
So I change Apache Felix Maven Bundle Plugin configuration to the strict minmal => meaning all packages are public.