### PR TITLE
Cancellation of requests

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/LeshanServer.java
@@ -166,6 +166,7 @@ public class LeshanServer implements LwM2mServer {
             public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
                     Registration newReg) {
                 requestSender.cancelPendingRequests(registration);
+                observationService.cancelObservations(registration);
             }
 
             @Override


### PR DESCRIPTION
We have a problem with observation listeners that linger after a client has unregistered. Would the proposed change fix this, the comment directly above indicates that the intention was to also remove observations?