### PR TITLE
Fail fast when null callback is used with async send method

### DIFF
--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/AsyncRequestObserver.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/AsyncRequestObserver.java
@@ -21,8 +21,30 @@ import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 
+/**
+ * A dedicated {@link CoapAsyncRequestObserver} for LWM2M.
+ * <p>
+ * A {@link LwM2mResponse} is created from the CoAP Response received. This behavior is not implemented and should be
+ * provided by overriding {@link #buildResponse(Response)}.
+ * 
+ * @param <T> the type of the {@link LwM2mResponse} to build from the CoAP response
+ */
 public abstract class AsyncRequestObserver<T extends LwM2mResponse> extends CoapAsyncRequestObserver {
 
+    /**
+     * A Californium message observer for a CoAP request helping to get results asynchronously dedicated for LWM2M
+     * requests.
+     * <p>
+     * The Californium API does not ensure that message callback are exclusive. E.g. In some race condition, you can get
+     * a onReponse call and a onCancel one. The CoapAsyncRequestObserver ensure that you will receive only one event.
+     * Meaning, you get either 1 response or 1 error.
+     * 
+     * @param coapRequest The CoAP request to observe.
+     * @param responseCallback This is called when a response is received. This MUST NOT be null.
+     * @param errorCallback This is called when an error happens. This MUST NOT be null.
+     * @param timeoutInMs A response timeout(in millisecond) which is raised if neither a response or error happens (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     */
     public AsyncRequestObserver(Request coapRequest, final ResponseCallback<T> responseCallback,
             final ErrorCallback errorCallback, long timeoutInMs) {
         super(coapRequest, null, errorCallback, timeoutInMs);
@@ -43,5 +65,11 @@ public abstract class AsyncRequestObserver<T extends LwM2mResponse> extends Coap
         };
     }
 
