### PR TITLE
Remove TODO about usage of "bad request" on update and delete registration if device is unauthorized.

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -97,8 +97,6 @@ public class RegistrationHandler {
         }
 
         if (authorizer.isAuthorized(updateRequest, registration, sender) == null) {
-            // TODO replace by Forbidden if https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181 is
-            // closed.
             return new SendableResponse<>(UpdateResponse.badRequest("forbidden"));
         }
 
@@ -134,8 +132,6 @@ public class RegistrationHandler {
             return new SendableResponse<>(DeregisterResponse.notFound());
         }
         if (authorizer.isAuthorized(deregisterRequest, registration, sender) == null) {
-            // TODO replace by Forbidden if https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181 is
-            // closed.
             return new SendableResponse<>(DeregisterResponse.badRequest("forbidden"));
         }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/Authorizer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/Authorizer.java
@@ -25,9 +25,6 @@ import org.eclipse.leshan.server.registration.Registration;
  */
 public interface Authorizer {
 
-    // TODO remove the BAD_REQUEST code if https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181 is
-    // closed.
-
     /**
      * Return the registration if this request should be handle by the LWM2M Server. When <code>null</code> is returned
      * the LWM2M server will stop to handle this request and will respond with a {@link ResponseCode#FORBIDDEN} or


### PR DESCRIPTION
See https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/181

The specification says : 
> The LwM2M specification defines the use of the endpoint client name in
the Bootstrap-Request and in the Register messages. Since the endpoint
client name is not authenticated at the application layer the LwM2M
Server MUST compare the received endpoint client name identifier with
the identifier used at the DTLS handshake. This comparison may either be
an equality match or may involve a dedicated lookup table to ensure that
LwM2M Clients cannot intentionally or due to misconfiguration
impersonate other LwM2M Clients. The LwM2M Server MUST respond with a
“4.00 Bad Request” to the LwM2M Client if these fields do not match.