### PR TITLE
Add a way to make "atomic" operation (read/write) on LwM2mInstanceEnabler

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Device.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Device.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -56,7 +57,7 @@ public class Device extends BaseInstanceEnabler {
     }
 
     @Override
-    public ReadResponse read(int resourceid) {
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
 
         switch (resourceid) {
         case 0: // manufacturer
@@ -81,12 +82,12 @@ public class Device extends BaseInstanceEnabler {
             return ReadResponse.success(resourceid, supportedBinding);
 
         default:
-            return super.read(resourceid);
+            return super.read(identity, resourceid);
         }
     }
 
     @Override
-    public WriteResponse write(int resourceid, LwM2mResource value) {
+    public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
 
         switch (resourceid) {
 
@@ -101,17 +102,17 @@ public class Device extends BaseInstanceEnabler {
             return WriteResponse.success();
 
         default:
-            return super.write(resourceid, value);
+            return super.write(identity, resourceid, value);
         }
     }
 
     @Override
-    public ExecuteResponse execute(int resourceid, String params) {
+    public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
 
         if (resourceid == 4) { // reboot
             return ExecuteResponse.internalServerError("not implemented");
         } else {
-            return super.execute(resourceid, params);
+            return super.execute(identity, resourceid, params);
         }
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.leshan.SecurityMode;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -135,7 +136,7 @@ public class Security extends BaseInstanceEnabler {
     }
 
     @Override
-    public WriteResponse write(int resourceId, LwM2mResource value) {
+    public WriteResponse write(ServerIdentity identity, int resourceId, LwM2mResource value) {
         LOG.debug("Write on resource {}: {}", resourceId, value);
 
         // restricted to BS server?
@@ -189,13 +190,13 @@ public class Security extends BaseInstanceEnabler {
             return WriteResponse.success();
 
         default:
-            return super.write(resourceId, value);
+            return super.write(identity, resourceId, value);
         }
 
     }
 
     @Override
-    public ReadResponse read(int resourceid) {
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
         // only accessible for internal read?
 
         switch (resourceid) {
@@ -221,13 +222,13 @@ public class Security extends BaseInstanceEnabler {
             return ReadResponse.success(resourceid, shortServerId);
 
         default:
-            return super.read(resourceid);
+            return super.read(identity, resourceid);
         }
     }
 
     @Override
-    public ExecuteResponse execute(int resourceid, String params) {
-        return super.execute(resourceid, params);
+    public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
+        return super.execute(identity, resourceid, params);
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
@@ -20,6 +20,7 @@ package org.eclipse.leshan.client.object;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -56,7 +57,7 @@ public class Server extends BaseInstanceEnabler {
     }
 
     @Override
-    public ReadResponse read(int resourceid) {
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
 
         switch (resourceid) {
         case 0: // short server ID
@@ -82,12 +83,12 @@ public class Server extends BaseInstanceEnabler {
             return ReadResponse.success(resourceid, binding.toString());
 
         default:
-            return super.read(resourceid);
+            return super.read(identity, resourceid);
         }
     }
 
     @Override
-    public WriteResponse write(int resourceid, LwM2mResource value) {
+    public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
 
         switch (resourceid) {
 
@@ -138,18 +139,18 @@ public class Server extends BaseInstanceEnabler {
             }
 
         default:
-            return super.write(resourceid, value);
+            return super.write(identity, resourceid, value);
         }
     }
 
     @Override
-    public ExecuteResponse execute(int resourceid, String params) {
+    public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
 
         if (resourceid == 8) { // registration update trigger
             // TODO implement registration update trigger executable resource
             return ExecuteResponse.internalServerError("not implemented");
         } else {
-            return super.execute(resourceid, params);
+            return super.execute(identity, resourceid, params);
         }
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.response.ExecuteResponse;
@@ -67,24 +68,24 @@ public class BaseInstanceEnabler implements LwM2mInstanceEnabler {
     }
 
     @Override
-    public ReadResponse read(int resourceid) {
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
         return ReadResponse.notFound();
     }
 
     @Override
-    public WriteResponse write(int resourceid, LwM2mResource value) {
+    public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
         return WriteResponse.notFound();
     }
 
     @Override
-    public ExecuteResponse execute(int resourceid, String params) {
+    public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
         return ExecuteResponse.notFound();
     }
 
     @Override
-    public ObserveResponse observe(int resourceid) {
+    public ObserveResponse observe(ServerIdentity identity, int resourceid) {
         // Perform a read by default
-        ReadResponse readResponse = this.read(resourceid);
+        ReadResponse readResponse = this.read(identity, resourceid);
         return new ObserveResponse(readResponse.getCode(), readResponse.getContent(), null, null,
                 readResponse.getErrorMessage());
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnablerFactory.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnablerFactory.java
@@ -29,7 +29,7 @@ public abstract class BaseInstanceEnablerFactory implements LwM2mInstanceEnabler
         }
 
         // create new instance
-        LwM2mInstanceEnabler instance = create(model);
+        LwM2mInstanceEnabler instance = create();
 
         // set id if not already done
         if (instance.getId() == null) {
@@ -41,6 +41,9 @@ public abstract class BaseInstanceEnablerFactory implements LwM2mInstanceEnabler
                         String.format("instance id should be %d but was %d", id, instance.getId()));
             }
         }
+
+        // set model
+        instance.setModel(model);
 
         return instance;
     }
@@ -58,10 +61,9 @@ public abstract class BaseInstanceEnablerFactory implements LwM2mInstanceEnabler
     /**
      * Create a new instance enabler.
      * 
-     * @param model of this instance (CAN NOT be null).
      * @return the new instance enabler
      */
-    public abstract LwM2mInstanceEnabler create(ObjectModel model);
+    public abstract LwM2mInstanceEnabler create();
 
     public static int generateNewInstanceId(Collection<Integer> alreadyUsedIdentifier) {
         if (alreadyUsedIdentifier.isEmpty()) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -93,10 +93,10 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
                 return CreateResponse.notFound();
             }
         }
-        return doCreate(request);
+        return doCreate(identity, request);
     }
 
-    protected CreateResponse doCreate(CreateRequest request) {
+    protected CreateResponse doCreate(ServerIdentity identity, CreateRequest request) {
         // This should be a not implemented error, but this is not defined in the spec.
         return CreateResponse.internalServerError("not implemented");
     }
@@ -230,10 +230,10 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
             }
         }
 
-        return doDelete(request);
+        return doDelete(identity, request);
     }
 
-    protected DeleteResponse doDelete(DeleteRequest request) {
+    protected DeleteResponse doDelete(ServerIdentity identity, DeleteRequest request) {
         // This should be a not implemented error, but this is not defined in the spec.
         return DeleteResponse.internalServerError("not implemented");
     }
@@ -245,10 +245,10 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
                 return BootstrapDeleteResponse.badRequest("Device object instance is not deletable");
             }
         }
-        return doDelete(request);
+        return doDelete(identity, request);
     }
 
