### PR TITLE
Update to use Californium 2.0.0-M17

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreHandler.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreHandler.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.client.californium;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+public class OscoreHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+}

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/CaliforniumEndpointsManager.java
@@ -49,6 +49,7 @@ import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
 import org.eclipse.californium.scandium.dtls.rpkstore.TrustedRpkStore;
 import org.eclipse.californium.scandium.dtls.x509.CertificateVerifier;
 import org.eclipse.leshan.SecurityMode;
+import org.eclipse.leshan.client.californium.OscoreHandler;
 import org.eclipse.leshan.client.servers.EndpointsManager;
 import org.eclipse.leshan.client.servers.Server;
 import org.eclipse.leshan.client.servers.ServerInfo;
@@ -174,7 +175,7 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
         } else if (serverInfo.useOscore) {
             // oscore only mode
             LOG.info("Adding OSCORE context for " + serverInfo.getFullUri().toASCIIString());
-            HashMapCtxDB db = HashMapCtxDB.getInstance(); // TODO: Do not use singleton here but give it to endpoint
+            HashMapCtxDB db = OscoreHandler.getContextDB(); // TODO: Do not use singleton here but give it to endpoint
                                                           // builder (for Cf-M16)
 
             AlgorithmID hkdfAlg = null;

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/CaliforniumLwM2mRequestSender.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/impl/CaliforniumLwM2mRequestSender.java
@@ -24,6 +24,7 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.elements.util.Bytes;
 import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSException;
+import org.eclipse.leshan.client.californium.OscoreHandler;
 import org.eclipse.leshan.client.request.LwM2mRequestSender;
 import org.eclipse.leshan.core.californium.AsyncRequestObserver;
 import org.eclipse.leshan.core.californium.SyncRequestObserver;
@@ -49,7 +50,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
         Request coapRequest = coapClientRequestBuilder.getRequest();
 
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
-        HashMapCtxDB db = HashMapCtxDB.getInstance();
+        HashMapCtxDB db = OscoreHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);
@@ -88,7 +89,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
         Request coapRequest = coapClientRequestBuilder.getRequest();
 
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
-        HashMapCtxDB db = HashMapCtxDB.getInstance();
+        HashMapCtxDB db = OscoreHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -50,6 +50,7 @@ import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.LwM2m;
 import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
+import org.eclipse.leshan.client.californium.OscoreHandler;
 import org.eclipse.leshan.client.object.Oscore;
 import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
@@ -317,7 +318,8 @@ public class LeshanClientDemo {
             System.out.println("Using OSCORE");
             useOSCore = true;
 
-            OSCoreCoapStackFactory.useAsDefault();
+            HashMapCtxDB db = OscoreHandler.getContextDB();
+            OSCoreCoapStackFactory.useAsDefault(db);
 
         }
         try {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CaliforniumLwM2mRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/CaliforniumLwM2mRequestSender.java
@@ -46,6 +46,7 @@ import org.eclipse.leshan.core.request.DownlinkRequest;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.server.californium.CoapRequestSender;
 import org.eclipse.leshan.server.model.LwM2mModelProvider;
 import org.eclipse.leshan.server.registration.Registration;
@@ -94,7 +95,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
         final Request coapRequest = coapRequestBuilder.getRequest();
 
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
-        HashMapCtxDB db = HashMapCtxDB.getInstance();
+        HashMapCtxDB db = OscoreHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);
@@ -141,7 +142,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
         final Request coapRequest = coapRequestBuilder.getRequest();
 
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
-        HashMapCtxDB db = HashMapCtxDB.getInstance();
+        HashMapCtxDB db = OscoreHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/InMemoryRegistrationStore.java
@@ -504,4 +504,9 @@ public class InMemoryRegistrationStore implements CaliforniumRegistrationStore, 
         } else
             return false;
     }
+
+    @Override
+    public void setExecutor(ScheduledExecutorService executor) {
+        // TODO we could reuse californium executor ?
+    }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/impl/RegisterResource.java
@@ -46,6 +46,7 @@ import org.eclipse.leshan.core.response.DeregisterResponse;
 import org.eclipse.leshan.core.response.RegisterResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
 import org.eclipse.leshan.core.response.UpdateResponse;
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.server.registration.RegistrationHandler;
 import org.eclipse.leshan.server.registration.RegistrationService;
 import org.slf4j.Logger;
@@ -152,7 +153,7 @@ public class RegisterResource extends CoapResource {
 
             // Update the URI of the associated OSCORE Context with the client's URI
             // So the server can send requests to the client
-            HashMapCtxDB db = HashMapCtxDB.getInstance();
+            HashMapCtxDB db = OscoreHandler.getContextDB();
             OSCoreCtx clientCtx = db.getContext(exchange.advanced().getCryptographicContextID());
 
             try {

--- a/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
+++ b/leshan-server-cluster/src/main/java/org/eclipse/leshan/server/cluster/RedisRegistrationStore.java
@@ -743,4 +743,9 @@ public class RedisRegistrationStore implements CaliforniumRegistrationStore, Sta
     public void setExpirationListener(ExpirationListener listener) {
         expirationListener = listener;
     }
+
+    @Override
+    public void setExecutor(ScheduledExecutorService executor) {
+        // TODO we could reuse californium executor ?
+    }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreHandler.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.server;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+public class OscoreHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 
 import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCtx;
-
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.util.Validate;
 
 /**
@@ -98,7 +98,7 @@ public class SecurityInfo implements Serializable {
         Validate.notNull(oscoreCtx);
 
         // Add the OSCORE Context to the context database
-        HashMapCtxDB db = HashMapCtxDB.getInstance();
+        HashMapCtxDB db = OscoreHandler.getContextDB();
         db.addContext(oscoreCtx);
 
         return new SecurityInfo(endpoint, identity, null, null, false, oscoreCtx);

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -43,6 +43,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
@@ -59,6 +60,7 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeDecoder;
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.californium.impl.LeshanServer;
 import org.eclipse.leshan.server.cluster.RedisRegistrationStore;
@@ -128,7 +130,8 @@ public class LeshanServerDemo {
         Options options = new Options();
 
         // Enable OSCORE stack (fine to do even when using DTLS or only CoAP)
-        OSCoreCoapStackFactory.useAsDefault();
+        HashMapCtxDB db = OscoreHandler.getContextDB();
+        OSCoreCoapStackFactory.useAsDefault(db);
 
         final StringBuilder X509Chapter = new StringBuilder();
         X509Chapter.append("\n .");

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ Contributors:
         <test.exclusion.pattern>**/Redis*.java</test.exclusion.pattern>
 
         <!-- dependencies version -->
-        <californium.version>2.0.0-M15</californium.version>
+        <californium.version>2.0.0-M16</californium.version>
         <logback.version>1.2.3</logback.version>
         <slf4j.api.version>1.7.25</slf4j.api.version>
         <jetty.version>9.1.4.v20140401</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ Contributors:
         <test.exclusion.pattern>**/Redis*.java</test.exclusion.pattern>
 
         <!-- dependencies version -->
-        <californium.version>2.0.0-M16</californium.version>
+        <californium.version>2.0.0-M17</californium.version>
         <logback.version>1.2.3</logback.version>
         <slf4j.api.version>1.7.25</slf4j.api.version>
         <jetty.version>9.1.4.v20140401</jetty.version>


### PR DESCRIPTION
The OSCORE-related code has been updated to use Californium 2.0.0-M17. For now the OSCORE context database is still handled as a singleton. This will be updated in a coming PR.