### PR TITLE
Implements an identity and matching of the identity for OSCORE

### DIFF
--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
@@ -38,12 +38,6 @@ public class EndpointContextUtil {
 
     public static Identity extractIdentity(EndpointContext context) {
         InetSocketAddress peerAddress = context.getPeerAddress();
-        // Build identity for OSCORE if it is used
-        if (context.get(OSCoreEndpointContextInfo.OSCORE_SENDER_ID) != null) {
-            String oscoreIdentity = "sid=" + context.get(OSCoreEndpointContextInfo.OSCORE_SENDER_ID) + ",rid="
-                    + context.get(OSCoreEndpointContextInfo.OSCORE_RECIPIENT_ID);
-            return Identity.oscoreOnly(peerAddress, oscoreIdentity.toLowerCase());
-        }
         Principal senderIdentity = context.getPeerIdentity();
         if (senderIdentity != null) {
             if (senderIdentity instanceof PreSharedKeyIdentity) {
@@ -57,6 +51,13 @@ public class EndpointContextUtil {
                 return Identity.x509(peerAddress, x509CommonName);
             }
             throw new IllegalStateException("Unable to extract sender identity : unexpected type of Principal");
+        } else {
+            // Build identity for OSCORE if it is used
+            if (context.get(OSCoreEndpointContextInfo.OSCORE_SENDER_ID) != null) {
+                String oscoreIdentity = "sid=" + context.get(OSCoreEndpointContextInfo.OSCORE_SENDER_ID) + ",rid="
+                        + context.get(OSCoreEndpointContextInfo.OSCORE_RECIPIENT_ID);
+                return Identity.oscoreOnly(peerAddress, oscoreIdentity.toLowerCase());
+            }
         }
         return Identity.unsecure(peerAddress);
     }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
@@ -89,7 +89,7 @@ public class Identity {
     }
 
     public boolean isSecure() {
-        return isPSK() || isRPK() || isX509() || isOSCORE();
+        return isPSK() || isRPK() || isX509();
     }
 
     public static Identity unsecure(InetSocketAddress peerAddress) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - add protected constructor for sub-classing
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
@@ -31,13 +32,16 @@ public class Identity {
     private final String pskIdentity;
     private final PublicKey rawPublicKey;
     private final String x509CommonName;
+    private final String oscoreIdentity;
 
-    private Identity(InetSocketAddress peerAddress, String pskIdentity, PublicKey rawPublicKey, String x509CommonName) {
+    private Identity(InetSocketAddress peerAddress, String pskIdentity, PublicKey rawPublicKey, String x509CommonName,
+            String oscoreIdentity) {
         Validate.notNull(peerAddress);
         this.peerAddress = peerAddress;
         this.pskIdentity = pskIdentity;
         this.rawPublicKey = rawPublicKey;
         this.x509CommonName = x509CommonName;
+        this.oscoreIdentity = oscoreIdentity;
     }
 
     protected Identity(Identity identity) {
@@ -45,6 +49,7 @@ public class Identity {
         this.pskIdentity = identity.pskIdentity;
         this.rawPublicKey = identity.rawPublicKey;
         this.x509CommonName = identity.x509CommonName;
+        this.oscoreIdentity = identity.oscoreIdentity;
     }
 
     public InetSocketAddress getPeerAddress() {
@@ -63,6 +68,10 @@ public class Identity {
         return x509CommonName;
     }
 
+    public String getOscoreIdentity() {
+        return oscoreIdentity;
+    }
+
     public boolean isPSK() {
         return pskIdentity != null && !pskIdentity.isEmpty();
     }
@@ -75,40 +84,52 @@ public class Identity {
         return x509CommonName != null && !x509CommonName.isEmpty();
     }
 
+    public boolean isOSCORE() {
+        return oscoreIdentity != null && !oscoreIdentity.isEmpty();
+    }
+
     public boolean isSecure() {
-        return isPSK() || isRPK() || isX509();
+        return isPSK() || isRPK() || isX509() || isOSCORE();
     }
 
     public static Identity unsecure(InetSocketAddress peerAddress) {
-        return new Identity(peerAddress, null, null, null);
+        return new Identity(peerAddress, null, null, null, null);
     }
 
     public static Identity unsecure(InetAddress address, int port) {
-        return new Identity(new InetSocketAddress(address, port), null, null, null);
+        return new Identity(new InetSocketAddress(address, port), null, null, null, null);
     }
 
     public static Identity psk(InetSocketAddress peerAddress, String identity) {
-        return new Identity(peerAddress, identity, null, null);
+        return new Identity(peerAddress, identity, null, null, null);
     }
 
     public static Identity psk(InetAddress address, int port, String identity) {
-        return new Identity(new InetSocketAddress(address, port), identity, null, null);
+        return new Identity(new InetSocketAddress(address, port), identity, null, null, null);
     }
 
     public static Identity rpk(InetSocketAddress peerAddress, PublicKey publicKey) {
-        return new Identity(peerAddress, null, publicKey, null);
+        return new Identity(peerAddress, null, publicKey, null, null);
     }
 
     public static Identity rpk(InetAddress address, int port, PublicKey publicKey) {
-        return new Identity(new InetSocketAddress(address, port), null, publicKey, null);
+        return new Identity(new InetSocketAddress(address, port), null, publicKey, null, null);
     }
 
     public static Identity x509(InetSocketAddress peerAddress, String commonName) {
-        return new Identity(peerAddress, null, null, commonName);
+        return new Identity(peerAddress, null, null, commonName, null);
     }
 
     public static Identity x509(InetAddress address, int port, String commonName) {
-        return new Identity(new InetSocketAddress(address, port), null, null, commonName);
+        return new Identity(new InetSocketAddress(address, port), null, null, commonName, null);
+    }
+
+    public static Identity oscoreOnly(InetSocketAddress peerAddress, String oscoreIdentity) {
+        return new Identity(peerAddress, null, null, null, oscoreIdentity);
+    }
+
+    public static Identity oscoreOnly(InetAddress address, int port, String oscoreIdentity) {
+        return new Identity(new InetSocketAddress(address, port), null, null, null, oscoreIdentity);
     }
 
     @Override
@@ -119,6 +140,8 @@ public class Identity {
             return String.format("Identity %s[rpk=%s]", peerAddress, rawPublicKey);
         else if (x509CommonName != null)
             return String.format("Identity %s[x509=%s]", peerAddress, x509CommonName);
+        else if (oscoreIdentity != null)
+            return String.format("Identity %s[oscore=%s]", peerAddress, oscoreIdentity);
         else
             return String.format("Identity %s[unsecure]", peerAddress);
     }
@@ -131,6 +154,7 @@ public class Identity {
         result = prime * result + ((pskIdentity == null) ? 0 : pskIdentity.hashCode());
         result = prime * result + ((rawPublicKey == null) ? 0 : rawPublicKey.hashCode());
         result = prime * result + ((x509CommonName == null) ? 0 : x509CommonName.hashCode());
+        result = prime * result + ((oscoreIdentity == null) ? 0 : oscoreIdentity.hashCode());
         return result;
     }
 
@@ -162,6 +186,11 @@ public class Identity {
             if (other.x509CommonName != null)
                 return false;
         } else if (!x509CommonName.equals(other.x509CommonName))
+            return false;
+        if (oscoreIdentity == null) {
+            if (other.oscoreIdentity != null)
+                return false;
+        } else if (!oscoreIdentity.equals(other.oscoreIdentity))
             return false;
         return true;
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
@@ -88,16 +88,14 @@ public class SecurityChecker {
 
                 return checkX509Identity(endpoint, clientIdentity, securityInfo);
 
-            } else if (clientIdentity.isOSCORE()) {
-
-                return checkOscoreIdentity(endpoint, clientIdentity, securityInfo);
-
             } else {
                 LOG.debug("Unable to authenticate client '{}': unknown authentication mode", endpoint);
                 return false;
             }
         } else {
-            if (securityInfo != null) {
+            if (clientIdentity.isOSCORE()) {
+                return checkOscoreIdentity(endpoint, clientIdentity, securityInfo);
+            } else if (securityInfo != null) {
                 LOG.debug("Client '{}' must connect using DTLS", endpoint);
                 return false;
             }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
@@ -88,12 +88,16 @@ public class SecurityChecker {
 
                 return checkX509Identity(endpoint, clientIdentity, securityInfo);
 
+            } else if (clientIdentity.isOSCORE()) {
+
+                return checkOscoreIdentity(endpoint, clientIdentity, securityInfo);
+
             } else {
                 LOG.debug("Unable to authenticate client '{}': unknown authentication mode", endpoint);
                 return false;
             }
         } else {
-            if (securityInfo != null && securityInfo.useOSCore == false) {
+            if (securityInfo != null) {
                 LOG.debug("Client '{}' must connect using DTLS", endpoint);
                 return false;
             }
@@ -180,7 +184,28 @@ public class SecurityChecker {
     }
 
     protected boolean checkOscoreIdentity(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
-        // TODO: Add comprehensive checks here
+        // Manage OSCORE authentication
+        // ----------------------------------------------------
+        if (!securityInfo.useOSCORE()) {
+            LOG.debug("Client '{}' is not supposed to use OSCORE to authenticate", endpoint);
+            return false;
+        }
+
+        if (!matchOscoreIdentity(endpoint, clientIdentity.getOscoreIdentity(), securityInfo.getOscoreIdentity())) {
+            return false;
+        }
+
+        LOG.trace("Authenticated client '{}' using OSCORE", endpoint);
+        return true;
+    }
+
+    protected boolean matchOscoreIdentity(String endpoint, String receivedOscoreIdentity,
+            String expectedOscoreIdentity) {
+        if (!receivedOscoreIdentity.equals(expectedOscoreIdentity)) {
+            LOG.debug("Invalid identity for client '{}': expected '{}' but was '{}'", endpoint, expectedOscoreIdentity,
+                    receivedOscoreIdentity);
+            return false;
+        }
         return true;
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.util.Hex;
 import org.eclipse.leshan.util.Validate;
 
 /**
@@ -53,6 +54,7 @@ public class SecurityInfo implements Serializable {
 
     // OSCORE (FIXME: Save content properly information here. Must be serializable.)
     boolean useOSCore;
+    private final String oscoreIdentity;
 
     private SecurityInfo(String endpoint, String identity, byte[] preSharedKey, PublicKey rawPublicKey,
             boolean useX509Cert, OSCoreCtx oscoreCtx) {
@@ -63,6 +65,7 @@ public class SecurityInfo implements Serializable {
         this.rawPublicKey = rawPublicKey;
         this.useX509Cert = useX509Cert;
         this.useOSCore = oscoreCtx != null;
+        this.oscoreIdentity = generateOscoreIdentity(oscoreCtx);
     }
 
     /**
@@ -92,16 +95,27 @@ public class SecurityInfo implements Serializable {
     /**
      * Construct a {@link SecurityInfo} when using OSCORE.
      */
-    public static SecurityInfo newOSCoreInfo(String endpoint, String identity, OSCoreCtx oscoreCtx) {
-        Validate.notEmpty(identity);
-        Validate.notNull(identity);
+    public static SecurityInfo newOSCoreInfo(String endpoint, OSCoreCtx oscoreCtx) {
         Validate.notNull(oscoreCtx);
 
         // Add the OSCORE Context to the context database
         HashMapCtxDB db = OscoreHandler.getContextDB();
         db.addContext(oscoreCtx);
 
-        return new SecurityInfo(endpoint, identity, null, null, false, oscoreCtx);
+        return new SecurityInfo(endpoint, null, null, null, false, oscoreCtx);
+    }
+
+    /**
+     * Generates an OSCORE identity from an OSCORE context
+     */
+    private static String generateOscoreIdentity(OSCoreCtx oscoreCtx) {
+        if (oscoreCtx == null) {
+            return null;
+        }
+
+        String oscoreIdentity = "sid=" + Hex.encodeHexString(oscoreCtx.getSenderId()) + ",rid="
+                + Hex.encodeHexString(oscoreCtx.getRecipientId());
+        return oscoreIdentity;
     }
 
     public String getEndpoint() {
@@ -117,6 +131,13 @@ public class SecurityInfo implements Serializable {
 
     public byte[] getPreSharedKey() {
         return preSharedKey;
+    }
+
+    /**
+     * The OSCORE identity
+     */
+    public String getOscoreIdentity() {
+        return oscoreIdentity;
     }
 
     public boolean usePSK() {
@@ -135,6 +156,10 @@ public class SecurityInfo implements Serializable {
         return useX509Cert;
     }
 
+    public boolean useOSCORE() {
+        return oscoreIdentity != null;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -144,6 +169,7 @@ public class SecurityInfo implements Serializable {
         result = prime * result + Arrays.hashCode(preSharedKey);
         result = prime * result + ((rawPublicKey == null) ? 0 : rawPublicKey.hashCode());
         result = prime * result + (useX509Cert ? 1231 : 1237);
+        result = prime * result + ((oscoreIdentity == null) ? 0 : oscoreIdentity.hashCode());
         return result;
     }
 
@@ -175,14 +201,21 @@ public class SecurityInfo implements Serializable {
             return false;
         if (useX509Cert != other.useX509Cert)
             return false;
+        if (oscoreIdentity == null) {
+            if (other.oscoreIdentity != null)
+                return false;
+        } else if (!oscoreIdentity.equals(other.oscoreIdentity))
+            return false;
+
         return true;
     }
 
     @Override
     public String toString() {
         // Note : preSharedKey is explicitly excluded from display for security purposes
-        return String.format("SecurityInfo [endpoint=%s, identity=%s, rawPublicKey=%s, useX509Cert=%s]", endpoint,
-                identity, rawPublicKey, useX509Cert);
+        return String.format(
+                "SecurityInfo [endpoint=%s, identity=%s, rawPublicKey=%s, useX509Cert=%s, oscoreIdentity=%s]", endpoint,
+                identity, rawPublicKey, useX509Cert, oscoreIdentity);
     }
 
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
@@ -53,7 +53,6 @@ public class SecurityInfo implements Serializable {
     private final boolean useX509Cert;
 
     // OSCORE (FIXME: Save content properly information here. Must be serializable.)
-    boolean useOSCore;
     private final String oscoreIdentity;
 
     private SecurityInfo(String endpoint, String identity, byte[] preSharedKey, PublicKey rawPublicKey,
@@ -64,7 +63,6 @@ public class SecurityInfo implements Serializable {
         this.preSharedKey = preSharedKey;
         this.rawPublicKey = rawPublicKey;
         this.useX509Cert = useX509Cert;
-        this.useOSCore = oscoreCtx != null;
         this.oscoreIdentity = generateOscoreIdentity(oscoreCtx);
     }
 

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
@@ -168,16 +168,7 @@ public class SecurityDeserializer implements JsonDeserializer<SecurityInfo> {
                     throw new JsonParseException("Failed to generate OSCORE context", e);
                 }
 
-                // Create an identity string from the OSCORE context information
-                StringBuilder b = new StringBuilder();
-                if (ctx.getIdContext() != null) {
-                    b.append(Hex.encodeHex(ctx.getIdContext()));
-                    b.append(":");
-                }
-                b.append(Hex.encodeHex(ctx.getRecipientId()));
-                String identity = b.toString();
-
-                info = SecurityInfo.newOSCoreInfo(endpoint, identity, ctx);
+                info = SecurityInfo.newOSCoreInfo(endpoint, ctx);
             } else {
                 throw new JsonParseException("Invalid security info content");
             }

--- a/leshan-server-demo/src/main/resources/webapp/partials/client-list.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/client-list.html
@@ -21,7 +21,7 @@
 				<td>{{client.registrationDate | date:'medium'}}</td>
 				<td>{{client.lastUpdate | date:'medium'}}</td>
 				<td><i class="glyphicon glyphicon-info-sign" tooltip-html-unsafe="{{clientTooltip(client)}}"></i></td>
-				<td><span ng-style="{'visibility': client.secure ? 'visible': 'hidden'}" class="glyphicon glyphicon-lock" tooltip-html-unsafe="Communication over DTLS"></span></td>
+				<td><span ng-style="{'visibility': client.secure ? 'visible': 'hidden'}" class="glyphicon glyphicon-lock" tooltip-html-unsafe="Communication over DTLS/OSCORE"></span></td>
 				<td><span ng-style="{'visibility': client.sleeping ? 'visible': 'hidden'}" class="glyphicon glyphicon-log-out" tooltip-html-unsafe="Device using queue mode is absent"></span></td>
 			</tr>
 		</tbody>

--- a/leshan-server-demo/src/main/resources/webapp/partials/client-list.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/client-list.html
@@ -21,7 +21,7 @@
 				<td>{{client.registrationDate | date:'medium'}}</td>
 				<td>{{client.lastUpdate | date:'medium'}}</td>
 				<td><i class="glyphicon glyphicon-info-sign" tooltip-html-unsafe="{{clientTooltip(client)}}"></i></td>
-				<td><span ng-style="{'visibility': client.secure ? 'visible': 'hidden'}" class="glyphicon glyphicon-lock" tooltip-html-unsafe="Communication over DTLS/OSCORE"></span></td>
+				<td><span ng-style="{'visibility': client.secure ? 'visible': 'hidden'}" class="glyphicon glyphicon-lock" tooltip-html-unsafe="Communication over DTLS"></span></td>
 				<td><span ng-style="{'visibility': client.sleeping ? 'visible': 'hidden'}" class="glyphicon glyphicon-log-out" tooltip-html-unsafe="Device using queue mode is absent"></span></td>
 			</tr>
 		</tbody>


### PR DESCRIPTION
An identity string based on OSCORE parameters is now set for connected clients that use OSCORE. The identity string contains the OSCORE Sender and Recipient ID the client and server are using. These parameters can be retrieved from the source EndpointContext.

The identity for OSCORE is also set as a SecurityInfo based on the OSCORE context configured on the server to use with a specific client.

The identity of a connected client and the configured SecurityInfo are then matched in the SecurityChecker.