-    public BootstrapDeleteResponse doDelete(BootstrapDeleteRequest request) {
+    public BootstrapDeleteResponse doDelete(ServerIdentity identity, BootstrapDeleteRequest request) {
         // This should be a not implemented error, but this is not defined in the spec.
         return BootstrapDeleteResponse.internalServerError("not implemented");
     }
@@ -278,10 +278,10 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
             return ExecuteResponse.methodNotAllowed();
         }
 
-        return doExecute(request);
+        return doExecute(identity, request);
     }
 
-    protected ExecuteResponse doExecute(ExecuteRequest request) {
+    protected ExecuteResponse doExecute(ServerIdentity identity, ExecuteRequest request) {
         // This should be a not implemented error, but this is not defined in the spec.
         return ExecuteResponse.internalServerError("not implemented");
     }
@@ -305,11 +305,11 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
         if (id == LwM2mId.SECURITY) {
             return DiscoverResponse.notFound();
         }
-        return doDiscover(request);
+        return doDiscover(identity, request);
 
     }
 
-    protected DiscoverResponse doDiscover(DiscoverRequest request) {
+    protected DiscoverResponse doDiscover(ServerIdentity identity, DiscoverRequest request) {
 
         LwM2mPath path = request.getPath();
         if (path.isObject()) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
@@ -20,6 +20,7 @@ package org.eclipse.leshan.client.resource;
 
 import java.util.List;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.response.ExecuteResponse;
@@ -77,41 +78,49 @@ public interface LwM2mInstanceEnabler {
     /**
      * Gets the current value of one of this LWM2M object instance's resources.
      * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
      * @param resourceId the ID of the resource to get the value of
      * @return the response object representing the outcome of the operation. An implementation should set the result's
      *         {@link ReadResponse#getCode() response code} to either reflect the success or reason for failure to
      *         retrieve the value.
      */
-    ReadResponse read(int resourceId);
+    ReadResponse read(ServerIdentity identity, int resourceId);
 
     /**
      * Sets the value of one of this LWM2M object instance's resources.
      * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
      * @param resourceid the ID of the resource to set the value for
      * @param value the value to set the resource to
      * @return the response object representing the outcome of the operation. An implementation should set the result's
      *         {@link WriteResponse#getCode() response code} to either reflect the success or reason for failure to set
      *         the value.
      */
-    WriteResponse write(int resourceid, LwM2mResource value);
+    WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value);
 
     /**
      * Executes the operation represented by one of this LWM2M object instance's resources.
      * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
      * @param resourceid the ID of the resource to set the value for
      * @param params the input parameters of the operation
      * @return the response object representing the outcome of the operation. An implementation should set the result's
      *         {@link ExecuteResponse#getCode() response code} to either reflect the success or reason for failure to
      *         execute the operation.
      */
-    ExecuteResponse execute(int resourceid, String params);
+    ExecuteResponse execute(ServerIdentity identity, int resourceid, String params);
 
     /**
      * Performs an observe register on one of this LWM2M object instance's resources.
-     *
+     * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
      * @param resourceid the ID of the resource to set the value for
      */
-    ObserveResponse observe(int resourceid);
+    ObserveResponse observe(ServerIdentity identity, int resourceid);
 
     /**
      * @param objectModel the model of this instance

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
@@ -22,7 +22,9 @@ import java.util.List;
 
 import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.request.WriteRequest.Mode;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -62,6 +64,14 @@ public interface LwM2mInstanceEnabler {
     void setId(int id);
 
     /**
+     * Set the model of this instance. It should be called only by
+     * {@link LwM2mInstanceEnablerFactory#create(ObjectModel, Integer, java.util.Collection)}.
+     * 
+     * @param model the model of this instance
+     */
+    void setModel(ObjectModel model);
+
+    /**
      * Adds a callback handler that gets notified about changes to any of this LWM2M object instance's resources.
      * 
      * @param listener the handler to add, a <code>null</code> value is silently ignored
@@ -76,6 +86,17 @@ public interface LwM2mInstanceEnabler {
     void removeResourceChangedListener(ResourceChangedListener listener);
 
     /**
+     * Gets values of all readable resources of this instance.
+     * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
+     * 
+     * @return a success response with an {@link LwM2mObjectInstance} as content or a failure response with optional
+     *         explanation message.
+     */
+    ReadResponse read(ServerIdentity identity);
+
+    /**
      * Gets the current value of one of this LWM2M object instance's resources.
      * 
      * @param identity the identity of the requester. This could be an internal call in this case
@@ -86,6 +107,19 @@ public interface LwM2mInstanceEnabler {
      *         retrieve the value.
      */
     ReadResponse read(ServerIdentity identity, int resourceId);
+
+    /**
+     * Sets all resources of this LWM2M object instance.
+     * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
+     * @param replace if replace is true a {@link Mode#REPLACE} should be done, else {@link Mode#UPDATE} should be done.
+     * @param value all the resources to be written.
+     * @return the response object representing the outcome of the operation. An implementation should set the result's
+     *         {@link WriteResponse#getCode() response code} to either reflect the success or reason for failure to set
+     *         the value.
+     */
+    WriteResponse write(ServerIdentity identity, boolean replace, LwM2mObjectInstance value);
 
     /**
      * Sets the value of one of this LWM2M object instance's resources.
@@ -114,6 +148,16 @@ public interface LwM2mInstanceEnabler {
     ExecuteResponse execute(ServerIdentity identity, int resourceid, String params);
 
     /**
+     * Performs an observe register the whole LWM2M object instance.
+     * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
+     * @return a success response with an {@link LwM2mObjectInstance} as content or a failure response with optional
+     *         explanation message.
+     */
+    ObserveResponse observe(ServerIdentity identity);
+
+    /**
      * Performs an observe register on one of this LWM2M object instance's resources.
      * 
      * @param identity the identity of the requester. This could be an internal call in this case
@@ -135,5 +179,4 @@ public interface LwM2mInstanceEnabler {
      * @param resourceId the ID of the resource to be reseted
      */
     void reset(int resourceId);
-
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectsInitializer.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectsInitializer.java
@@ -31,10 +31,8 @@ public class ObjectsInitializer {
 
     protected LwM2mInstanceEnablerFactory defaultFactory = new BaseInstanceEnablerFactory() {
         @Override
-        public LwM2mInstanceEnabler create(ObjectModel model) {
-            SimpleInstanceEnabler simpleInstanceEnabler = new SimpleInstanceEnabler();
-            simpleInstanceEnabler.setObjectModel(model);
-            return simpleInstanceEnabler;
+        public LwM2mInstanceEnabler create() {
+            return new SimpleInstanceEnabler();
         }
     };
 
@@ -167,6 +165,7 @@ public class ObjectsInitializer {
                 int id = BaseInstanceEnablerFactory.generateNewInstanceId(instances.keySet());
                 instance.setId(id);
             }
+            instance.setModel(objectModel);
             instances.put(instance.getId(), instance);
         }
         return new ObjectEnabler(objectModel.id, objectModel, instances, getFactoryFor(objectModel),
@@ -198,7 +197,7 @@ public class ObjectsInitializer {
     protected LwM2mInstanceEnablerFactory getClassFactory(final Class<? extends LwM2mInstanceEnabler> clazz) {
         LwM2mInstanceEnablerFactory factory = new BaseInstanceEnablerFactory() {
             @Override
-            public LwM2mInstanceEnabler create(ObjectModel model) {
+            public LwM2mInstanceEnabler create() {
                 try {
                     return clazz.newInstance();
                 } catch (InstantiationException | IllegalAccessException e) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
@@ -38,7 +38,6 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
 
     private static Logger LOG = LoggerFactory.getLogger(SimpleInstanceEnabler.class);
     protected Map<Integer, LwM2mResource> resources = new HashMap<>();
-    protected ObjectModel objectModel;
 
     public SimpleInstanceEnabler() {
     }
@@ -65,7 +64,7 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
 
     @Override
     public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
-        if (objectModel.resources.containsKey(resourceid)) {
+        if (getModel().resources.containsKey(resourceid)) {
             LOG.info("Executing resource [{}] with params [{}]", resourceid, params);
             return ExecuteResponse.success();
         } else {
@@ -78,8 +77,9 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
         resources.remove(resourceid);
     }
 
-    public void setObjectModel(ObjectModel objectModel) {
-        this.objectModel = objectModel;
+    @Override
+    public void setModel(ObjectModel objectModel) {
+        super.setModel(objectModel);
 
         // initialize resources
         for (ResourceModel resourceModel : objectModel.resources.values()) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
@@ -47,7 +48,7 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
     }
 
     @Override
-    public ReadResponse read(int resourceid) {
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
         if (resources.containsKey(resourceid)) {
             return ReadResponse.success(resources.get(resourceid));
         }
@@ -55,7 +56,7 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
     }
 
     @Override
-    public WriteResponse write(int resourceid, LwM2mResource value) {
+    public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
         LwM2mResource previousValue = resources.put(resourceid, value);
         if (!value.equals(previousValue))
             fireResourcesChange(resourceid);
@@ -63,7 +64,7 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
     }
 
     @Override
-    public ExecuteResponse execute(int resourceid, String params) {
+    public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
         if (objectModel.resources.containsKey(resourceid)) {
             LOG.info("Executing resource [{}] with params [{}]", resourceid, params);
             return ExecuteResponse.success();

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import org.eclipse.leshan.LwM2mId;
 import org.eclipse.leshan.SecurityMode;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.core.node.LwM2mObject;
@@ -231,7 +232,7 @@ public class ServersInfoExtractor {
     }
 
     public static boolean isBootstrapServer(LwM2mInstanceEnabler instance) {
-        ReadResponse response = instance.read(LwM2mId.SEC_BOOTSTRAP);
+        ReadResponse response = instance.read(ServerIdentity.SYSTEM, LwM2mId.SEC_BOOTSTRAP);
         if (response == null || response.isFailure()) {
             return false;
         }

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/BaseInstanceEnablerFactoryTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/BaseInstanceEnablerFactoryTest.java
@@ -27,7 +27,6 @@ import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.client.resource.SimpleInstanceEnabler;
 import org.eclipse.leshan.core.model.LwM2mModel;
 import org.eclipse.leshan.core.model.ObjectLoader;
-import org.eclipse.leshan.core.model.ObjectModel;
 import org.junit.Test;
 
 public class BaseInstanceEnablerFactoryTest {
@@ -42,7 +41,7 @@ public class BaseInstanceEnablerFactoryTest {
         BaseInstanceEnablerFactory badInstanceEnablerFactory = new BaseInstanceEnablerFactory() {
 
             @Override
-            public LwM2mInstanceEnabler create(ObjectModel model) {
+            public LwM2mInstanceEnabler create() {
                 // do no respect the contract and set a bad id;
                 return new SimpleInstanceEnabler(id + 1);
             }
@@ -56,7 +55,7 @@ public class BaseInstanceEnablerFactoryTest {
         BaseInstanceEnablerFactory instanceEnablerFactory = new BaseInstanceEnablerFactory() {
 
             @Override
-            public LwM2mInstanceEnabler create(ObjectModel model) {
+            public LwM2mInstanceEnabler create() {
                 return new SimpleInstanceEnabler();
             }
         };

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
@@ -174,17 +174,16 @@ public class LinkFormatHelperTest {
         // create factory
         BaseInstanceEnablerFactory factory = new BaseInstanceEnablerFactory() {
             @Override
-            public LwM2mInstanceEnabler create(ObjectModel model) {
-                SimpleInstanceEnabler simpleInstanceEnabler = new SimpleInstanceEnabler();
-                simpleInstanceEnabler.setObjectModel(model);
-                return simpleInstanceEnabler;
+            public LwM2mInstanceEnabler create() {
+                return new SimpleInstanceEnabler();
             }
         };
 
         // create first instance
         Map<Integer, LwM2mInstanceEnabler> instances = new HashMap<>();
-        LwM2mInstanceEnabler instance = factory.create(objectModel);
+        LwM2mInstanceEnabler instance = factory.create();
         instance.setId(0);
+        instance.setModel(objectModel);
         instances.put(0, instance);
 
         // create objectEnabler

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
@@ -12,6 +12,7 @@ import java.util.TimeZone;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
@@ -42,7 +43,7 @@ public class MyDevice extends BaseInstanceEnabler {
     }
 
     @Override
-    public ReadResponse read(int resourceid) {
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
         LOG.info("Read on Device Resource " + resourceid);
         switch (resourceid) {
         case 0:
@@ -80,12 +81,12 @@ public class MyDevice extends BaseInstanceEnabler {
         case 21:
             return ReadResponse.success(resourceid, getMemoryTotal());
         default:
-            return super.read(resourceid);
+            return super.read(identity, resourceid);
         }
     }
 
     @Override
-    public ExecuteResponse execute(int resourceid, String params) {
+    public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
         LOG.info("Execute on Device resource " + resourceid);
         if (params != null && params.length() != 0)
             System.out.println("\t params " + params);
@@ -93,7 +94,7 @@ public class MyDevice extends BaseInstanceEnabler {
     }
 
     @Override
-    public WriteResponse write(int resourceid, LwM2mResource value) {
+    public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
         LOG.info("Write on Device Resource " + resourceid + " value " + value);
         switch (resourceid) {
         case 13:
@@ -107,7 +108,7 @@ public class MyDevice extends BaseInstanceEnabler {
             fireResourcesChange(resourceid);
             return WriteResponse.success();
         default:
-            return super.write(resourceid, value);
+            return super.write(identity, resourceid, value);
         }
     }
 

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyLocation.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyLocation.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -43,7 +44,7 @@ public class MyLocation extends BaseInstanceEnabler {
     }
 
     @Override
-    public ReadResponse read(int resourceid) {
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
         LOG.info("Read on Location Resource " + resourceid);
         switch (resourceid) {
         case 0:
@@ -53,7 +54,7 @@ public class MyLocation extends BaseInstanceEnabler {
         case 5:
             return ReadResponse.success(resourceid, getTimestamp());
         default:
-            return super.read(resourceid);
+            return super.read(identity, resourceid);
         }
     }
 

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.response.ExecuteResponse;
@@ -43,7 +44,7 @@ public class RandomTemperatureSensor extends BaseInstanceEnabler {
     }
 
     @Override
-    public synchronized ReadResponse read(int resourceId) {
+    public synchronized ReadResponse read(ServerIdentity identity, int resourceId) {
         switch (resourceId) {
         case MIN_MEASURED_VALUE:
             return ReadResponse.success(resourceId, getTwoDigitValue(minMeasuredValue));
@@ -54,18 +55,18 @@ public class RandomTemperatureSensor extends BaseInstanceEnabler {
         case UNITS:
             return ReadResponse.success(resourceId, UNIT_CELSIUS);
         default:
-            return super.read(resourceId);
+            return super.read(identity, resourceId);
         }
     }
 
     @Override
-    public synchronized ExecuteResponse execute(int resourceId, String params) {
+    public synchronized ExecuteResponse execute(ServerIdentity identity, int resourceId, String params) {
         switch (resourceId) {
         case RESET_MIN_MAX_MEASURED_VALUES:
             resetMinMaxMeasuredValues();
             return ExecuteResponse.success();
         default:
-            return super.execute(resourceId, params);
+            return super.execute(identity, resourceId, params);
         }
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -33,6 +33,7 @@ import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.object.Server;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.model.LwM2mModel;
@@ -130,11 +131,11 @@ public class IntegrationTestHelper {
         initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.U, false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U") {
             @Override
-            public ExecuteResponse execute(int resourceid, String params) {
+            public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
                 if (resourceid == 4) {
                     return ExecuteResponse.success();
                 } else {
-                    return super.execute(resourceid, params);
+                    return super.execute(identity, resourceid, params);
                 }
             }
         });

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
@@ -27,6 +27,7 @@ import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.object.Server;
+import org.eclipse.leshan.client.request.ServerIdentity;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.model.LwM2mModel;
@@ -69,11 +70,11 @@ public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
         initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.UQ, false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "UQ") {
             @Override
-            public ExecuteResponse execute(int resourceid, String params) {
+            public ExecuteResponse execute(ServerIdentity identity, int resourceid, String params) {
                 if (resourceid == 4) {
                     return ExecuteResponse.success();
                 } else {
-                    return super.execute(resourceid, params);
+                    return super.execute(identity, resourceid, params);
                 }
             }
         });


### PR DESCRIPTION
Experimental work to try to support https://github.com/eclipse/leshan/issues/597#issuecomment-437888248

>At the client side I need to read all resources of a particular instance and pass it to another layer. Now since resources ids are called one by one in switch case (write/read), its not possible to send complete object at once. Thats the main reason I wanted to read complete instance at once and pass it to other layer.

The new API in LwM2mInstanceEnabler

```java
/**
* Gets values of all readable resources of this instance.
* 
* @param identity the identity of the requester. This could be an internal call in this case
*        <code> identity == ServerIdentity.SYSTEM</code>.
* 
* @return a success response with an {@link LwM2mObjectInstance} as content or a failure response with optional
*         explanation message.
*/
ReadResponse read(ServerIdentity identity);
```