### PR TITLE
Initial support for OSCORE communication between client and server

### DIFF
--- a/leshan-client-cf/pom.xml
+++ b/leshan-client-cf/pom.xml
@@ -46,6 +46,12 @@ Contributors:
             <groupId>org.eclipse.californium</groupId>
             <artifactId>scandium</artifactId>
         </dependency>
+	<!-- Dependency for OSCORE support -->
+        <dependency>
+                <groupId>org.eclipse.californium</groupId>
+                <artifactId>cf-oscore</artifactId>
+                <version>${californium.version}</version>
+            </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -35,6 +35,12 @@ Contributors:
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
         </dependency>
+	<!-- Dependency for OSCORE support -->
+        <dependency>
+                <groupId>org.eclipse.californium</groupId>
+                <artifactId>cf-oscore</artifactId>
+                <version>${californium.version}</version>
+            </dependency>
 
         <!-- runtime dependencies -->
         <dependency>

--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -33,6 +33,12 @@ Contributors:
             <groupId>org.eclipse.leshan</groupId>
             <artifactId>leshan-core</artifactId>
         </dependency>
+	<!-- Dependency for OSCORE support -->
+        <dependency>
+                <groupId>org.eclipse.californium</groupId>
+                <artifactId>cf-oscore</artifactId>
+                <version>${californium.version}</version>
+            </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -43,6 +43,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.californium.scandium.dtls.CertificateMessage;
@@ -125,6 +126,9 @@ public class LeshanServerDemo {
     public static void main(String[] args) {
         // Define options for command line tools
         Options options = new Options();
+
+        // Enable OSCORE stack (fine to do even when using DTLS or only CoAP)
+        OSCoreCoapStackFactory.useAsDefault();
 
         final StringBuilder X509Chapter = new StringBuilder();
         X509Chapter.append("\n .");

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecuritySerializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecuritySerializer.java
@@ -42,7 +42,9 @@ public class SecuritySerializer implements JsonSerializer<SecurityInfo> {
         if (src.getIdentity() != null) {
             JsonObject psk = new JsonObject();
             psk.addProperty("identity", src.getIdentity());
-            psk.addProperty("key", Hex.encodeHexString(src.getPreSharedKey()));
+            if (src.getPreSharedKey() != null) {
+                psk.addProperty("key", Hex.encodeHexString(src.getPreSharedKey()));
+            }
             element.add("psk", psk);
         }
 

--- a/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
@@ -99,7 +99,12 @@ angular.module('securityControllers', [])
                     var security = {endpoint: $scope.endpoint, psk : { identity : $scope.pskIdentity , key : $scope.pskValue}};
                 } else if($scope.securityMode == "rpk") {
                     var security = {endpoint: $scope.endpoint, rpk : { x : $scope.rpkXValue , y : $scope.rpkYValue, params : $scope.rpkParamsValue || $scope.defaultParams}};
-                } else {
+                //Information for OSCORE
+                } else if($scope.securityMode == "oscore") {
+                    var security = {endpoint: $scope.endpoint, oscore : { masterSecret : $scope.masterSecret, masterSalt : $scope.masterSalt,
+                        idContext : $scope.idContext, senderId : $scope.senderId, recipientId : $scope.recipientId,
+                        aeadAlgorithm : $scope.aeadAlgorithm || $scope.defaultAeadAlgorithm, hkdfAlgorithm : $scope.hkdfAlgorithm || $scope.defaultHkdfAlgorithm }};
+                    } else {
                     var security = {endpoint: $scope.endpoint, x509 : true};
                 }
                 if(security) {
@@ -126,6 +131,8 @@ angular.module('securityControllers', [])
             $scope.rpkXValue = '';
             $scope.rpkYValue = '';
             $scope.defaultParams = 'secp256r1';
+            $scope.defaultAeadAlgorithm = 'AES_CCM_16_64_128';
+            $scope.defaultHkdfAlgorithm = 'HKDF_HMAC_SHA_256';
        };
 }])
 

--- a/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
@@ -58,6 +58,17 @@
 				Identity : <code>{{ security.psk.identity }}</code><br/>
 				Key : <code>{{ security.psk.key }}</code>
 			</td>
