### PR TITLE
 Add udpate command to client-demo to trigger registration update

### DIFF
--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -477,6 +477,8 @@ public class LeshanClientDemo {
         commandsHelp.append(System.lineSeparator());
         commandsHelp.append("  - delete <objectId> : to disable a new object.");
         commandsHelp.append(System.lineSeparator());
+        commandsHelp.append("  - update : to trigger a registration update.");
+        commandsHelp.append(System.lineSeparator());
         commandsHelp.append("  - w : to move to North.");
         commandsHelp.append(System.lineSeparator());
         commandsHelp.append("  - a : to move to East.");
@@ -537,6 +539,8 @@ public class LeshanClientDemo {
                         scanner.next();
                         LOG.info("\"Invalid syntax, <objectid> must be an integer : delete <objectId>");
                     }
+                } else if (command.startsWith("update")) {
+                    client.triggerRegistrationUpdate();
                 } else if (command.length() == 1 && wasdCommands.contains(command.charAt(0))) {
                     locationInstance.moveLocation(command);
                 } else {


### PR DESCRIPTION
It aims to fix #453.

Commands available :

  - create <objectId> : to enable a new object.
  - delete <objectId> : to disable a new object.
  - **update : to trigger a registration update.**
  - w : to move to North.
  - a : to move to East.
  - s : to move to South.
  - d : to move to West.