+    /**
+     * Build the {@link LwM2mResponse} from the CoAP {@link Response}.
+     * 
+     * @param coapResponse The CoAP response received.
+     * @return the corresponding {@link LwM2mResponse}.
+     */
     protected abstract T buildResponse(Response coapResponse);
 }

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/CoapAsyncRequestObserver.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/CoapAsyncRequestObserver.java
@@ -34,6 +34,15 @@ import org.eclipse.leshan.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A Californium message observer for a CoAP request.
+ * <p>
+ * Either a response or an error is raised. Results are available via callbacks.
+ * <p>
+ * This class also provides response timeout facility.
+ * 
+ * @see https://github.com/eclipse/leshan/wiki/Request-Timeout for more details.
+ */
 public class CoapAsyncRequestObserver extends AbstractRequestObserver {
 
     private static final Logger LOG = LoggerFactory.getLogger(CoapAsyncRequestObserver.class);
@@ -54,6 +63,19 @@ public class CoapAsyncRequestObserver extends AbstractRequestObserver {
 
     private final AtomicBoolean responseTimedOut = new AtomicBoolean(false);
 
+    /**
+     * A Californium message observer for a CoAP request helping to get results asynchronously.
+     * <p>
+     * The Californium API does not ensure that message callback are exclusive. E.g. In some race condition, you can get
+     * a onReponse call and a onCancel one. The CoapAsyncRequestObserver ensure that you will receive only one event.
+     * Meaning, you get either 1 response or 1 error.
+     * 
+     * @param coapRequest The CoAP request to observe.
+     * @param responseCallback This is called when a response is received. This MUST NOT be null.
+     * @param errorCallback This is called when an error happens. This MUST NOT be null.
+     * @param timeoutInMs A response timeout(in millisecond) which is raised if neither a response or error happens (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     */
     public CoapAsyncRequestObserver(Request coapRequest, CoapResponseCallback responseCallback,
             ErrorCallback errorCallback, long timeoutInMs) {
         super(coapRequest);

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/CoapSyncRequestObserver.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/CoapSyncRequestObserver.java
@@ -29,6 +29,15 @@ import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A Californium message observer for a CoAP request.
+ * <p>
+ * Results are available via synchronous {@link #waitForCoapResponse()} method.
+ * <p>
+ * This class also provides response timeout facility.
+ * 
+ * @see https://github.com/eclipse/leshan/wiki/Request-Timeout for more details.
+ */
 public class CoapSyncRequestObserver extends AbstractRequestObserver {
 
     private static final Logger LOG = LoggerFactory.getLogger(CoapSyncRequestObserver.class);
@@ -39,9 +48,14 @@ public class CoapSyncRequestObserver extends AbstractRequestObserver {
     private AtomicReference<RuntimeException> exception = new AtomicReference<>();
     private long timeout;
 
-    public CoapSyncRequestObserver(Request coapRequest, long timeout) {
+    /**
+     * @param coapRequest The CoAP request to observe.
+     * @param timeoutInMs A response timeout(in millisecond) which is raised if neither a response or error happens (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     */
+    public CoapSyncRequestObserver(Request coapRequest, long timeoutInMs) {
         super(coapRequest);
-        this.timeout = timeout;
+        this.timeout = timeoutInMs;
     }
 
     @Override
@@ -80,6 +94,17 @@ public class CoapSyncRequestObserver extends AbstractRequestObserver {
         latch.countDown();
     }
 
+    /**
+     * Wait for the CoAP response.
+     * 
+     * @return the CoAP response. The response can be <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     * 
+     * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     */
     public Response waitForCoapResponse() throws InterruptedException {
         try {
             boolean timeElapsed = false;

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/SyncRequestObserver.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/SyncRequestObserver.java
@@ -17,14 +17,37 @@ package org.eclipse.leshan.core.californium;
 
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.leshan.core.request.exception.InvalidResponseException;
+import org.eclipse.leshan.core.request.exception.RequestRejectedException;
+import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 
+/**
+ * A dedicated {@link SyncRequestObserver} for LWM2M.
+ * <p>
+ * A {@link LwM2mResponse} is created from the CoAP Response received. This behavior is not implemented and should be
+ * provided by overriding {@link #buildResponse(Response)}.
+ * 
+ * @param <T> the type of the {@link LwM2mResponse} to build from the CoAP response
+ */
 public abstract class SyncRequestObserver<T extends LwM2mResponse> extends CoapSyncRequestObserver {
 
     public SyncRequestObserver(Request coapRequest, long timeout) {
         super(coapRequest, timeout);
     }
 
+    /**
+     * Wait for the LWM2M response.
+     * 
+     * @return the LWM2M response. The response can be <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     * 
+     * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     * @throws InvalidResponseException if the response received is malformed.
+     */
     public T waitForResponse() throws InterruptedException {
         Response coapResponse = waitForCoapResponse();
         if (coapResponse != null) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/CaliforniumLwM2mBootstrapRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/CaliforniumLwM2mBootstrapRequestSender.java
@@ -17,9 +17,14 @@ package org.eclipse.leshan.server.californium.bootstrap;
 
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.leshan.core.model.LwM2mModel;
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeEncoder;
 import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.exception.InvalidResponseException;
+import org.eclipse.leshan.core.request.exception.RequestRejectedException;
+import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
@@ -29,34 +34,94 @@ import org.eclipse.leshan.server.californium.request.RequestSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * An implementation of {@link LwM2mBootstrapRequestSender} based on Californium.
+ */
 public class CaliforniumLwM2mBootstrapRequestSender implements LwM2mBootstrapRequestSender {
 
     static final Logger LOG = LoggerFactory.getLogger(CaliforniumLwM2mBootstrapRequestSender.class);
 
     private final LwM2mModel model;
-
     private final RequestSender sender;
 
+    /**
+     * @param secureEndpoint The endpoint used to send coaps request.
+     * @param nonSecureEndpoint The endpoint used to send coap request.
+     * @param model the {@link LwM2mModel} used to encode/decode {@link LwM2mNode}.
+     * @param encoder The {@link LwM2mNodeEncoder} used to encode {@link LwM2mNode}.
+     * @param decoder The {@link LwM2mNodeDecoder} used to encode {@link LwM2mNode}.
+     */
     public CaliforniumLwM2mBootstrapRequestSender(Endpoint secureEndpoint, Endpoint nonSecureEndpoint, LwM2mModel model,
             LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder) {
         this.model = model;
         this.sender = new RequestSender(secureEndpoint, nonSecureEndpoint, encoder, decoder);
     }
 
+    /**
+     * Send a Lightweight M2M request synchronously. Will block until a response is received from the remote server.
+     * <p>
+     * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
+     * way.
+     * 
+     * @param destination The {@link BootstrapSession} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @return the LWM2M response. The response can be <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     * 
+     * @throws CodecException if request payload can not be encoded.
+     * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     * @throws InvalidResponseException if the response received is malformed.
+     */
     @Override
-    public <T extends LwM2mResponse> T send(BootstrapSession destination, DownlinkRequest<T> request, long timeout)
+    public <T extends LwM2mResponse> T send(BootstrapSession destination, DownlinkRequest<T> request, long timeoutInMs)
             throws InterruptedException {
         return sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(), model,
-                null, request, timeout);
+                null, request, timeoutInMs);
     }
 
+    /**
+     * Send a Lightweight M2M {@link DownlinkRequest} asynchronously to a LWM2M client.
+     * 
+     * The Californium API does not ensure that message callback are exclusive. E.g. In some race condition, you can get
+     * a onReponse call and a onCancel one. This method ensures that you will receive only one event. Meaning, you get
+     * either 1 response or 1 error.
+     * 
+     * @param destination The {@link BootstrapSession} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param responseCallback a callback called when a response is received (successful or error response). This
+     *        callback MUST NOT be null.
+     * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
+     *        <ul>
+     *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
+     *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
+     *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
+     *        <li>{@link InvalidResponseException} if the response received is malformed.</li>
+     *        <li>{@link TimeoutException} if the timeout expires (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
+     *        <li>or any other RuntimeException for unexpected issue.
+     *        </ul>
+     *        This callback MUST NOT be null.
+     * @throws CodecException if request payload can not be encoded.
+     */
     @Override
-    public <T extends LwM2mResponse> void send(BootstrapSession destination, DownlinkRequest<T> request, long timeout,
-            ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
+    public <T extends LwM2mResponse> void send(BootstrapSession destination, DownlinkRequest<T> request,
+            long timeoutInMs, ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
         sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(), model, null,
-                request, timeout, responseCallback, errorCallback);
+                request, timeoutInMs, responseCallback, errorCallback);
     }
 
+    /**
+     * Cancel all ongoing requests for a given bootstrap session.
+     * 
+     * @param session the bootstrap session for which we need to cancel requests.
+     */
     @Override
     public void cancelOngoingRequests(BootstrapSession destination) {
         sender.cancelRequests(destination.getId());

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumLwM2mRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumLwM2mRequestSender.java
@@ -21,9 +21,14 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.leshan.core.californium.CoapResponseCallback;
 import org.eclipse.leshan.core.model.LwM2mModel;
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeEncoder;
 import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.exception.InvalidResponseException;
+import org.eclipse.leshan.core.request.exception.RequestRejectedException;
+import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
@@ -34,6 +39,9 @@ import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.request.LwM2mRequestSender;
 import org.eclipse.leshan.util.Validate;
 
+/**
+ * An implementation of {@link LwM2mRequestSender} and {@link CoapRequestSender} based on Californium.
+ */
 public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRequestSender {
 
     private final ObservationServiceImpl observationService;
@@ -41,8 +49,13 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
     private final RequestSender sender;
 
     /**
-     * @param observationService the service for keeping track of observed resources
-     * @param modelProvider provides the supported objects definitions
+     * @param secureEndpoint The endpoint used to send coaps request.
+     * @param nonSecureEndpoint The endpoint used to send coap request.
+     * @param observationService The service used to store observation.
+     * @param modelProvider the {@link LwM2mModelProvider} used retrieve the {@link LwM2mModel} used to encode/decode
+     *        {@link LwM2mNode}.
+     * @param encoder The {@link LwM2mNodeEncoder} used to encode {@link LwM2mNode}.
+     * @param decoder The {@link LwM2mNodeDecoder} used to encode {@link LwM2mNode}.
      */
     public CaliforniumLwM2mRequestSender(Endpoint secureEndpoint, Endpoint nonSecureEndpoint,
             ObservationServiceImpl observationService, LwM2mModelProvider modelProvider, LwM2mNodeEncoder encoder,
@@ -54,6 +67,26 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
         this.sender = new RequestSender(secureEndpoint, nonSecureEndpoint, encoder, decoder);
     }
 
+    /**
+     * Send a Lightweight M2M request synchronously. Will block until a response is received from the remote server.
+     * <p>
+     * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
+     * way.
+     * 
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @return the LWM2M response. The response can be <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     * 
+     * @throws CodecException if request payload can not be encoded.
+     * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     * @throws InvalidResponseException if the response received is malformed.
+     */
     @Override
     public <T extends LwM2mResponse> T send(Registration destination, DownlinkRequest<T> request, long timeout)
             throws InterruptedException {
@@ -72,15 +105,41 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
         return response;
     }
 
+    /**
+     * Send a Lightweight M2M {@link DownlinkRequest} asynchronously to a LWM2M client.
+     * 
+     * The Californium API does not ensure that message callback are exclusive. E.g. In some race condition, you can get
+     * a onReponse call and a onCancel one. This method ensures that you will receive only one event. Meaning, you get
+     * either 1 response or 1 error.
+     * 
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param responseCallback a callback called when a response is received (successful or error response). This
+     *        callback MUST NOT be null.
+     * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
+     *        <ul>
+     *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
+     *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
+     *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
+     *        <li>{@link InvalidResponseException} if the response received is malformed.</li>
+     *        <li>{@link TimeoutException} if the timeout expires (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
+     *        <li>or any other RuntimeException for unexpected issue.
+     *        </ul>
+     *        This callback MUST NOT be null.
+     * @throws CodecException if request payload can not be encoded.
+     */
     @Override
-    public <T extends LwM2mResponse> void send(final Registration destination, DownlinkRequest<T> request, long timeout,
-            final ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
+    public <T extends LwM2mResponse> void send(final Registration destination, DownlinkRequest<T> request,
+            long timeoutInMs, final ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
         // Retrieve the objects definition
         final LwM2mModel model = modelProvider.getObjectModel(destination);
 
         // Send requests asynchronously
         sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(), model,
-                destination.getRootPath(), request, timeout, new ResponseCallback<T>() {
+                destination.getRootPath(), request, timeoutInMs, new ResponseCallback<T>() {
                     @Override
                     public void onResponse(T response) {
                         if (response != null && response.getClass() == ObserveResponse.class && response.isSuccess()) {
@@ -92,19 +151,68 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
                 }, errorCallback);
     }
 
+    /**
+     * Send a CoAP {@link Request} synchronously to a LWM2M client. Will block until a response is received from the
+     * remote client.
+     * <p>
+     * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
+     * way.
+     * 
+     * @param destination The {@link Registration} associate to the device we want to sent the request. s
+     * @param coapRequest The request to send to the client.
+     * @param timeoutInMs The response timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @return the response or <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     * 
+     * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     */
     @Override
-    public Response sendCoapRequest(Registration destination, Request coapRequest, long timeout)
+    public Response sendCoapRequest(Registration destination, Request coapRequest, long timeoutInMs)
             throws InterruptedException {
-        return sender.sendCoapRequest(destination.getIdentity(), destination.getId(), coapRequest, timeout);
+        return sender.sendCoapRequest(destination.getIdentity(), destination.getId(), coapRequest, timeoutInMs);
     }
 
+    /**
+     * Sends a CoAP {@link Request} asynchronously to a LWM2M client.
+     * 
+     * The Californium API does not ensure that message callback are exclusive. E.g. In some race condition, you can get
+     * a onReponse call and a onCancel one. This method ensures that you will receive only one event. Meaning, you get
+     * either 1 response or 1 error.
+     * 
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The response timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param responseCallback a callback called when a response is received (successful or error response). This
+     *        callback MUST NOT be null.
+     * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
+     *        <ul>
+     *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
+     *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
+     *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
+     *        <li>{@link TimeoutException} if the timeout expires (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
+     *        <li>or any other RuntimeException for unexpected issue.
+     *        </ul>
+     *        This callback MUST NOT be null.
+     */
     @Override
-    public void sendCoapRequest(Registration destination, Request coapRequest, long timeout,
+    public void sendCoapRequest(Registration destination, Request coapRequest, long timeoutInMs,
             CoapResponseCallback responseCallback, ErrorCallback errorCallback) {
-        sender.sendCoapRequest(destination.getIdentity(), destination.getId(), coapRequest, timeout, responseCallback,
-                errorCallback);
+        sender.sendCoapRequest(destination.getIdentity(), destination.getId(), coapRequest, timeoutInMs,
+                responseCallback, errorCallback);
     }
 
+    /**
+     * cancel all ongoing messages for a LWM2M client identified by the registration identifier. In case a client
+     * de-registers, the consumer can use this method to cancel all ongoing messages for the given client.
+     * 
+     * @param registration client registration meta data of a LWM2M client.
+     */
     @Override
     public void cancelOngoingRequests(Registration registration) {
         Validate.notNull(registration);

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumQueueModeRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumQueueModeRequestSender.java
@@ -21,17 +21,29 @@ import org.eclipse.leshan.core.californium.CoapResponseCallback;
 import org.eclipse.leshan.core.request.exception.ClientSleepingException;
 import org.eclipse.leshan.core.request.exception.TimeoutException;
 import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.server.queue.Presence;
 import org.eclipse.leshan.server.queue.PresenceServiceImpl;
 import org.eclipse.leshan.server.queue.QueueModeLwM2mRequestSender;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.request.LwM2mRequestSender;
 
+/**
+ * A {@link LwM2mRequestSender} and {@link CoapRequestSender} which supports LWM2M Queue Mode.
+ */
 public class CaliforniumQueueModeRequestSender extends QueueModeLwM2mRequestSender implements CoapRequestSender {
 
+    /**
+     * @param presenceService the presence service object for setting the client into {@link Presence#SLEEPING} when
+     *        request Timeout expires and into {@link Presence#Awake} when a response arrives.
+     * @param delegatedSender internal sender that it is used for sending the requests, using delegation.
+     */
     public CaliforniumQueueModeRequestSender(PresenceServiceImpl presenceService, LwM2mRequestSender delegatedSender) {
         super(presenceService, delegatedSender);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Response sendCoapRequest(Registration destination, Request coapRequest, long timeout)
             throws InterruptedException {
@@ -67,6 +79,9 @@ public class CaliforniumQueueModeRequestSender extends QueueModeLwM2mRequestSend
         return response;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void sendCoapRequest(final Registration destination, Request coapRequest, long timeout,
             final CoapResponseCallback responseCallback, final ErrorCallback errorCallback) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestSender.java
@@ -18,37 +18,64 @@ package org.eclipse.leshan.server.californium.request;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.leshan.core.californium.CoapResponseCallback;
-import org.eclipse.leshan.core.node.codec.CodecException;
+import org.eclipse.leshan.core.request.exception.ClientSleepingException;
+import org.eclipse.leshan.core.request.exception.RequestRejectedException;
+import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.eclipse.leshan.core.response.ErrorCallback;
+import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.server.registration.Registration;
 
+/**
+ * A {@link CoapRequestSender} is responsible to send CoAP {@link Request} for a given {@link Registration}.
+ */
 public interface CoapRequestSender {
 
     /**
-     * Sends a CoAP request synchronously. Will block until a response is received from the remote client.
+     * Send a CoAP {@link Request} synchronously to a LWM2M client. Will block until a response is received from the
+     * remote client.
+     * <p>
+     * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
+     * way.
      * 
-     * @param destination the remote client
-     * @param request the request to send to the client
-     * @param timeout the request timeout in millisecond
-     * @return the response or <code>null</code> if the timeout expires (given parameter or CoAP timeout).
+     * @param destination The registration linked to the LWM2M client to which the request must be sent.
+     * @param coapRequest The request to send to the client.
+     * @param timeoutInMs The response timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @return the response or <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
      * 
-     * @throws CodecException if request payload can not be encoded.
      * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     * @throws ClientSleepingException if client is currently sleeping.
      */
-    Response sendCoapRequest(final Registration destination, final Request coapRequest, long timeout)
+    Response sendCoapRequest(final Registration destination, final Request coapRequest, long timeoutInMs)
             throws InterruptedException;
 
     /**
-     * Sends a CoAP request asynchronously.
+     * Sends a CoAP {@link Request} asynchronously to a LWM2M client.
      * 
-     * @param destination the remote client
-     * @param request the request to send to the client
-     * @param timeout the request timeout in millisecond
-     * @param responseCallback a callback called when a response is received (successful or error response)
-     * @param errorCallback a callback called when an error or exception occurred when response is received
+     * {@link ResponseCallback} and {@link ErrorCallback} are exclusively called.
      * 
-     * @throws CodecException if request payload can not be encoded.
+     * @param destination The registration linked to the LWM2M client to which the request must be sent.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The response timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param responseCallback a callback called when a response is received (successful or error response). This
+     *        callback MUST NOT be null.
+     * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
+     *        <ul>
+     *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
+     *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
+     *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
+     *        <li>{@link ClientSleepingException} if client is currently sleeping.</li>
+     *        <li>{@link TimeoutException} if the timeout expires (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
+     *        <li>or any other RuntimeException for unexpected issue.
+     *        </ul>
+     *        This callback MUST NOT be null.
      */
-    void sendCoapRequest(final Registration destination, final Request coapRequest, long timeout,
+    void sendCoapRequest(final Registration destination, final Request coapRequest, long timeoutInMs,
             CoapResponseCallback responseCallback, ErrorCallback errorCallback);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LwM2mBootstrapRequestSender.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LwM2mBootstrapRequestSender.java
@@ -15,29 +15,73 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
+import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.exception.InvalidResponseException;
+import org.eclipse.leshan.core.request.exception.RequestRejectedException;
+import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 
+/**
+ * A {@link LwM2mBootstrapRequestSender} is responsible to send LWM2M {@link DownlinkRequest} for a given
+ * {@link BootstrapSession}.
+ */
 public interface LwM2mBootstrapRequestSender {
+
     /**
      * Send a Lightweight M2M request synchronously. Will block until a response is received from the remote server.
+     * <p>
+     * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
+     * way.
      * 
-     * @return the LWM2M response. The response can be <code>null</code> if the timeout (given parameter or CoAP
-     *         timeout) expires.
+     * @param destination The {@link BootstrapSession} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @return the LWM2M response. The response can be <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     * 
+     * @throws CodecException if request payload can not be encoded.
+     * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     * @throws InvalidResponseException if the response received is malformed.
      */
-    <T extends LwM2mResponse> T send(BootstrapSession destination, DownlinkRequest<T> request, long timeout)
+    <T extends LwM2mResponse> T send(BootstrapSession destination, DownlinkRequest<T> request, long timeoutInMs)
             throws InterruptedException;
 
     /**
-     * Send a Lightweight M2M request asynchronously.
+     * Send a Lightweight M2M {@link DownlinkRequest} asynchronously to a LWM2M client.
+     * 
+     * {@link ResponseCallback} and {@link ErrorCallback} are exclusively called.
+     * 
+     * @param destination The {@link BootstrapSession} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param responseCallback a callback called when a response is received (successful or error response). This
+     *        callback MUST NOT be null.
+     * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
+     *        <ul>
+     *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
+     *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
+     *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
+     *        <li>{@link InvalidResponseException} if the response received is malformed.</li>
+     *        <li>{@link TimeoutException} if the timeout expires (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
+     *        <li>or any other RuntimeException for unexpected issue.
+     *        </ul>
+     *        This callback MUST NOT be null.
+     * @throws CodecException if request payload can not be encoded.
      */
-    <T extends LwM2mResponse> void send(BootstrapSession destination, DownlinkRequest<T> request, long timeout,
+    <T extends LwM2mResponse> void send(BootstrapSession destination, DownlinkRequest<T> request, long timeoutInMs,
             ResponseCallback<T> responseCallback, ErrorCallback errorCallback);
 
     /**
-     * cancel all ongoing requests for a given bootstrap session.
+     * Cancel all ongoing requests for a given bootstrap session.
      * 
      * @param session the bootstrap session for which we need to cancel requests.
      */

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueModeLwM2mRequestSender.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/queue/QueueModeLwM2mRequestSender.java
@@ -25,6 +25,9 @@ import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.request.LwM2mRequestSender;
 import org.eclipse.leshan.util.Validate;
 
+/**
+ * A {@link LwM2mRequestSender} which supports LWM2M Queue Mode.
+ */
 public class QueueModeLwM2mRequestSender implements LwM2mRequestSender {
 
     protected PresenceServiceImpl presenceService;
@@ -43,6 +46,9 @@ public class QueueModeLwM2mRequestSender implements LwM2mRequestSender {
         this.delegatedSender = delegatedSender;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public <T extends LwM2mResponse> T send(final Registration destination, DownlinkRequest<T> request, long timeout)
             throws InterruptedException {
@@ -74,6 +80,9 @@ public class QueueModeLwM2mRequestSender implements LwM2mRequestSender {
         return response;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public <T extends LwM2mResponse> void send(final Registration destination, DownlinkRequest<T> request, long timeout,
             final ResponseCallback<T> responseCallback, final ErrorCallback errorCallback) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender.java
@@ -18,39 +18,70 @@ package org.eclipse.leshan.server.request;
 
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.exception.ClientSleepingException;
+import org.eclipse.leshan.core.request.exception.InvalidResponseException;
+import org.eclipse.leshan.core.request.exception.RequestRejectedException;
+import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.server.registration.Registration;
 
+/**
+ * A {@link LwM2mRequestSender} is responsible to send LWM2M {@link DownlinkRequest} for a given {@link Registration}.
+ */
 public interface LwM2mRequestSender {
 
     /**
-     * Sends a Lightweight M2M request synchronously. Will block until a response is received from the remote client.
+     * Send a Lightweight M2M request synchronously. Will block until a response is received from the remote server.
+     * <p>
+     * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
+     * way.
      * 
-     * @param destination the remote client
-     * @param request the request to send to the client
-     * @param timeout the request timeout in millisecond
-     * @return the response or <code>null</code> if the timeout expires (given parameter or CoAP timeout).
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @return the LWM2M response. The response can be <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
      * 
      * @throws CodecException if request payload can not be encoded.
      * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     * @throws InvalidResponseException if the response received is malformed.
+     * @throws ClientSleepingException if client is currently sleeping.
      */
-    <T extends LwM2mResponse> T send(Registration destination, DownlinkRequest<T> request, long timeout)
+    <T extends LwM2mResponse> T send(Registration destination, DownlinkRequest<T> request, long timeoutInMs)
             throws InterruptedException;
 
     /**
-     * Sends a Lightweight M2M request asynchronously.
+     * Send a Lightweight M2M {@link DownlinkRequest} asynchronously to a LWM2M client.
      * 
-     * @param destination the remote client
-     * @param request the request to send to the client
-     * @param timeout the request timeout in millisecond
-     * @param responseCallback a callback called when a response is received (successful or error response)
-     * @param errorCallback a callback called when an error or exception occurred when response is received
+     * {@link ResponseCallback} and {@link ErrorCallback} are exclusively called.
      * 
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param responseCallback a callback called when a response is received (successful or error response). This
+     *        callback MUST NOT be null.
+     * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
+     *        <ul>
+     *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
+     *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
+     *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
+     *        <li>{@link InvalidResponseException} if the response received is malformed.</li>
+     *        <li>{@link ClientSleepingException} if client is currently sleeping.</li>
+     *        <li>{@link TimeoutException} if the timeout expires (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
+     *        <li>or any other RuntimeException for unexpected issue.
+     *        </ul>
+     *        This callback MUST NOT be null.
      * @throws CodecException if request payload can not be encoded.
      */
-    <T extends LwM2mResponse> void send(Registration destination, DownlinkRequest<T> request, long timeout,
+    <T extends LwM2mResponse> void send(Registration destination, DownlinkRequest<T> request, long timeoutInMs,
             ResponseCallback<T> responseCallback, ErrorCallback errorCallback);
 
     /**


### PR DESCRIPTION
This aims to avoid the NPE part of the issue #743. 