+			<!-- OSCORE fields -->
+			<td ng-if="security.oscore">OSCORE</td>
+			<td ng-if="security.oscore">
+				Master Secret : <code>{{ security.oscore.masterSecret }}</code><br/>
+				Master Salt : <code>{{ security.oscore.masterSalt }}</code><br/>
+				ID Context : <code>{{ security.oscore.idContext }}</code><br/>
+				Sender ID : <code>{{ security.oscore.senderId }}</code><br/>
+				Recipient ID : <code>{{ security.oscore.recipientId }}</code><br/>
+				AEAD Algorithm : <code>{{ security.oscore.aeadAlgorithm }}</code><br/>
+				HKDF Algorithm : <code>{{ security.oscore.hkdfAlgorithm }}</code>
+			</td>
 			<td ng-if="security.rpk">Raw Public Key <br/><small class="text-muted" >(Elliptic Curve)</small></td>
 			<td ng-if="security.rpk">
 				Params : <code>{{ security.rpk.params }}</code><br/> 
@@ -101,6 +112,8 @@
 								<option value="psk">Pre-Shared Key</option>
 								<option value="rpk">Raw Public Key (Elliptic Curves)</option>
 								<option value="x509">X.509 Certificate</option>
+								<!-- Drop-down option for OSCORE security context information -->
+								<option value="oscore">OSCORE</option>
 							</select>
 						</div>
 					</div>
@@ -125,6 +138,83 @@
 							<p class="help-block" ng-if="form.pskValue.$error.required">The pre-shared key is required</p>
 							<p class="help-block" ng-if="form.pskValue.$error.pattern">Hexadecimal format is expected</p>
 							<p class="help-block" ng-if="form.pskValue.$error.maxlength">The pre-shared key is too long</p>
+						</div>
+					</div>
+
+					<!-- OSCORE inputs -->
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="masterSecretValue" class="col-sm-4 control-label">Master Secret</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="2" id="masterSecretValue" name="masterSecret" 
+							ng-model="masterSecret" ng-required="securityMode=='oscore'" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="64" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.masterSecret.$error.required">Master Secret is required</p>
+							<p class="help-block" ng-if="form.masterSecret.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.masterSecret.$error.maxlength">Master Secret is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="masterSaltValue" class="col-sm-4 control-label">Master Salt</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="2" id="masterSaltValue" name="masterSalt" 
+							ng-model="masterSalt" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="64" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.masterSalt.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.masterSalt.$error.maxlength">Master Salt is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="idContextValue" class="col-sm-4 control-label">ID Context</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="idContextValue" name="idContext" 
+							ng-model="idContext" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="32" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.idContext.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.idContext.$error.maxlength">ID Context is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="senderIdValue" class="col-sm-4 control-label">Sender ID</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="senderIdValue" name="senderId" 
+							ng-model="senderId" ng-required="securityMode=='oscore'" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="16" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.senderId.$error.required">Sender ID is required</p>
+							<p class="help-block" ng-if="form.senderId.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.senderId.$error.maxlength">Sender ID is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="recipientIdValue" class="col-sm-4 control-label">Recipient ID</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="recipientIdValue" name="recipientId" 
+							ng-model="recipientId" ng-required="securityMode=='oscore'" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="16" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.recipientId.$error.required">Recipient ID is required</p>
+							<p class="help-block" ng-if="form.recipientId.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.recipientId.$error.maxlength">Recipient ID is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="aeadAlgorithmValue" class="col-sm-4 control-label">AEAD Algorithm</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="aeadAlgorithmValue" name="aeadAlgorithm" 
+							ng-model="aeadAlgorithm" ng-maxlength="32" placeholder="{{defaultAeadAlgorithm}}" ></textarea>
+							<p class="help-block" ng-if="form.aeadAlgorithm.$error.maxlength">AEAD Algorithm is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="hkdfAlgorithmValue" class="col-sm-4 control-label">HKDF Algorithm</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="hkdfAlgorithmValue" name="hkdfAlgorithm" 
+							ng-model="hkdfAlgorithm" ng-maxlength="32" placeholder="{{defaultHkdfAlgorithm}}" ></textarea>
+							<p class="help-block" ng-if="form.hkdfAlgorithm.$error.maxlength">HKDF Algorithm is too long</p>
 						</div>
 					</div>
 


### PR DESCRIPTION
This pull request adds early support for using OSCORE to communicate between a Leshan client and server. The server can register and perform its requests towards the server using OSCORE. Likewise the server can perform requests to the client using OSCORE.

The web interface of the server has been extended to allow adding clients that use OSCORE for security including their OSCORE security context information.

On the client side further additions are needed to allow setting OSCORE security context information on it. For instance via command line arguments.