### PR TITLE
DeleteRequest should target object instance only.

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/DeleteRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/DeleteRequest.java
@@ -41,7 +41,7 @@ public class DeleteRequest extends AbstractDownlinkRequest<DeleteResponse> {
      * @exception InvalidRequestException if the path is not valid.
      */
     public DeleteRequest(String path) throws InvalidRequestException {
-        super(newPath(path));
+        this(newPath(path));
     }
 
     private DeleteRequest(LwM2mPath target) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/DiscoverRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/DiscoverRequest.java
@@ -62,7 +62,7 @@ public class DiscoverRequest extends AbstractDownlinkRequest<DiscoverResponse> {
      * @exception InvalidRequestException if the path is not valid.
      */
     public DiscoverRequest(String path) throws InvalidRequestException {
-        super(newPath(path));
+        this(newPath(path));
     }
 
     private DiscoverRequest(LwM2mPath target) {


### PR DESCRIPTION
And for DiscoverRequest, there's nothing different with current behavior but just fixed it for patterns of DownlinkRequest classes.

Signed-off-by: Rokwoon Kim <k862390@gmail.com>