### PR TITLE
Add Validator for DDF File and Object Model

### DIFF
--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -42,6 +42,13 @@ Contributors:
             <artifactId>slf4j-simple</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -451,7 +451,7 @@ public class LeshanClientDemo {
         List<ObjectModel> models = ObjectLoader.loadDefault();
         models.addAll(ObjectLoader.loadDdfResources("/models", modelPaths));
         if (modelsFolderPath != null) {
-            models.addAll(ObjectLoader.loadObjectsFromDir(new File(modelsFolderPath)));
+            models.addAll(ObjectLoader.loadObjectsFromDir(new File(modelsFolderPath), true));
         }
 
         // Initialize object list

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -83,7 +83,7 @@ public class LeshanClientDemo {
 
     // /!\ This field is a COPY of org.eclipse.leshan.server.demo.LeshanServerDemo.modelPaths /!\
     // TODO create a leshan-demo project ?
-    private final static String[] modelPaths = new String[] { "10241.xml", "10242.xml", "10243.xml", "10244.xml",
+    public final static String[] modelPaths = new String[] { "10241.xml", "10242.xml", "10243.xml", "10244.xml",
                             "10245.xml", "10246.xml", "10247.xml", "10248.xml", "10249.xml", "10250.xml", "10251.xml",
                             "10252.xml", "10253.xml", "10254.xml", "10255.xml", "10256.xml", "10257.xml", "10258.xml",
                             "10259.xml", "10260-2_0.xml", "10262.xml", "10263.xml", "10264.xml", "10265.xml",

--- a/leshan-client-demo/src/test/java/org/eclipse/leshan/client/demo/model/ValidateClientDemoModelsTest.java
+++ b/leshan-client-demo/src/test/java/org/eclipse/leshan/client/demo/model/ValidateClientDemoModelsTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.model;
+
+import java.io.IOException;
+
+import org.eclipse.leshan.client.demo.LeshanClientDemo;
+import org.eclipse.leshan.core.model.InvalidDDFFileException;
+import org.eclipse.leshan.core.model.InvalidModelException;
+import org.eclipse.leshan.core.model.ObjectLoader;
+import org.junit.Test;
+
+public class ValidateClientDemoModelsTest {
+
+    @Test
+    public void validate_embedded_models() throws InvalidModelException, InvalidDDFFileException, IOException {
+        ObjectLoader.loadDdfResources("/models/", LeshanClientDemo.modelPaths, true);
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/DDFFileParser.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/DDFFileParser.java
@@ -42,9 +42,22 @@ public class DDFFileParser {
     private static final Logger LOG = LoggerFactory.getLogger(DDFFileParser.class);
 
     private final DocumentBuilderFactory factory;
+    private final DDFFileValidator ddfValidator;
 
     public DDFFileParser() {
+        this(null);
+    }
+
+    /**
+     * Build a DDFFileParser with a given {@link DDFFileValidator}.
+     * 
+     * @param ddfValidator a {@link DDFFileValidator} or {@code null} if no validation required.
+     * @since 1.1
+     */
+    public DDFFileParser(DDFFileValidator ddfValidator) {
         factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        this.ddfValidator = ddfValidator;
     }
 
     public List<ObjectModel> parse(File ddfFile) {
@@ -62,9 +75,16 @@ public class DDFFileParser {
         LOG.debug("Parsing DDF file {}", streamName);
 
         try {
+            // Parse XML file
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document document = builder.parse(inputStream);
 
+            // Validate XML against Schema
+            if (ddfValidator != null) {
+                ddfValidator.validate(document);
+            }
+
+            // Build list of ObjectModel
             ArrayList<ObjectModel> objects = new ArrayList<>();
             NodeList nodeList = document.getDocumentElement().getElementsByTagName("Object");
             for (int i = 0; i < nodeList.getLength(); i++) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/DDFFileParser.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/DDFFileParser.java
@@ -113,6 +113,9 @@ public class DDFFileParser {
         boolean multiple = false;
         boolean mandatory = false;
         List<ResourceModel> resources = new ArrayList<>();
+        String urn = null;
+        String description2 = null;
+        String lwm2mVersion = null;
 
         for (int i = 0; i < object.getChildNodes().getLength(); i++) {
             Node field = object.getChildNodes().item(i);
@@ -172,9 +175,13 @@ public class DDFFileParser {
                 }
                 break;
             case "ObjectURN":
+                urn = field.getTextContent();
+                break;
             case "LWM2MVersion":
+                lwm2mVersion = field.getTextContent();
+                break;
             case "Description2":
-                // TODO it should be supported in Leshan v1.1 or later.
+                description2 = field.getTextContent();
                 break;
             default:
                 LOG.warn("Unexpected object element [{}] in {} : it will be ignored.", field.getNodeName(), streamName);
@@ -182,7 +189,8 @@ public class DDFFileParser {
             }
         }
 
-        return new ObjectModel(id, name, description, version, multiple, mandatory, resources);
+        return new ObjectModel(id, name, description, version, multiple, mandatory, resources, urn, lwm2mVersion,
+                description2);
 
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/DDFFileValidator.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/DDFFileValidator.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.model;
+
+import org.w3c.dom.Node;
+
+/**
+ * A DDF File Validator.
+ * <p>
+ * Validate a DDF File against a LWM2M.xsd schema.
+ * 
+ * @since 1.1
+ */
+public interface DDFFileValidator {
+
+    /**
+     * Validate a DOM node (could be DOM Document) against the LWM2M.xsd Schema.
+     * 
+     * @param xmlToValidate DOM node to validate
+     * @throws InvalidDDFFileException if ddf file is invalid.
+     */
+    public void validate(Node xmlToValidate) throws InvalidDDFFileException;
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/DefaultDDFFileValidator.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/DefaultDDFFileValidator.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.model;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+/**
+ * A DDF File Validator.
+ * <p>
+ * Validate a DDF File against the embedded LWM2M.xsd schema.
+ * 
+ * @since 1.1
+ */
+
+public class DefaultDDFFileValidator implements DDFFileValidator {
+    private static String LWM2M_V1_SCHEMA_PATH = "/schemas/LWM2M.xsd";
+
+    @Override
+    public void validate(Node xmlToValidate) throws InvalidDDFFileException {
+        try {
+            validate(new DOMSource(xmlToValidate));
+        } catch (SAXException | IOException e) {
+            throw new InvalidDDFFileException(e);
+        }
+    }
+
+    /**
+     * Validate a XML {@link Source} against the embedded LWM2M.xsd Schema.
+     * 
+     * @param xmlToValidate an XML source to validate
+     * @throws SAXException see {@link Validator#validate(Source)}
+     * @throws IOException see {@link Validator#validate(Source)}
+     */
+    public void validate(Source xmlToValidate) throws SAXException, IOException {
+        Validator validator = getEmbeddedLwM2mSchema().newValidator();
+        validator.validate(xmlToValidate);
+    }
+
+    /**
+     * Get the Embedded the LWM2M.xsd Schema.
+     * 
+     * @throws SAXException see {@link SchemaFactory#newSchema(Source))}
+     */
+    protected Schema getEmbeddedLwM2mSchema() throws SAXException {
+        InputStream inputStream = DDFFileValidator.class.getResourceAsStream(LWM2M_V1_SCHEMA_PATH);
+        Source source = new StreamSource(inputStream);
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        return schemaFactory.newSchema(source);
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/InvalidDDFFileException.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/InvalidDDFFileException.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.model;
+
+/**
+ * Raised by {@link DDFFileValidator} if a DDF file is invalid
+ * 
+ * @since 1.1
+ */
+public class InvalidDDFFileException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidDDFFileException() {
+    }
+
+    public InvalidDDFFileException(String m) {
+        super(m);
+    }
+
+    public InvalidDDFFileException(String m, Object... args) {
+        super(String.format(m, args));
+    }
+
+    public InvalidDDFFileException(Throwable e) {
+        super(e);
+    }
+
+    public InvalidDDFFileException(String m, Throwable e) {
+        super(m, e);
+    }
+
+    public InvalidDDFFileException(Throwable e, String m, Object... args) {
+        super(String.format(m, args), e);
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/InvalidModelException.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/InvalidModelException.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.model;
+
+/**
+ * An exception raised when {@link ObjectModelValidator} detect an error.
+ * 
+ * @since 1.1
+ */
+public class InvalidModelException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidModelException(String m) {
+        super(m);
+    }
+
+    public InvalidModelException(String m, Object... args) {
+        super(String.format(m, args));
+    }
+
+    public InvalidModelException(Throwable e) {
+        super(e);
+    }
+
+    public InvalidModelException(String m, Throwable e) {
+        super(m, e);
+    }
+
+    public InvalidModelException(Throwable e, String m, Object... args) {
+        super(String.format(m, args), e);
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectLoader.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectLoader.java
@@ -35,7 +35,7 @@ public class ObjectLoader {
 
     private static final Logger LOG = LoggerFactory.getLogger(ObjectLoader.class);
 
-    private static final String[] ddfpaths = new String[] { "LWM2M_Security-v1_0.xml", "LWM2M_Server-v1_0.xml",
+    static final String[] ddfpaths = new String[] { "LWM2M_Security-v1_0.xml", "LWM2M_Server-v1_0.xml",
                             "LWM2M_Access_Control-v1_0_3.xml", "LWM2M_Device-v1_0_3.xml",
                             "LWM2M_Connectivity_Monitoring-v1_0_2.xml", "LWM2M_Firmware_Update-v1_0_3.xml",
                             "LWM2M_Location-v1_0_2.xml", "LWM2M_Connectivity_Statistics-v1_0_4.xml" };

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModel.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModel.java
@@ -40,6 +40,7 @@ public class ObjectModel {
     private static final int OMA_OBJECT_MIN_ID = 0;
     private static final int OMA_OBJECT_MAX_ID = 1023;
 
+    // TODO in version 2.0 all field should be null-able and ObjectModelValidator should be responsible to validate it.
     public final int id;
     public final String name;
     public final String description;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModel.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModel.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.core.LwM2m;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +46,12 @@ public class ObjectModel {
     public final String version;
     public final boolean multiple;
     public final boolean mandatory;
+    /** @since 1.1 */
+    public final String urn;
+    /** @since 1.1 */
+    public final String lwm2mVersion;
+    /** @since 1.1 */
+    public final String description2;
 
     public final Map<Integer, ResourceModel> resources; // resources by ID
 
@@ -56,7 +62,14 @@ public class ObjectModel {
 
     public ObjectModel(int id, String name, String description, String version, boolean multiple, boolean mandatory,
             Collection<ResourceModel> resources) {
-        Validate.notEmpty(version);
+        this(id, name, description, version, multiple, mandatory, resources, URN.generateURN(id, version), null, "");
+    }
+
+    /**
+     * @since 1.1
+     */
+    public ObjectModel(int id, String name, String description, String version, boolean multiple, boolean mandatory,
+            Collection<ResourceModel> resources, String urn, String lwm2mVersion, String description2) {
 
         this.id = id;
         this.name = name;
@@ -64,6 +77,9 @@ public class ObjectModel {
         this.version = version;
         this.multiple = multiple;
         this.mandatory = mandatory;
+        this.urn = urn;
+        this.lwm2mVersion = lwm2mVersion;
+        this.description2 = description2;
 
         Map<Integer, ResourceModel> resourcesMap = new HashMap<>(resources.size());
         for (ResourceModel resource : resources) {
@@ -91,13 +107,22 @@ public class ObjectModel {
         return version;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("ObjectModel [id=").append(id).append(", name=").append(name).append(", description=")
-                .append(description).append(", version=").append(version).append(", multiple=").append(multiple)
-                .append(", mandatory=").append(mandatory).append(", resources=").append(resources).append("]");
-        return builder.toString();
+    /**
+     * @return the LWM2M version and if the LWM2M version is null or empty return the default value 1.0
+     * @see LwM2m#VERSION
+     * @since 1.1
+     */
+    public String getLwM2mVersion() {
+        if (lwm2mVersion == null || lwm2mVersion.isEmpty()) {
+            return LwM2m.VERSION;
+        }
+        return lwm2mVersion;
     }
 
+    @Override
+    public String toString() {
+        return String.format(
+                "ObjectModel [id=%s, name=%s, description=%s, version=%s, multiple=%s, mandatory=%s, urn=%s, lwm2mVersion=%s, description2=%s, resources=%s]",
+                id, name, description, version, multiple, mandatory, urn, lwm2mVersion, description2, resources);
+    }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModelValidator.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/ObjectModelValidator.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.model;
+
+import java.util.List;
+
+/**
+ * Validate an LWM2M Object or Resource Model.
+ * 
+ * @since 1.1
+ */
+public interface ObjectModelValidator {
+
+    /**
+     * Validate a list of {@link ObjectModel}.
+     * 
+     * @param models the list of {@link ObjectModel} to validate
+     * @param modelName a hint about where the object come from to make debug easier. e.g a filename if model was store
+     *        in a file.
+     * @throws InvalidModelException is raised when an {@link ObjectModel} is Invalid
+     */
+    public void validate(List<ObjectModel> models, String modelName) throws InvalidModelException;
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/ResourceModel.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/ResourceModel.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.core.model;
 
 /**
  * A resource description
+ * 
  * @see "LWM2M specification D.1 Object Template."
  * @see <a href="http://openmobilealliance.org/tech/profiles/LWM2M.xsd">LWM2M Editor Schema</a>
  */
@@ -38,10 +39,12 @@ public class ResourceModel {
         }
     }
 
+    // TODO in version 2.0 : NONE should be added.
     public enum Type {
         STRING, INTEGER, FLOAT, BOOLEAN, OPAQUE, TIME, OBJLNK
     }
 
+    // TODO in version 2.0 all field should be null-able and ObjectModelValidator should be responsible to validate it.
     public final int id;
     public final String name;
     public final Operations operations;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/model/URN.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/model/URN.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.model;
+
+/**
+ * Some utility methods about object URN field of LWM2M Object Model
+ * 
+ * @since 1.1
+ */
+public class URN {
+    public static final String OMA_LABEL = "oma";
+    public static final String EXT_LABEL = "ext";
+    public static final String X_LABEL = "x";
+    public static final String INVALID_LABEL = "invalid";
+    public static final String RESERVED_LABEL = "reserved";
+
+    /**
+     * Generate URN from object Id and Object version.
+     */
+    public static String generateURN(int objectId, String objectVersion) {
+        StringBuilder urn = new StringBuilder("urn:oma:lwm2m");
+        urn.append(":").append(getUrnKind(objectId));
+        urn.append(":").append(objectId);
+        if (objectVersion != null && !objectVersion.isEmpty() && !objectVersion.equals(ObjectModel.DEFAULT_VERSION))
+            urn.append(":").append(objectVersion);
+        return urn.toString();
+    }
+
+    /**
+     * Return URN "kind" from object id.
+     * 
+     * @param objectId
+     * @return {@link #OMA_LABEL}, {@link #EXT_LABEL} or {@link #X_LABEL} for valid object id. {@link #INVALID_LABEL} is
+     *         returned for invalid id and {@link #RESERVED_LABEL} for reserved range.
+     * 
+     * @see <a href="http://www.openmobilealliance.org/wp/OMNA/LwM2M/LwM2MRegistry.html">OMA LightweightM2M (LwM2M)
+     *      Object and Resource Registry </a>
+     */
+    public static String getUrnKind(int objectId) {
+        if (0 <= objectId && objectId <= 1023)
+            return OMA_LABEL;
+        if (1024 <= objectId && objectId <= 2047)
+            return RESERVED_LABEL;
+        if (2048 <= objectId && objectId <= 10240)
+            return EXT_LABEL;
+        if (10241 <= objectId && objectId <= 42768)
+            return X_LABEL;
+        return INVALID_LABEL;
+    }
+}

--- a/leshan-core/src/main/resources/schemas/LWM2M.xsd
+++ b/leshan-core/src/main/resources/schemas/LWM2M.xsd
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+LWM2M XML Schema - LWM2M Editor Schema
+   version - 1.0.1
+   date    - 14 Jan 2017
+
+FILE INFORMATION
+
+  Public Reachable Information
+    Path: http://www.openmobilealliance.org/tech/profiles
+    Name: LWM2M.xsd
+
+NORMATIVE INFORMATION
+
+  Information about this file can be found in the LW M2M online editor
+
+  This is available at http://www.openmobilealliance.org/
+
+  Send comments to technical-comments@mail.openmobilealliance.org
+
+CHANGE HISTORY
+
+21112013 First version
+06082015 Bug Fix to correct mismatch
+18022016 Legal Disclaimer updated from template OMA-TEMPLATE-SUP_XSD_example-20160218-I
+24032016 Changed "xs:unsignedshort" to "xs:unsignedShort"
+25052016 Incorporated OMA-DM-LightweightM2M-2016-0066R01-INP_CR_Update_LWM2M_xsd
+14012017 Introduction of two new elements: LWM2MObject and ObjectVersion
+
+LEGAL DISCLAIMER
+
+  Copyright 2017 Open Mobile Alliance Ltd.  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+  The above license is used as a license under copyright only.  Please
+  reference the OMA IPR Policy for patent licensing terms:
+  http://www.openmobilealliance.org/ipr.html
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="LWM2M">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" name="Object">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Name" type="xs:string"/>
+              <xs:element name="Description1" type="xs:string"/>
+              <xs:element name="ObjectID" type="xs:unsignedShort"/>
+              <xs:element name="ObjectURN" type="xs:string"/>
+              <xs:element name="LWM2MVersion" type="xs:string" minOccurs="0"/>
+              <xs:element name="ObjectVersion" type="xs:string" minOccurs="0"/>			  
+              <xs:element name="MultipleInstances">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="Multiple"/>
+                    <xs:enumeration value="Single"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="Mandatory">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="Mandatory"/>
+                    <xs:enumeration value="Optional"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+              <xs:element name="Resources">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element maxOccurs="unbounded" name="Item">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="Name" type="xs:string"/>
+                          <xs:element name="Operations">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="R"/>
+                                <xs:enumeration value="W"/>
+                                <xs:enumeration value="RW"/>
+                                <xs:enumeration value="E"/>
+                                <xs:enumeration value=""/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:element>
+                          <xs:element name="MultipleInstances">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="Multiple"/>
+                                <xs:enumeration value="Single"/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:element>
+                          <xs:element name="Mandatory">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="Mandatory"/>
+                                <xs:enumeration value="Optional"/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:element>
+                          <xs:element name="Type">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="String"/>
+                                <xs:enumeration value="Integer"/>
+                                <xs:enumeration value="Float"/>
+                                <xs:enumeration value="Boolean"/>
+                                <xs:enumeration value="Opaque"/>
+                                <xs:enumeration value="Time"/>
+                                <xs:enumeration value="Objlnk"/>
+                                <xs:enumeration value=""/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:element>
+                          <xs:element name="RangeEnumeration" type="xs:string"/>
+                          <xs:element name="Units" type="xs:string"/>
+                          <xs:element name="Description" type="xs:string"/>
+                        </xs:sequence>
+                        <xs:attribute name="ID" type="xs:unsignedShort" use="required"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="Description2" type="xs:string"/>
+            </xs:sequence>
+            <xs:attribute name="ObjectType" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/model/ValidateModelsTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/model/ValidateModelsTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.model;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class ValidateModelsTest {
+
+    @Test
+    public void validate_embedded_models() throws InvalidModelException, InvalidDDFFileException, IOException {
+        ObjectLoader.loadDdfResources("/models/", ObjectLoader.ddfpaths, true);
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -523,7 +523,7 @@ public class LeshanServerDemo {
         List<ObjectModel> models = ObjectLoader.loadDefault();
         models.addAll(ObjectLoader.loadDdfResources("/models/", modelPaths));
         if (modelsFolderPath != null) {
-            models.addAll(ObjectLoader.loadObjectsFromDir(new File(modelsFolderPath)));
+            models.addAll(ObjectLoader.loadObjectsFromDir(new File(modelsFolderPath), true));
         }
         LwM2mModelProvider modelProvider = new VersionedModelProvider(models);
         builder.setObjectModelProvider(modelProvider);

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -91,7 +91,7 @@ public class LeshanServerDemo {
 
     // /!\ This field is a COPY of org.eclipse.leshan.client.demo.LeshanClientDemo.modelPaths /!\
     // TODO create a leshan-demo project ?
-    private final static String[] modelPaths = new String[] { "10241.xml", "10242.xml", "10243.xml", "10244.xml",
+    public final static String[] modelPaths = new String[] { "10241.xml", "10242.xml", "10243.xml", "10244.xml",
                             "10245.xml", "10246.xml", "10247.xml", "10248.xml", "10249.xml", "10250.xml", "10251.xml",
                             "10252.xml", "10253.xml", "10254.xml", "10255.xml", "10256.xml", "10257.xml", "10258.xml",
                             "10259.xml", "10260-2_0.xml", "10260.xml", "10262.xml", "10263.xml", "10264.xml",

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/model/Ddf2JsonGenerator.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/model/Ddf2JsonGenerator.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.leshan.core.model.DDFFileParser;
+import org.eclipse.leshan.core.model.InvalidDDFFileException;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.util.json.JsonException;
 
@@ -42,7 +43,7 @@ public class Ddf2JsonGenerator {
         }
     }
 
-    public void generate(File input, OutputStream output) throws IOException, JsonException {
+    public void generate(File input, OutputStream output) throws IOException, JsonException, InvalidDDFFileException {
         // check input exists
         if (!input.exists())
             throw new FileNotFoundException(input.toString());
@@ -60,7 +61,7 @@ public class Ddf2JsonGenerator {
         DDFFileParser ddfParser = new DDFFileParser();
         for (File f : files) {
             if (f.canRead()) {
-                objectModels.addAll(ddfParser.parse(f));
+                objectModels.addAll(ddfParser.parseEx(f));
             }
         }
 
@@ -76,7 +77,8 @@ public class Ddf2JsonGenerator {
         generate(objectModels, output);
     }
 
-    public static void main(String[] args) throws FileNotFoundException, IOException, JsonException {
+    public static void main(String[] args)
+            throws FileNotFoundException, IOException, JsonException, InvalidDDFFileException {
         // default value
         String ddfFilesPath = DEFAULT_DDF_FILES_PATH;
         String outputPath = DEFAULT_OUTPUT_PATH;

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/model/DdfList2JsonGenerator.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/model/DdfList2JsonGenerator.java
@@ -32,6 +32,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.eclipse.leshan.core.model.InvalidDDFFileException;
 import org.eclipse.leshan.core.util.json.JsonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,7 +106,7 @@ public class DdfList2JsonGenerator {
         }
     }
 
-    public static void main(String[] args) throws IOException, JsonException {
+    public static void main(String[] args) throws IOException, JsonException, InvalidDDFFileException {
         // default values
         String ddfFilesPath = Ddf2JsonGenerator.DEFAULT_DDF_FILES_PATH;
         String outputPath = Ddf2JsonGenerator.DEFAULT_OUTPUT_PATH;

--- a/leshan-server-demo/src/test/java/org/eclipse/leshan/server/demo/model/ValidateServerDemoModelsTest.java
+++ b/leshan-server-demo/src/test/java/org/eclipse/leshan/server/demo/model/ValidateServerDemoModelsTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.model;
+
+import java.io.IOException;
+
+import org.eclipse.leshan.core.model.InvalidDDFFileException;
+import org.eclipse.leshan.core.model.InvalidModelException;
+import org.eclipse.leshan.core.model.ObjectLoader;
+import org.eclipse.leshan.server.demo.LeshanServerDemo;
+import org.junit.Test;
+
+public class ValidateServerDemoModelsTest {
+
+    @Test
+    public void validate_embedded_models() throws InvalidModelException, InvalidDDFFileException, IOException {
+        ObjectLoader.loadDdfResources("/models/", LeshanServerDemo.modelPaths, true);
+    }
+}


### PR DESCRIPTION
This PR was triggered by #835.

The PR provides a DDF file validator and an Object Model Validator.
The DDF file validator validate the file using the LWM2M.xsd schema.
And Object Model Validator do more advanced validation like validate URN or version format.

ObjectLoader can now load a model using validation or not.
Validation is not free and so it could make sense to not validate a trusted model like the one embedded in a jar.

