### PR TITLE
Delete all instance on bootstrap delete "/" except device and bs server

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapHandler.java
@@ -16,8 +16,6 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.bootstrap;
 
-import static org.eclipse.leshan.LwM2mId.*;
-
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -27,7 +25,6 @@ import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.servers.ServerInfo;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
-import org.eclipse.leshan.core.request.DeleteRequest;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapDeleteResponse;
 import org.eclipse.leshan.core.response.BootstrapFinishResponse;
@@ -77,21 +74,9 @@ public class BootstrapHandler {
                 return BootstrapDeleteResponse.badRequest("not from a bootstrap server");
             }
 
-            // The spec say that delete on "/" should delete all the existing Object Instances - except LWM2M
-            // Bootstrap Server Account, (see 5.2.5.2 Bootstrap Delete)
-            // For now we only remove security and server object.
-
             // Delete all device management server
-            LwM2mObjectEnabler serverObject = objects.get(SERVER);
-            for (Integer instanceId : serverObject.getAvailableInstanceIds()) {
-                serverObject.delete(identity, new DeleteRequest(SERVER, instanceId));
-            }
-
-            // Delete all security instance (except bootstrap one)
-            // TODO do not delete bootstrap server (see 5.2.5.2 Bootstrap Delete)
-            LwM2mObjectEnabler securityObject = objects.get(SECURITY);
-            for (Integer instanceId : securityObject.getAvailableInstanceIds()) {
-                securityObject.delete(identity, new DeleteRequest(SECURITY, instanceId));
+            for (LwM2mObjectEnabler enabler : objects.values()) {
+                enabler.delete(identity, new BootstrapDeleteRequest(enabler.getId()));
             }
 
             return BootstrapDeleteResponse.success();


### PR DESCRIPTION
5.2.7.5 BOOTSTRAP DELETE, the specification says : 

> When the Delete operation is used without any parameter (i.e. without Object ID parameter), all Instances of all Objects in the LwM2M Client MUST be removed (except for the two cases mentioned above); this functionality could be used for initialization purpose before LwM2MBootstrap-Server sends Write operation(s) to the LwM2MClient.

> The two exceptions are the LwM2MBootstrap-Server Account and the single Instance of the Mandatory Device Object (ID:3) which are not affected by any Delete operation.