### PR TITLE
Fix NPE in bsserver-demo with x509 auth mode

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
@@ -189,18 +189,7 @@ public class LeshanBootstrapServerDemo {
             builder.setCertificateChain(new X509Certificate[] { serverCertificate });
 
             // Use a certificate verifier which trust all certificates by default.
-            dtlsConfig.setCertificateVerifier(new CertificateVerifier() {
-                @Override
-                public void verifyCertificate(CertificateMessage message, DTLSSession session)
-                        throws HandshakeException {
-                    // trust all means never raise HandshakeException
-                }
-
-                @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                    return null;
-                }
-            });
+            builder.setTrustedCertificates(new X509Certificate[0]);
         } catch (Exception e) {
             LOG.error("Unable to load embedded X.509 certificate.", e);
             System.exit(-1);


### PR DESCRIPTION
In order to trust all client certificates, bs-server demo creates a `CertificateVerifier` instance which returns `NULL` when the `getAcceptedIssuers()` function is called. As stated in https://github.com/eclipse/californium/issues/1245, to trust all certificates it should return empty array not `NULL`.
The changes in commit 25413f2c2e5dddd4ce0cb873e791bdd72282a3ec  should also applied for bsserver-demo. With this fix, I could solve the problem mentioned in this issue https://github.com/eclipse/leshan/issues/839.