### PR TITLE
Remove support of deprecated update registration using PUT.

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
@@ -116,7 +116,7 @@ public class RegisterResource extends LwM2mCoapResource {
         }
     }
 
-    private void handleRegister(CoapExchange exchange, Request request) {
+    protected void handleRegister(CoapExchange exchange, Request request) {
         // Get identity
         // --------------------------------
         Identity sender = extractIdentity(request.getSourceContext());
@@ -176,7 +176,7 @@ public class RegisterResource extends LwM2mCoapResource {
         sendableResponse.sent();
     }
 
-    private void handleUpdate(CoapExchange exchange, Request request, String registrationId) {
+    protected void handleUpdate(CoapExchange exchange, Request request, String registrationId) {
         // Get identity
         Identity sender = extractIdentity(request.getSourceContext());
 
@@ -220,7 +220,7 @@ public class RegisterResource extends LwM2mCoapResource {
         sendableResponse.sent();
     }
 
-    private void handleDeregister(CoapExchange exchange, String registrationId) {
+    protected void handleDeregister(CoapExchange exchange, String registrationId) {
         // Get identity
         Identity sender = extractIdentity(exchange.advanced().getRequest().getSourceContext());
 
@@ -239,31 +239,6 @@ public class RegisterResource extends LwM2mCoapResource {
             exchange.respond(toCoapResponseCode(deregisterResponse.getCode()));
         }
         sendableResponse.sent();
-    }
-
-    // Since the V1_0-20150615-D version of specification, the registration update should be a CoAP POST.
-    // To keep compatibility with older version, we still accept CoAP PUT.
-    // TODO remove this backward compatibility when the version 1.0.0 of the spec will be released.
-    @Override
-    public void handlePUT(CoapExchange exchange) {
-        Request request = exchange.advanced().getRequest();
-
-        LOG.trace("UPDATE received : {}", request);
-        if (!Type.CON.equals(request.getType())) {
-            handleInvalidRequest(exchange, "CON CoAP type expected");
-            return;
-        }
-
-        List<String> uri = exchange.getRequestOptions().getUriPath();
-        if (uri == null || uri.size() != 2 || !RESOURCE_NAME.equals(uri.get(0))) {
-            handleInvalidRequest(exchange, "Bad URI");
-            return;
-        }
-
-        LOG.debug(
-                "Warning a client made a registration update using a CoAP PUT, a POST must be used since version V1_0-20150615-D of the specification. Request: {}",
-                request);
-        handleUpdate(exchange, request, uri.get(1));
     }
 
     /*


### PR DESCRIPTION
Since the V1_0-20150615-D (draft) version of specification, the registration update should be a CoAP POST.
Until now, to keep compatibility with older version, we also accepted CoAP PUT.

After more than 4 years, I think it's time to remove it.

If you still need to support devices which are not compliant with the v1.0.x of the LWM2M specification and so want to keep the backward compatibility, you can to this like this : 

```java
LeshanServerBuilder builder = new LeshanServerBuilder() {
    @Override
    protected LeshanServer createServer(CoapEndpoint unsecuredEndpoint, CoapEndpoint securedEndpoint,
            CaliforniumRegistrationStore registrationStore, SecurityStore securityStore, Authorizer authorizer,
            LwM2mModelProvider modelProvider, LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder,
            NetworkConfig coapConfig, boolean noQueueMode, ClientAwakeTimeProvider awakeTimeProvider,
            RegistrationIdProvider registrationIdProvider) {
        return new LeshanServer(unsecuredEndpoint, securedEndpoint, registrationStore, securityStore,
                authorizer, modelProvider, encoder, decoder, coapConfig, noQueueMode, awakeTimeProvider,
                registrationIdProvider) {
            @Override
            protected CoapResource createRegisterResource(RegistrationServiceImpl registrationService,
                    Authorizer authorizer, RegistrationIdProvider registrationIdProvider) {
                return new RegisterResource(
                        new RegistrationHandler(registrationService, authorizer, registrationIdProvider)) {
                    // Since the V1_0-20150615-D version of specification, the registration update should be a
                    // CoAP POST.
                    // To keep compatibility with older version, we still accept CoAP PUT.
                    @Override
                    public void handlePUT(CoapExchange exchange) {
                        Request request = exchange.advanced().getRequest();

                        LOG.trace("UPDATE received : {}", request);
                        if (!Type.CON.equals(request.getType())) {
                            handleInvalidRequest(exchange, "CON CoAP type expected");
                            return;
                        }

                        List<String> uri = exchange.getRequestOptions().getUriPath();
                        if (uri == null || uri.size() != 2 || !RESOURCE_NAME.equals(uri.get(0))) {
                            handleInvalidRequest(exchange, "Bad URI");
                            return;
                        }

                        LOG.debug(
                                "Warning a client made a registration update using a CoAP PUT, a POST must be used since version V1_0-20150615-D of the specification. Request: {}",
                                request);
                        handleUpdate(exchange, request, uri.get(1));
                    }
                };
            }
        };
    }
};
```