### PR TITLE
Server SHOULD not initiate DTLS connection for device using Queue mode

### DIFF
--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
@@ -26,7 +26,9 @@ import java.util.regex.Pattern;
 import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.MapBasedEndpointContext;
 import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
@@ -71,9 +73,11 @@ public class EndpointContextUtil {
      * Create Californium {@link EndpointContext} from Leshan {@link Identity}.
      * 
      * @param identity The Leshan {@link Identity} to convert.
+     * @param preventConnectionInitiation prevent to initiate a Handshake if there is no DTLS connection.
+     * 
      * @return The corresponding Californium {@link EndpointContext}.
      */
-    public static EndpointContext extractContext(Identity identity) {
+    public static EndpointContext extractContext(Identity identity, boolean preventConnectionInitiation) {
         Principal peerIdentity = null;
         if (identity != null) {
             if (identity.isPSK()) {
@@ -84,6 +88,11 @@ public class EndpointContextUtil {
                 /* simplify distinguished name to CN= part */
                 peerIdentity = new X500Principal("CN=" + identity.getX509CommonName());
             }
+        }
+
+        if (peerIdentity != null && preventConnectionInitiation) {
+                return new MapBasedEndpointContext(identity.getPeerAddress(), peerIdentity,
+                        DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_NONE);
         }
         return new AddressEndpointContext(identity.getPeerAddress(), peerIdentity);
     }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/BindingMode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/BindingMode.java
@@ -36,5 +36,17 @@ public enum BindingMode {
     US,
 
     /** UDP with Queue Mode and SMS */
-    UQS
+    UQS;
+
+    public boolean useSMS() {
+        return equals(S) || equals(SQ) || equals(UQS);
+    }
+
+    public boolean useQueueMode() {
+        return equals(UQ) || equals(SQ) || equals(UQS);
+    }
+
+    public boolean useUDP() {
+        return equals(U) || equals(UQ) || equals(UQS);
+    }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/CaliforniumLwM2mBootstrapRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/CaliforniumLwM2mBootstrapRequestSender.java
@@ -82,7 +82,7 @@ public class CaliforniumLwM2mBootstrapRequestSender implements LwM2mBootstrapReq
     public <T extends LwM2mResponse> T send(BootstrapSession destination, DownlinkRequest<T> request, long timeoutInMs)
             throws InterruptedException {
         return sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(), model,
-                null, request, timeoutInMs);
+                null, request, timeoutInMs, false);
     }
 
     /**
@@ -115,7 +115,7 @@ public class CaliforniumLwM2mBootstrapRequestSender implements LwM2mBootstrapReq
     public <T extends LwM2mResponse> void send(BootstrapSession destination, DownlinkRequest<T> request,
             long timeoutInMs, ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
         sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(), model, null,
-                request, timeoutInMs, responseCallback, errorCallback);
+                request, timeoutInMs, responseCallback, errorCallback, false);
     }
 
     /**

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumLwM2mRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumLwM2mRequestSender.java
@@ -97,7 +97,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
 
         // Send requests synchronously
         T response = sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(),
-                model, destination.getRootPath(), request, timeout);
+                model, destination.getRootPath(), request, timeout, destination.preventServerToInitiateConnection());
 
         // Handle special observe case
         if (response != null && response.getClass() == ObserveResponse.class && response.isSuccess()) {
@@ -149,7 +149,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
                         }
                         responseCallback.onResponse(response);
                     }
-                }, errorCallback);
+                }, errorCallback, destination.preventServerToInitiateConnection());
     }
 
     /**
@@ -174,7 +174,8 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
     @Override
     public Response sendCoapRequest(Registration destination, Request coapRequest, long timeoutInMs)
             throws InterruptedException {
-        return sender.sendCoapRequest(destination.getIdentity(), destination.getId(), coapRequest, timeoutInMs);
+        return sender.sendCoapRequest(destination.getIdentity(), destination.getId(), coapRequest, timeoutInMs,
+                destination.preventServerToInitiateConnection());
     }
 
     /**
@@ -205,7 +206,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender, CoapRe
     public void sendCoapRequest(Registration destination, Request coapRequest, long timeoutInMs,
             CoapResponseCallback responseCallback, ErrorCallback errorCallback) {
         sender.sendCoapRequest(destination.getIdentity(), destination.getId(), coapRequest, timeoutInMs,
-                responseCallback, errorCallback);
+                responseCallback, errorCallback, destination.preventServerToInitiateConnection());
     }
 
     /**

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilder.java
@@ -61,27 +61,20 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     private final String rootPath;
     private final String registrationId;
     private final String endpoint;
+    private final boolean preventConnectionInitiation;
 
     private final LwM2mModel model;
     private final LwM2mNodeEncoder encoder;
 
-    public CoapRequestBuilder(Identity destination, LwM2mModel model, LwM2mNodeEncoder encoder) {
-        this.destination = destination;
-        this.rootPath = null;
-        this.registrationId = null;
-        this.endpoint = null;
-        this.model = model;
-        this.encoder = encoder;
-    }
-
     public CoapRequestBuilder(Identity destination, String rootPath, String registrationId, String endpoint,
-            LwM2mModel model, LwM2mNodeEncoder encoder) {
+            LwM2mModel model, LwM2mNodeEncoder encoder, boolean preventConnectionInitiation) {
         this.destination = destination;
         this.rootPath = rootPath;
         this.endpoint = endpoint;
         this.registrationId = registrationId;
         this.model = model;
         this.encoder = encoder;
+        this.preventConnectionInitiation = preventConnectionInitiation;
     }
 
     @Override
@@ -181,7 +174,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     public void visit(BootstrapDeleteRequest request) {
         coapRequest = Request.newDelete();
         coapRequest.setConfirmable(true);
-        EndpointContext context = EndpointContextUtil.extractContext(destination);
+        EndpointContext context = EndpointContextUtil.extractContext(destination, preventConnectionInitiation);
         coapRequest.setDestinationContext(context);
         setTarget(coapRequest, request.getPath());
     }
@@ -190,7 +183,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     public void visit(BootstrapFinishRequest request) {
         coapRequest = Request.newPost();
         coapRequest.setConfirmable(true);
-        EndpointContext context = EndpointContextUtil.extractContext(destination);
+        EndpointContext context = EndpointContextUtil.extractContext(destination, preventConnectionInitiation);
         coapRequest.setDestinationContext(context);
 
         // root path
@@ -205,8 +198,8 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         coapRequest.getOptions().addUriPath("bs");
     }
 
-    private final void setTarget(Request coapRequest, LwM2mPath path) {
-        EndpointContext context = EndpointContextUtil.extractContext(destination);
+    protected void setTarget(Request coapRequest, LwM2mPath path) {
+        EndpointContext context = EndpointContextUtil.extractContext(destination, preventConnectionInitiation);
         coapRequest.setDestinationContext(context);
 
         // root path

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/ObservationServiceTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/ObservationServiceTest.java
@@ -28,8 +28,6 @@ import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.request.ObserveRequest;
 import org.eclipse.leshan.server.californium.CaliforniumTestSupport;
-import org.eclipse.leshan.server.californium.observation.ObservationServiceImpl;
-import org.eclipse.leshan.server.californium.observation.ObserveUtil;
 import org.eclipse.leshan.server.californium.registration.CaliforniumRegistrationStore;
 import org.eclipse.leshan.server.californium.registration.InMemoryRegistrationStore;
 import org.eclipse.leshan.server.model.StandardModelProvider;
@@ -142,7 +140,8 @@ public class ObservationServiceTest {
         coapRequest.getOptions().addUriPath(String.valueOf(target.getObjectInstanceId()));
         coapRequest.getOptions().addUriPath(String.valueOf(target.getResourceId()));
         coapRequest.setObserve();
-        coapRequest.setDestinationContext(EndpointContextUtil.extractContext(support.registration.getIdentity()));
+        coapRequest
+                .setDestinationContext(EndpointContextUtil.extractContext(support.registration.getIdentity(), false));
         Map<String, String> context = ObserveUtil.createCoapObserveRequestContext(registration.getEndpoint(),
                 registrationId, new ObserveRequest(target.toString()));
         coapRequest.setUserContext(context);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
@@ -47,7 +47,6 @@ import org.eclipse.leshan.core.request.ReadRequest;
 import org.eclipse.leshan.core.request.WriteAttributesRequest;
 import org.eclipse.leshan.core.request.WriteRequest;
 import org.eclipse.leshan.core.request.WriteRequest.Mode;
-import org.eclipse.leshan.server.californium.request.CoapRequestBuilder;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.Registration.Builder;
 import org.eclipse.leshan.tlv.Tlv;
@@ -91,7 +90,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         ReadRequest request = new ReadRequest(3, 0);
         builder.visit(request);
 
@@ -109,7 +108,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         ReadRequest request = new ReadRequest(3, 0, 1);
         builder.visit(request);
 
@@ -124,7 +123,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         ReadRequest request = new ReadRequest(3);
         builder.visit(request);
 
@@ -139,7 +138,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         DiscoverRequest request = new DiscoverRequest(3, 0);
         builder.visit(request);
 
@@ -158,7 +157,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         WriteRequest request = new WriteRequest(Mode.UPDATE, 3, 0, LwM2mSingleResource.newStringResource(4, "value"));
         builder.visit(request);
 
@@ -182,7 +181,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         WriteRequest request = new WriteRequest(3, 0, 14, "value");
         builder.visit(request);
 
@@ -197,7 +196,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         AttributeSet attributes = new AttributeSet(new Attribute(Attribute.MINIMUM_PERIOD, 10L),
                 new Attribute(Attribute.MAXIMUM_PERIOD, 100L));
         WriteAttributesRequest request = new WriteAttributesRequest(3, 0, 14, attributes);
@@ -217,7 +216,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         ExecuteRequest request = new ExecuteRequest(3, 0, 12, "params");
         builder.visit(request);
 
@@ -236,7 +235,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         CreateRequest request = new CreateRequest(12, LwM2mSingleResource.newStringResource(0, "value"));
         builder.visit(request);
 
@@ -259,7 +258,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         CreateRequest request = new CreateRequest(12,
                 new LwM2mObjectInstance(26, LwM2mSingleResource.newStringResource(0, "value")));
         builder.visit(request);
@@ -284,7 +283,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         DeleteRequest request = new DeleteRequest(12, 0);
         builder.visit(request);
 
@@ -302,7 +301,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder);
+                reg.getEndpoint(), model, encoder, false);
         ObserveRequest request = new ObserveRequest(12, 0);
         builder.visit(request);
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -267,6 +267,15 @@ public class Registration implements Serializable {
     }
 
     /**
+     * @return True if no DTLS handshake must be initiated by the Server for this registration.
+     */
+    public boolean preventServerToInitiateConnection() {
+        // We consider that initiates a connection (act as DTLS client to initiate a handshake) does not make sense for
+        // QueueMode as if we lost connection device is probably absent.
+        return bindingMode.useQueueMode() && bindingMode.useUDP();
+    }
+
+    /**
      * @return true if the last registration update was done less than lifetime seconds ago.
      */
     public boolean isAlive() {
@@ -287,7 +296,7 @@ public class Registration implements Serializable {
     }
 
     public boolean usesQueueMode() {
-        return bindingMode.equals(BindingMode.UQ) || bindingMode.equals(BindingMode.UQS);
+        return bindingMode.useQueueMode() && bindingMode.useUDP();
     }
 
     /**


### PR DESCRIPTION
We consider that initiates a connection (server act as DTLS client to initiate a handshake) does not make sense for QueueMode as if we lost connection device is probably absent.
        