### PR TITLE
Provide a way to share an executor between several clients

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -23,6 +23,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.util.ExecutorsUtil;
+import org.eclipse.californium.elements.util.NamedThreadFactory;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.leshan.client.LwM2mClient;
 import org.eclipse.leshan.client.RegistrationEngine;
@@ -87,6 +89,12 @@ public class LeshanClient implements LwM2mClient {
         };
         if (sharedExecutor != null) {
             clientSideServer.setExecutors(sharedExecutor, sharedExecutor, true);
+        } else {
+            // use same executor as main and secondary one.
+            ScheduledExecutorService executor = ExecutorsUtil.newScheduledThreadPool(
+                    coapConfig.getInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT),
+                    new NamedThreadFactory("CoapServer(main)#"));
+            clientSideServer.setExecutors(executor, executor, false);
         }
 
         // Create CoAP resources for each lwm2m Objects.

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -263,6 +263,10 @@ public class LeshanClientBuilder {
         if (incompleteConfig.getConnectionThreadCount() == null) {
             dtlsConfigBuilder.setConnectionThreadCount(1);
         }
+        // Use only 1 thread to receive DTLS data by default
+        if (incompleteConfig.getReceiverThreadCount() == null) {
+            dtlsConfigBuilder.setReceiverThreadCount(1);
+        }
 
         // Deactivate SNI by default
         // TODO should we support SNI ?


### PR DESCRIPTION
It aims to implement partially #491.
To go further we need https://github.com/eclipse/californium/issues/1203.

You can now use : 

```java
ScheduledExecutorService sharedExecutor = Executors.newScheduledThreadPool(100,
        new NamedThreadFactory("shared executor"));

LeshanClient[] clients = new LeshanClient[3000];
for (int i = 0; i < clients.length; i++) {
    LeshanClientBuilder builder = new LeshanClientBuilder("myclient" + i);
    builder.setSharedExecutor(sharedExecutor);
    clients[i] = builder.build();
}
```