### PR TITLE
Add ACL to Bootstrap Server Config

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -33,6 +33,8 @@ public class BootstrapConfig implements Serializable {
 
     public Map<Integer, ServerSecurity> security = new HashMap<>();
 
+    public Map<Integer, ACLConfig> acls = new HashMap<>();
+
     /** server configuration (object 1) */
     static public class ServerConfig implements Serializable {
         public int shortId;
@@ -45,10 +47,9 @@ public class BootstrapConfig implements Serializable {
 
         @Override
         public String toString() {
-            return String
-                    .format("ServerConfig [shortId=%s, lifetime=%s, defaultMinPeriod=%s, defaultMaxPeriod=%s, disableTimeout=%s, notifIfDisabled=%s, binding=%s]",
-                            shortId, lifetime, defaultMinPeriod, defaultMaxPeriod, disableTimeout, notifIfDisabled,
-                            binding);
+            return String.format(
+                    "ServerConfig [shortId=%s, lifetime=%s, defaultMinPeriod=%s, defaultMaxPeriod=%s, disableTimeout=%s, notifIfDisabled=%s, binding=%s]",
+                    shortId, lifetime, defaultMinPeriod, defaultMaxPeriod, disableTimeout, notifIfDisabled, binding);
         }
     }
 
@@ -71,18 +72,30 @@ public class BootstrapConfig implements Serializable {
         @Override
         public String toString() {
             // Note : secretKey and smsBindingKeySecret are explicitly excluded from the display for security purposes
-            return String
-                    .format("ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s]",
-                            uri, bootstrapServer, securityMode, Arrays.toString(publicKeyOrId),
-                            Arrays.toString(serverPublicKey), smsSecurityMode,
-                            Arrays.toString(smsBindingKeyParam), serverSmsNumber,
-                            serverId, clientOldOffTime, bootstrapServerAccountTimeout);
+            return String.format(
+                    "ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s]",
+                    uri, bootstrapServer, securityMode, Arrays.toString(publicKeyOrId),
+                    Arrays.toString(serverPublicKey), smsSecurityMode, Arrays.toString(smsBindingKeyParam),
+                    serverSmsNumber, serverId, clientOldOffTime, bootstrapServerAccountTimeout);
+        }
+    }
+
+    /** server configuration (object 1) */
+    static public class ACLConfig implements Serializable {
+        public int objectId;
+        public int objectInstanceId;
+        public Map<Integer, Long> acls;
+        public Integer AccessControlOwner;
+
+        @Override
+        public String toString() {
+            return String.format("ACLConfig [objectId=%s, objectInstanceId=%s, ACLs=%s, AccessControlOwner=%s]",
+                    objectId, objectInstanceId, acls, AccessControlOwner);
         }
     }
 
     @Override
     public String toString() {
-        return String.format("BootstrapConfig [servers=%s, security=%s]", servers, security);
+        return String.format("BootstrapConfig [servers=%s, security=%s, acls=%s]", servers, security, acls);
     }
-
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapFailureCause.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapFailureCause.java
@@ -32,6 +32,10 @@ public enum BootstrapFailureCause {
      */
     DELETE_FAILED,
     /**
+     * Object 2 (ACL) could not be written on the device
+     */
+    WRITE_ACL_FAILED,
+    /**
      * Object 1 (Server) could not be written on the device
      */
     WRITE_SERVER_FAILED,


### PR DESCRIPTION
There is no UI to set acl config in `leshan-bs-demo`.
But you can use REST API :

```python
import requests
import json

BASE_URL = "https://leshan.eclipse.org/bs/"  # the URL of the server.
url = BASE_URL + "api/bootstrap/clientendpoint"  # the client endpoint here !
data = {"servers": {"0": {"shortId": 123,
                        "lifetime": 20,
                        "defaultMinPeriod": 1,
                        "defaultMaxPeriod": None,
                        "disableTimeout": None,
                        "notifIfDisabled": True,
                        "binding": "U"}},
        "security": {"0":{"uri": "coaps://leshan.eclipse.org:5784",
                        "bootstrapServer": True,
                        "securityMode": "PSK",
                        "publicKeyOrId": [98,111,111,116,115,116,114,97,112,95,99,108,105,101,110,116,95,105,100,101,110,116,105,116,121], #binary represenation of "bootstrap_client_identity"
                        "serverPublicKey" : [],
                        "secretKey": [115,101,99,114,101,116,95,107,101,121], #binary representation of "private_key", the hexa value is 7365637265745f6b6579
                        "smsSecurityMode": "NO_SEC",
                        "smsBindingKeyParam" : [],
                        "smsBindingKeySecret" : [],
                        "serverSmsNumber" : "+3343577911",
                        "serverId" : 0,
                        "clientOldOffTime" : 20},
                   "1":{"uri": "coaps://leshan.eclipse.org:5684",
                        "bootstrapServer": False,
                        "securityMode": "PSK",
                        "publicKeyOrId": [115,101,99,117,114,101,95,99,108,105,101,110,116,95,105,100],#represenation of "secure_client_id"
                        "serverPublicKey" : [],
                        "secretKey": [112,114,105,118,97,116,101,95,107,101,121], #binary representation of "private_key", the hexa value is 707269766174655f6b6579
                        "smsSecurityMode": "NO_SEC",
                        "smsBindingKeyParam" : [],
                        "smsBindingKeySecret" : [],
                        "serverSmsNumber" : "+3343577464",
                        "serverId" : 123,
                        "clientOldOffTime" : 1}},
        "acls": {"0":{
                        "objectId": 3,
                        "objectInstanceId": 0,
                        "acls": {3333: 1},
                        "AccessControlOwner":123                        
                     }}};

headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
r = requests.post(url, data=json.dumps(data), headers=headers)
print r.status_code
print r.content
```