### PR TITLE
Change Authorizer API to return a registration instead of boolean.

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -64,10 +64,9 @@ public class RegistrationHandler {
                 .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
                 .additionalRegistrationAttributes(registerRequest.getAdditionalAttributes());
 
-        final Registration registration = builder.build();
-
         // We must check if the client is using the right identity.
-        if (!authorizer.isAuthorized(registerRequest, registration, sender)) {
+        final Registration registration = authorizer.isAuthorized(registerRequest, builder.build(), sender);
+        if (registration == null) {
             return new SendableResponse<>(RegisterResponse.forbidden(null));
         }
 
@@ -101,7 +100,7 @@ public class RegistrationHandler {
             return new SendableResponse<>(UpdateResponse.notFound());
         }
 
-        if (!authorizer.isAuthorized(updateRequest, registration, sender)) {
+        if (authorizer.isAuthorized(updateRequest, registration, sender) == null) {
             // TODO replace by Forbidden if https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181 is
             // closed.
             return new SendableResponse<>(UpdateResponse.badRequest("forbidden"));
@@ -138,7 +137,7 @@ public class RegistrationHandler {
         if (registration == null) {
             return new SendableResponse<>(DeregisterResponse.notFound());
         }
-        if (!authorizer.isAuthorized(deregisterRequest, registration, sender)) {
+        if (authorizer.isAuthorized(deregisterRequest, registration, sender) == null) {
             // TODO replace by Forbidden if https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181 is
             // closed.
             return new SendableResponse<>(DeregisterResponse.badRequest("forbidden"));

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/Authorizer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/Authorizer.java
@@ -29,8 +29,8 @@ public interface Authorizer {
     // closed.
 
     /**
-     * Return true if this request should be handle by the LWM2M Server. When false is returned the LWM2M server will
-     * stop to handle this request and will respond with a {@link ResponseCode#FORBIDDEN} or
+     * Return the registration if this request should be handle by the LWM2M Server. When <code>null</code> is returned
+     * the LWM2M server will stop to handle this request and will respond with a {@link ResponseCode#FORBIDDEN} or
      * {@link ResponseCode#BAD_REQUEST}.
      * 
      * @param request the request received
@@ -39,7 +39,7 @@ public interface Authorizer {
      *        For update request this is the registration before the update was done.
      * @param senderIdentity the {@link Identity} used to send the request.
      * 
-     * @return true if this request is authorized.
+     * @return the registration if this request is authorized or <code>null</code> it is not authorized.
      */
-    boolean isAuthorized(UplinkRequest<?> request, Registration registration, Identity senderIdentity);
+    Registration isAuthorized(UplinkRequest<?> request, Registration registration, Identity senderIdentity);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/DefaultAuthorizer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/DefaultAuthorizer.java
@@ -35,12 +35,16 @@ public class DefaultAuthorizer implements Authorizer {
     }
 
     @Override
-    public boolean isAuthorized(UplinkRequest<?> request, Registration registration, Identity senderIdentity) {
+    public Registration isAuthorized(UplinkRequest<?> request, Registration registration, Identity senderIdentity) {
 
         // do we have security information for this client?
         SecurityInfo expectedSecurityInfo = null;
         if (securityStore != null)
             expectedSecurityInfo = securityStore.getByEndpoint(registration.getEndpoint());
-        return SecurityCheck.checkSecurityInfo(registration.getEndpoint(), senderIdentity, expectedSecurityInfo);
+        if (SecurityCheck.checkSecurityInfo(registration.getEndpoint(), senderIdentity, expectedSecurityInfo)) {
+            return registration;
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
The idea is to allow user to create a custom registration which could be pass to RegistrationStore.

This could make sense if you need to store custom data linked to your registration. In this case you can create your own `CustomRegistration` which inherit `Registration` and return it in `Authorizer.isAuthorized`, then this will be passed to `RegistrationStore`.