### PR TITLE
Make configurable delete request for Bootstrap Server

### DIFF
--- a/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
+++ b/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
@@ -1,6 +1,6 @@
-// convert config from server format to UI format :
+// convert config from rest API format to UI format :
 // we regroup security and server data
-var convertConfig = function(config){
+var configFromRestToUI = function(config){
     var newConfig = {dm:[],bs:[]};
     for (var i in config.security){
         var security = config.security[i];
@@ -23,16 +23,16 @@ var convertConfig = function(config){
     }
     return newConfig;
 };
-var convertConfigs = function(configs){
+var configsFromRestToUI = function(configs){
     var newConfigs = {};
     for (var endpoint in configs){
-        newConfigs[endpoint] = convertConfig(configs[endpoint]);
+        newConfigs[endpoint] = configFromRestToUI(configs[endpoint]);
     }
     return newConfigs;
 };
 
-//convert config from UI to UI server:
-var toConfig = function(config){
+//convert config from UI to rest API format:
+var configFromUIToRest = function(config){
     var newConfig = {servers:{}, security:{}};
     for (var i = 0; i < config.bs.length; i++) {
         var bs = config.bs[i];
@@ -44,6 +44,7 @@ var toConfig = function(config){
         delete dm.security;
         newConfig.servers[j] = dm;
     }
+    newConfig.toDelete = ["/0", "/1"]
     return newConfig;
 };
 
@@ -57,7 +58,7 @@ function BsConfigStore() {
 
     self.init = function (){
         $.get('api/bootstrap', function(data) {
-            self.bsconfigs = convertConfigs(data);
+            self.bsconfigs = configsFromRestToUI(data);
             self.trigger('changed', self.bsconfigs);
         }).fail(function(xhr, status, error){
             var err = "Unable to get the bootstrap info list";
@@ -67,15 +68,14 @@ function BsConfigStore() {
     };
 
     self.add = function(endpoint,config) {
-        var data = toConfig(config);
-        console.log(data);
+        var data = configFromUIToRest(config);
         $.ajax({
             type: "POST",
             url: 'api/bootstrap/'+endpoint,
             data: JSON.stringify(data),
             contentType:"application/json; charset=utf-8",
         }).done(function () {
-            self.bsconfigs[endpoint] = convertConfig(data);
+            self.bsconfigs[endpoint] = configFromRestToUI(data);
             self.trigger('changed', self.bsconfigs);
         }).fail(function (xhr, status, error) {
           var err = "Unable to post the bootstrap config";

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -222,6 +222,14 @@ public class IntegrationTestHelper {
         }
     }
 
+    public void waitForBootstrapFinishedAtClientSide(long timeInSeconds) {
+        try {
+            assertTrue(clientObserver.waitForBootstrap(timeInSeconds, TimeUnit.SECONDS));
+        } catch (InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void ensureNoUpdate(long timeInSeconds) {
         try {
             registrationListener.waitForUpdate(timeInSeconds, TimeUnit.SECONDS);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -16,8 +16,10 @@
 package org.eclipse.leshan.server.bootstrap;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.leshan.SecurityMode;
@@ -28,6 +30,8 @@ import org.eclipse.leshan.core.request.BindingMode;
  */
 @SuppressWarnings("serial")
 public class BootstrapConfig implements Serializable {
+
+    public List<String> toDelete = new ArrayList<>();
 
     public Map<Integer, ServerConfig> servers = new HashMap<>();
 


### PR DESCRIPTION
Before this PR, bootstrap server always starts with delete request on "/".
Now in `BootstrapConfig`, there is a `toDelete` list of path to object to delete.