### PR TITLE
#732: fix rt and ver attributes of Link format.

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/util/LinkFormatHelper.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/util/LinkFormatHelper.java
@@ -48,8 +48,8 @@ public final class LinkFormatHelper {
 
         // create links for "object"
         String rootURL = getPath("/", root);
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("rt", "oma.lwm2m");
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("rt", "\"oma.lwm2m\"");
         links.add(new Link(rootURL, attributes));
 
         // sort resources
@@ -67,7 +67,7 @@ public final class LinkFormatHelper {
 
             List<Integer> availableInstance = objectEnabler.getAvailableInstanceIds();
             // Include an object link if there are no instances or there are object attributes (e.g. "ver")
-            Map<String, ?> objectAttributes = getObjectAttributes(objectEnabler.getObjectModel());
+            Map<String, String> objectAttributes = getObjectAttributes(objectEnabler.getObjectModel());
             if (availableInstance.isEmpty() || (objectAttributes != null)) {
                 String objectInstanceUrl = getPath("/", root, Integer.toString(objectEnabler.getId()));
                 links.add(new Link(objectInstanceUrl, objectAttributes));
@@ -89,7 +89,7 @@ public final class LinkFormatHelper {
         String rootPath = root == null ? "" : root;
 
         // create link for "object"
-        Map<String, ?> objectAttributes = getObjectAttributes(objectEnabler.getObjectModel());
+        Map<String, String> objectAttributes = getObjectAttributes(objectEnabler.getObjectModel());
         String objectURL = getPath("/", rootPath, Integer.toString(objectEnabler.getId()));
         links.add(new Link(objectURL, objectAttributes));
 
@@ -192,7 +192,7 @@ public final class LinkFormatHelper {
         return sb.toString();
     }
 
-    private static Map<String, ?> getObjectAttributes(ObjectModel objectModel) {
+    private static Map<String, String> getObjectAttributes(ObjectModel objectModel) {
         if (StringUtils.isEmpty(objectModel.version) || ObjectModel.DEFAULT_VERSION.equals(objectModel.version)) {
             return null;
         }

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
@@ -85,8 +85,7 @@ public class LinkFormatHelperTest {
         Link[] links = LinkFormatHelper.getObjectDescription(createObjectEnabler(locationModel), "/");
         String strLinks = Link.serialize(links);
 
-        assertEquals("</6>;ver=\"2.0\",</6/0>,</6/0/0>,</6/0/1>,</6/0/2>,</6/0/3>,</6/0/4>,</6/0/5>,</6/0/6>",
-                strLinks);
+        assertEquals("</6>;ver=2.0,</6/0>,</6/0/0>,</6/0/1>,</6/0/2>,</6/0/3>,</6/0/4>,</6/0/5>,</6/0/6>", strLinks);
     }
 
     @Test
@@ -128,7 +127,7 @@ public class LinkFormatHelperTest {
         Link[] links = LinkFormatHelper.getClientDescription(objectEnablers, null);
         String strLinks = Link.serialize(links);
 
-        assertEquals("</>;rt=\"oma.lwm2m\",</6>;ver=\"2.0\",</6/0>,</6/1>", strLinks);
+        assertEquals("</>;rt=\"oma.lwm2m\",</6>;ver=2.0,</6/0>,</6/1>", strLinks);
     }
 
     @Test
@@ -142,7 +141,7 @@ public class LinkFormatHelperTest {
         Link[] links = LinkFormatHelper.getClientDescription(objectEnablers, null);
         String strLinks = Link.serialize(links);
 
-        assertEquals("</>;rt=\"oma.lwm2m\",</6>;ver=\"2.0\"", strLinks);
+        assertEquals("</>;rt=\"oma.lwm2m\",</6>;ver=2.0", strLinks);
     }
 
     private ObjectModel getObjectModel(int id) {

--- a/leshan-core/src/test/java/org/eclipse/leshan/LinkObjectTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/LinkObjectTest.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,9 +32,9 @@ public class LinkObjectTest {
         Assert.assertEquals(5, parse.length);
         Assert.assertEquals("/", parse[0].getUrl());
 
-        Map<String, Object> attResult = new HashMap<>();
-        attResult.put("rt", "oma.lwm2m");
-        attResult.put("ct", 100);
+        Map<String, String> attResult = new HashMap<>();
+        attResult.put("rt", "\"oma.lwm2m\"");
+        attResult.put("ct", "100");
         Assert.assertEquals(attResult, parse[0].getAttributes());
 
         Assert.assertEquals("/1/101", parse[1].getUrl());
@@ -58,7 +60,7 @@ public class LinkObjectTest {
         Assert.assertEquals("/", parse[0].getUrl());
 
         Map<String, String> attResult = new HashMap<>();
-        attResult.put("k1", "quotes\"inside");
+        attResult.put("k1", "\"quotes\"inside\"");
         attResult.put("k2", "endwithquotes\"");
         attResult.put("k3", "noquotes");
         attResult.put("k4", "\"startwithquotes");
@@ -79,17 +81,9 @@ public class LinkObjectTest {
 
     @Test
     public void serialyse_with_attributes() {
-        HashMap<String, Object> attributesObj1 = new HashMap<>();
-        attributesObj1.put("number", 12);
-        Link obj1 = new Link("/1/0/1", attributesObj1);
-
-        HashMap<String, Object> attributesObj2 = new HashMap<>();
-        attributesObj2.put("string", "stringval");
-        Link obj2 = new Link("/2/1", attributesObj2);
-
-        HashMap<String, Object> attributesObj3 = new HashMap<>();
-        attributesObj3.put("empty", null);
-        Link obj3 = new Link("/3", attributesObj3);
+        Link obj1 = new Link("/1/0/1", "number", "12");
+        Link obj2 = new Link("/2/1", "string", "\"stringval\"");
+        Link obj3 = new Link("/3", "empty", null);
 
         String res = Link.serialize(obj1, obj2, obj3);
 
@@ -99,9 +93,9 @@ public class LinkObjectTest {
 
     @Test
     public void serialyse_with_root_url() {
-        HashMap<String, Object> attributesObj1 = new HashMap<>();
+        HashMap<String, Integer> attributesObj1 = new HashMap<>();
         attributesObj1.put("number", 12);
-        Link obj1 = new Link("/", attributesObj1);
+        Link obj1 = new Link("/", attributesObj1, Integer.class);
 
         String res = Link.serialize(obj1);
 
@@ -115,11 +109,11 @@ public class LinkObjectTest {
         attributesObj1.put("number1", 1);
         attributesObj1.put("number2", 1);
         attributesObj1.put("string1", "stringval1");
-        Link obj1 = new Link("/1/0", attributesObj1);
+        Link obj1 = new Link("/1/0", attributesObj1, Object.class);
 
-        HashMap<String, Object> attributesObj2 = new HashMap<>();
+        HashMap<String, Integer> attributesObj2 = new HashMap<>();
         attributesObj2.put("number3", 3);
-        Link obj2 = new Link("/2", attributesObj2);
+        Link obj2 = new Link("/2", attributesObj2, Integer.class);
 
         Link[] input = new Link[] { obj1, obj2 };
         String strObjs = Link.serialize(input);
@@ -136,5 +130,27 @@ public class LinkObjectTest {
         String output = Link.serialize(objs);
         Assert.assertEquals(input, output);
 
+    }
+
+    @Test
+    public void parse_quoted_ver_attributes() {
+        String input = "</1>;ver=\"2.2\"";
+        Link[] objs = Link.parse(input.getBytes());
+        assertEquals(objs[0].getAttributes().get("ver"), "\"2.2\"");
+    }
+
+    @Test
+    public void parse_unquoted_ver_attributes() {
+        String input = "</1>;ver=2.2";
+        Link[] objs = Link.parse(input.getBytes());
+        assertEquals(objs[0].getAttributes().get("ver"), "2.2");
+    }
+
+    @Test
+    public void serialyse_ver_attributes_without_quote() {
+        Map<String, String> att = new HashMap<>();
+        att.put("ver", "2.2");
+        Link link = new Link("/1", att);
+        assertEquals("</1>;ver=2.2", Link.serialize(link));
     }
 }

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
@@ -78,7 +78,7 @@ public class CoapRequestBuilderTest {
                 Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354));
         if (rootpath != null) {
             Map<String, String> attr = new HashMap<>();
-            attr.put("rt", "oma.lwm2m");
+            attr.put("rt", "\"oma.lwm2m\"");
             b.objectLinks(new Link[] { new Link(rootpath, attr) });
         }
         return b.build();

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -98,7 +98,7 @@ public class Registration implements Serializable {
         String rootPath = "/";
         if (objectLinks != null) {
             for (Link link : objectLinks) {
-                if (link != null && "oma.lwm2m".equals(link.getAttributes().get("rt"))) {
+                if (link != null && "oma.lwm2m".equals(Link.unquote(link.getAttributes().get("rt")))) {
                     rootPath = link.getUrl();
                     break;
                 }
@@ -366,21 +366,23 @@ public class Registration implements Serializable {
                     try {
                         // extract object id and version
                         int objectId = Integer.parseInt(m.group(1));
-                        Object version = link.getAttributes().get(Attribute.OBJECT_VERSION);
+                        String version = link.getAttributes().get(Attribute.OBJECT_VERSION);
+                        // un-quote version (see https://github.com/eclipse/leshan/issues/732)
+                        version = Link.unquote(version);
                         String currentVersion = objects.get(objectId);
 
                         // store it in map
                         if (currentVersion == null) {
                             // we never find version for this object add it
-                            if (version instanceof String) {
-                                objects.put(objectId, (String) version);
+                            if (version != null) {
+                                objects.put(objectId, version);
                             } else {
                                 objects.put(objectId, ObjectModel.DEFAULT_VERSION);
                             }
                         } else {
                             // if version is already set, we override it only if new version is not DEFAULT_VERSION
-                            if (version instanceof String && !version.equals(ObjectModel.DEFAULT_VERSION)) {
-                                objects.put(objectId, (String) version);
+                            if (version != null && !version.equals(ObjectModel.DEFAULT_VERSION)) {
+                                objects.put(objectId, version);
                             }
                         }
                     } catch (NumberFormatException e) {

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
@@ -53,6 +53,17 @@ public class RegistrationTest {
     }
 
     @Test
+    public void test_supported_object_given_an_object_link_with_unquoted_rootpath() {
+        Registration reg = given_a_registration_with_object_link_like("</root>;rt=oma.lwm2m, </root/1/0>,</3/0>");
+
+        // Ensure supported objects are correct
+        Map<Integer, String> supportedObject = reg.getSupportedObject();
+        assertEquals(1, supportedObject.size());
+        assertEquals(ObjectModel.DEFAULT_VERSION, supportedObject.get(1));
+        assertNull(supportedObject.get(3));
+    }
+
+    @Test
     public void test_supported_object_given_an_object_link_with_regexp_rootpath() {
         Registration reg = given_a_registration_with_object_link_like(
                 "</r(\\d+)oot>;rt=\"oma.lwm2m\", </r(\\d+)oot/1/0>,</3/0>");

--- a/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
+++ b/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
@@ -51,11 +51,9 @@ public class RegistrationSerDes {
             JsonObject ol = Json.object();
             ol.add("url", l.getUrl());
             JsonObject at = Json.object();
-            for (Map.Entry<String, Object> e : l.getAttributes().entrySet()) {
+            for (Map.Entry<String, String> e : l.getAttributes().entrySet()) {
                 if (e.getValue() == null) {
                     at.add(e.getKey(), Json.NULL);
-                } else if (e.getValue() instanceof Integer) {
-                    at.add(e.getKey(), (int) e.getValue());
                 } else {
                     at.add(e.getKey(), e.getValue().toString());
                 }
@@ -99,14 +97,15 @@ public class RegistrationSerDes {
         for (int i = 0; i < links.size(); i++) {
             JsonObject ol = (JsonObject) links.get(i);
 
-            Map<String, Object> attMap = new HashMap<>();
+            Map<String, String> attMap = new HashMap<>();
             JsonObject att = (JsonObject) ol.get("at");
             for (String k : att.names()) {
                 JsonValue jsonValue = att.get(k);
                 if (jsonValue.isNull()) {
                     attMap.put(k, null);
                 } else if (jsonValue.isNumber()) {
-                    attMap.put(k, jsonValue.asInt());
+                    // This else block is just needed for retro-compatibility
+                    attMap.put(k, Integer.toString(jsonValue.asInt()));
                 } else {
                     attMap.put(k, jsonValue.asString());
                 }

--- a/leshan-server-redis/src/test/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDesTest.java
+++ b/leshan-server-redis/src/test/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDesTest.java
@@ -36,7 +36,7 @@ public class RegistrationSerDesTest {
         att.put("ts", 12);
         att.put("rt", "test");
         att.put("hb", null);
-        objs[0] = new Link("/0/1024/2", att);
+        objs[0] = new Link("/0/1024/2", att, Object.class);
         objs[1] = new Link("/0/2");
 
         Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",


### PR DESCRIPTION
This PR aims to fix #729.

### About `ver` attribute

The lwm2m specification **v1.0.x** seems to not be clear about the use of quote `"` for `ver` value :
 - _§5.2.7.3 Bootstrap DISCOVER_ seems to not use quote : `</55>;ver=1.9,`
 - _§6.2.3Object Definition and Object Version Usage_ seems to use quote : `</44>;ver=“2.2”`

The version **v1.1.x** both examples seem to not use quote and the format is clearly defined in _§5.1.2. Attributes Classification_ : `"ver" "=" 1*DIGIT "." 1*DIGIT`, so quote MUST NOT be used in v1.1.x.

Regarding this, we choose to be able to read (server side) both quoted and unquoted value and we will write(client) it without using quote.

### About `rt="oma.lwm2m"` attribute

There is nothing clear in the specification neither in **v1.0.x** nor **v1.1.x**, but all example use quote (`"oma.lwm2m"`).

Following the [rfc669](https://tools.ietf.org/html/rfc6690#section-2) quote could be used or not for single rt value.

So we choose to be able to read (server side) both quoted and unquoted value and we will write(client) it with quote (like in lwm2m example).