### PR TITLE
Add usage of maven-toolchains-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,60 @@ Contributors:
             </properties>
         </profile>
         <profile>
+            <id>jdk8orGreater</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <jdk8orGreater>true</jdk8orGreater>
+            </properties>
+        </profile>
+        <profile>
+            <!-- This profile activate the usage of toolchain to compile using JDK 1.7-->
+            <id>useToolchain</id>
+            <properties>
+                <jdk8orGreater>false</jdk8orGreater>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-toolchains-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>toolchain</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <toolchains>
+                                <jdk>
+                                    <version>1.7</version>
+                                </jdk>
+                            </toolchains>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>configure-doclint</id>
+            <activation>
+                <property><name>jdk8orGreater</name><value>true</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <doclint>all,-missing</doclint>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <!-- this profile generate all the needed artifact and signatures needed, then release it on maven central -->
             <id>release</id>
             <activation>
@@ -236,6 +290,10 @@ Contributors:
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>1.4.1</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
                  <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
@@ -294,7 +352,6 @@ Contributors:
                     <configuration>
                         <excludePackageNames>org.eclipse.leshan.core.util</excludePackageNames>
                         <quiet>true</quiet>
-                        <doclint>all,-missing</doclint>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Add a profile to use [maven toolchain](https://maven.apache.org/plugins/maven-toolchains-plugin/toolchains/jdk.html). This allows to compile against JDK 1.7 running maven with a more recent JRE/JDK.

The doclint HACK is needed because of : https://issues.apache.org/jira/browse/MNG-6943.
We can use toolchain correctly on [jenkins](https://ci.eclipse.org/leshan/job/leshan-hudson-test/) thanks to : [eclipse#bug_560161](https://bugs.eclipse.org/bugs/show_bug.cgi?id=560161).

Using toolchain seems to allow us to get a rid of JAVA_TOOL_OPTIONS and _JAVA_OPTIONS workaround needed because of eclipse jenkins configuration :  [eclipse#bug_547626](https://bugs.eclipse.org/bugs/show_bug.cgi?id=547626).