### PR TITLE
Add Bootstrap Discover Request support.

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapHandler.java
@@ -22,9 +22,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.client.util.LinkFormatHelper;
+import org.eclipse.leshan.core.Link;
+import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
+import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
 import org.eclipse.leshan.core.response.BootstrapDeleteResponse;
+import org.eclipse.leshan.core.response.BootstrapDiscoverResponse;
 import org.eclipse.leshan.core.response.BootstrapFinishResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
 
@@ -102,5 +107,22 @@ public class BootstrapHandler {
     public synchronized void closeSession() {
         bootstrappingLatch = null;
         bootstrapping = false;
+    }
+
+    /**
+     * @since 1.1
+     */
+    public BootstrapDiscoverResponse discover(ServerIdentity identity, BootstrapDiscoverRequest request) {
+        if (!identity.isLwm2mBootstrapServer()) {
+            return BootstrapDiscoverResponse.badRequest("not a bootstrap server");
+        }
+
+        LwM2mPath path = request.getPath();
+        if (path.isRoot()) {
+            // Manage discover on object
+            Link[] ObjectLinks = LinkFormatHelper.getBootstrapClientDescription(objects.values());
+            return BootstrapDiscoverResponse.success(ObjectLinks);
+        }
+        return BootstrapDiscoverResponse.badRequest("invalid path");
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler2.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler2.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - use ServerIdentity
+ *******************************************************************************/
+package org.eclipse.leshan.client.resource;
+
+import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
+import org.eclipse.leshan.core.response.BootstrapDiscoverResponse;
+
+/**
+ * A new version of {@link LwM2mObjectEnabler} which support bootstrap discover.
+ * 
+ * @since 1.1
+ */
+public interface LwM2mObjectEnabler2 extends LwM2mObjectEnabler {
+
+    BootstrapDiscoverResponse discover(ServerIdentity identity, BootstrapDiscoverRequest request);
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -169,10 +169,24 @@ public class ServersInfoExtractor {
         }
     }
 
-    public static Long getServerId(LwM2mObjectEnabler serverEnabler, int instanceId) {
-        ReadResponse response = serverEnabler.read(ServerIdentity.SYSTEM,
-                new ReadRequest(SERVER, instanceId, SRV_SERVER_ID));
-        if (response.isSuccess()) {
+    public static Boolean isBootstrapServer(LwM2mObjectEnabler objectEnabler, int instanceId) {
+        ReadResponse response = objectEnabler.read(ServerIdentity.SYSTEM,
+                new ReadRequest(SECURITY, instanceId, SEC_BOOTSTRAP));
+        if (response != null && response.isSuccess()) {
+            return (Boolean) ((LwM2mResource) response.getContent()).getValue();
+        } else {
+            return null;
+        }
+    }
+
+    public static Long getServerId(LwM2mObjectEnabler objectEnabler, int instanceId) {
+        ReadResponse response = null;
+        if (objectEnabler.getId() == SERVER) {
+            response = objectEnabler.read(ServerIdentity.SYSTEM, new ReadRequest(SERVER, instanceId, SRV_SERVER_ID));
+        } else if (objectEnabler.getId() == SECURITY) {
+            response = objectEnabler.read(ServerIdentity.SYSTEM, new ReadRequest(SECURITY, instanceId, SEC_SERVER_ID));
+        }
+        if (response != null && response.isSuccess()) {
             return (Long) ((LwM2mResource) response.getContent()).getValue();
         } else {
             return null;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/BootstrapDiscoverRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/BootstrapDiscoverRequest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.request;
+
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.eclipse.leshan.core.response.BootstrapDiscoverResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Lightweight M2M request to let LWM2M Bootstrap server discovering which LwM2M Objects and Object Instances are
+ * supported by a certain LwM2M Client.
+ * 
+ * @since 1.1
+ */
+public class BootstrapDiscoverRequest extends AbstractDownlinkRequest<BootstrapDiscoverResponse> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BootstrapDiscoverRequest.class);
+
+    /**
+     * Creates a request for discovering all objects and instances supported by the client.
+     */
+    public BootstrapDiscoverRequest() {
+        this(LwM2mPath.ROOTPATH);
+    }
+
+    /**
+     * Creates a request for discovering instance of a given object.
+     *
+     * @param objectId the object type
+     */
+    public BootstrapDiscoverRequest(int objectId) {
+        this(new LwM2mPath(objectId));
+    }
+
+    /**
+     * Create a request for discovering
+     *
+     * @param path the path of the LWM2M node to discover
+     * @exception InvalidRequestException if the path is not valid.
+     */
+    public BootstrapDiscoverRequest(String path) throws InvalidRequestException {
+        this(newPath(path));
+    }
+
+    private BootstrapDiscoverRequest(LwM2mPath target) {
+        super(target);
+        if (!target.isRoot() && !target.isObject()) {
+            throw new InvalidRequestException("Invalid path %s : Discover request can only target root or object path",
+                    target);
+        }
+    }
+
+    @Override
+    public final String toString() {
+        return String.format("DiscoverRequest [%s]", getPath());
+    }
+
+    @Override
+    public void accept(DownlinkRequestVisitor visitor) {
+        if (visitor instanceof DownlinkRequestVisitor2) {
+            ((DownlinkRequestVisitor2) visitor).visit(this);
+        } else {
+            LOG.warn(
+                    "Your visitor {} does not support Bootstrap discover request, you should consider to make it implements DownlinkRequestVisitor2",
+                    this.getClass().getName());
+        }
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/DownlinkRequestVisitor2.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/DownlinkRequestVisitor2.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.request;
+
+/**
+ * A new version of {@link DownlinkRequestVisitor} which supports {@link BootstrapDiscoverRequest}
+ * 
+ * @since 1.1
+ */
+public interface DownlinkRequestVisitor2 extends DownlinkRequestVisitor {
+
+    void visit(BootstrapDiscoverRequest request);
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapDiscoverResponse.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/response/BootstrapDiscoverResponse.java
@@ -21,15 +21,18 @@ import org.eclipse.leshan.core.Link;
 import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.request.exception.InvalidResponseException;
 
-public class DiscoverResponse extends AbstractLwM2mResponse {
+/**
+ * @since 1.1
+ */
+public class BootstrapDiscoverResponse extends AbstractLwM2mResponse {
 
     private final Link[] links;
 
-    public DiscoverResponse(ResponseCode code, Link[] links, String errorMessage) {
+    public BootstrapDiscoverResponse(ResponseCode code, Link[] links, String errorMessage) {
         this(code, links, errorMessage, null);
     }
 
-    public DiscoverResponse(ResponseCode code, Link[] links, String errorMessage, Object coapResponse) {
+    public BootstrapDiscoverResponse(ResponseCode code, Link[] links, String errorMessage, Object coapResponse) {
         super(code, errorMessage, coapResponse);
         if (ResponseCode.CONTENT.equals(code)) {
             if (links == null)
@@ -59,9 +62,7 @@ public class DiscoverResponse extends AbstractLwM2mResponse {
         switch (code.getCode()) {
         case ResponseCode.CONTENT_CODE:
         case ResponseCode.BAD_REQUEST_CODE:
-        case ResponseCode.UNAUTHORIZED_CODE:
         case ResponseCode.NOT_FOUND_CODE:
-        case ResponseCode.METHOD_NOT_ALLOWED_CODE:
         case ResponseCode.INTERNAL_SERVER_ERROR_CODE:
             return true;
         default:
@@ -79,27 +80,19 @@ public class DiscoverResponse extends AbstractLwM2mResponse {
 
     // Syntactic sugar static constructors :
 
-    public static DiscoverResponse success(Link[] links) {
-        return new DiscoverResponse(ResponseCode.CONTENT, links, null);
+    public static BootstrapDiscoverResponse success(Link[] links) {
+        return new BootstrapDiscoverResponse(ResponseCode.CONTENT, links, null);
     }
 
-    public static DiscoverResponse badRequest(String errorMessage) {
-        return new DiscoverResponse(ResponseCode.BAD_REQUEST, null, errorMessage);
+    public static BootstrapDiscoverResponse badRequest(String errorMessage) {
+        return new BootstrapDiscoverResponse(ResponseCode.BAD_REQUEST, null, errorMessage);
     }
 
-    public static DiscoverResponse notFound() {
-        return new DiscoverResponse(ResponseCode.NOT_FOUND, null, null);
+    public static BootstrapDiscoverResponse notFound() {
+        return new BootstrapDiscoverResponse(ResponseCode.NOT_FOUND, null, null);
     }
 
-    public static DiscoverResponse unauthorized() {
-        return new DiscoverResponse(ResponseCode.UNAUTHORIZED, null, null);
-    }
-
-    public static DiscoverResponse methodNotAllowed() {
-        return new DiscoverResponse(ResponseCode.METHOD_NOT_ALLOWED, null, null);
-    }
-
-    public static DiscoverResponse internalServerError(String errorMessage) {
-        return new DiscoverResponse(ResponseCode.INTERNAL_SERVER_ERROR, null, errorMessage);
+    public static BootstrapDiscoverResponse internalServerError(String errorMessage) {
+        return new BootstrapDiscoverResponse(ResponseCode.INTERNAL_SERVER_ERROR, null, errorMessage);
     }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
@@ -31,6 +31,7 @@ import java.security.spec.ECPoint;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.KeySpec;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -43,16 +44,24 @@ import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.SecurityMode;
+import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.response.BootstrapDiscoverResponse;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ACLConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfigStore;
+import org.eclipse.leshan.server.bootstrap.BootstrapFailureCause;
+import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
+import org.eclipse.leshan.server.bootstrap.BootstrapHandlerFactory;
 import org.eclipse.leshan.server.bootstrap.BootstrapSession;
 import org.eclipse.leshan.server.bootstrap.DefaultBootstrapSession;
 import org.eclipse.leshan.server.bootstrap.DefaultBootstrapSessionManager;
+import org.eclipse.leshan.server.bootstrap.BootstrapSessionManager;
+import org.eclipse.leshan.server.bootstrap.DefaultBootstrapHandler;
+import org.eclipse.leshan.server.bootstrap.LwM2mBootstrapRequestSender;
 import org.eclipse.leshan.server.californium.bootstrap.LeshanBootstrapServer;
 import org.eclipse.leshan.server.californium.bootstrap.LeshanBootstrapServerBuilder;
 import org.eclipse.leshan.server.security.BootstrapSecurityStore;
@@ -69,6 +78,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
     public final PublicKey bootstrapServerPublicKey;
     public final PrivateKey bootstrapServerPrivateKey;
     public volatile DefaultBootstrapSession lastBootstrapSession;
+    public volatile BootstrapDiscoverResponse lastDiscoverAnswer;
 
     public BootstrapIntegrationTestHelper() {
         super();
@@ -101,7 +111,8 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
         }
     }
 
-    public void createBootstrapServer(BootstrapSecurityStore securityStore, BootstrapConfigStore bootstrapStore) {
+    private LeshanBootstrapServerBuilder createBootstrapBuilder(BootstrapSecurityStore securityStore,
+            BootstrapConfigStore bootstrapStore) {
         if (bootstrapStore == null) {
             bootstrapStore = unsecuredBootstrapStore();
         }
@@ -124,6 +135,45 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
             }
         });
 
+        return builder;
+    }
+
+    public void createBootstrapServer(BootstrapSecurityStore securityStore, BootstrapConfigStore bootstrapStore) {
+        bootstrapServer = createBootstrapBuilder(securityStore, bootstrapStore).build();
+    }
+
+    public void createBootstrapServer(BootstrapSecurityStore securityStore, BootstrapConfigStore bootstrapStore,
+            final BootstrapDiscoverRequest request) {
+        LeshanBootstrapServerBuilder builder = createBootstrapBuilder(securityStore, bootstrapStore);
+
+        // start bootstrap session by a bootstrap discover request
+        builder.setBootstrapHandlerFactory(new BootstrapHandlerFactory() {
+
+            @Override
+            public BootstrapHandler create(BootstrapConfigStore store, LwM2mBootstrapRequestSender sender,
+                    BootstrapSessionManager sessionManager) {
+                return new DefaultBootstrapHandler(store, sender, sessionManager) {
+
+                    @Override
+                    protected void startBootstrap(final BootstrapSession session, final BootstrapConfig cfg) {
+                        send(session, request, new SafeResponseCallback<BootstrapDiscoverResponse>(session) {
+
+                            @Override
+                            public void safeOnResponse(BootstrapDiscoverResponse response) {
+                                lastDiscoverAnswer = response;
+                                delete(session, cfg, new ArrayList<>(cfg.toDelete));
+                            }
+                        }, new SafeErrorCallback(session) {
+                            @Override
+                            public void safeOnError(Exception e) {
+                                stopSession(session, BootstrapFailureCause.INTERNAL_SERVER_ERROR);
+                            }
+                        });
+                    }
+                };
+            }
+        });
+
         bootstrapServer = builder.build();
     }
 
@@ -135,7 +185,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
         // Create Security Object (with bootstrap server only)
         String bsUrl = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                 + bootstrapServer.getUnsecuredAddress().getPort();
-        return new Security(bsUrl, true, 3, new byte[0], new byte[0], new byte[0], 12345);
+        return new Security(bsUrl, true, 3, new byte[0], new byte[0], new byte[0], 0);
     }
 
     @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilder.java
@@ -29,6 +29,7 @@ import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeEncoder;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
+import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.CancelObservationRequest;
@@ -37,7 +38,7 @@ import org.eclipse.leshan.core.request.CreateRequest;
 import org.eclipse.leshan.core.request.DeleteRequest;
 import org.eclipse.leshan.core.request.DiscoverRequest;
 import org.eclipse.leshan.core.request.DownlinkRequest;
-import org.eclipse.leshan.core.request.DownlinkRequestVisitor;
+import org.eclipse.leshan.core.request.DownlinkRequestVisitor2;
 import org.eclipse.leshan.core.request.ExecuteRequest;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.request.ObserveRequest;
@@ -52,7 +53,7 @@ import org.eclipse.leshan.server.californium.observation.ObserveUtil;
  * <p>
  * Call <code>CoapRequestBuilder#visit(lwm2mRequest)</code>, then get the result using {@link #getRequest()}
  */
-public class CoapRequestBuilder implements DownlinkRequestVisitor {
+public class CoapRequestBuilder implements DownlinkRequestVisitor2 {
 
     private Request coapRequest;
 
@@ -171,6 +172,13 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         coapRequest.getOptions().setContentFormat(format.getCode());
         coapRequest.setPayload(encoder.encode(request.getNode(), format, request.getPath(), model));
         setTarget(coapRequest, request.getPath());
+    }
+
+    @Override
+    public void visit(BootstrapDiscoverRequest request) {
+        coapRequest = Request.newGet();
+        setTarget(coapRequest, request.getPath());
+        coapRequest.getOptions().setAccept(MediaTypeRegistry.APPLICATION_LINK_FORMAT);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,17 @@ Contributors:
                                 <patch>equivalent</patch>
                             </versionIncreaseAllows>
                         </revapi.semver.ignore>
+                        <revapi.ignore>
+                            <item>
+                                <regex>true</regex>
+                                <code>java.class.externalClassExposedInAPI</code>
+                                <newArchive>org\.eclipse\.leshan:leshan.*:.*</newArchive>
+                                <justification>
+                                    Leshan sub-modules implement the Leshan API which makes them expose
+                                    Leshan-specific classes usually. 
+                                </justification>
+                            </item>
+                        </revapi.ignore>
                         <revapi.java>
                             <checks>
                                 <nonPublicPartOfAPI>


### PR DESCRIPTION
This PR add support for Bootstrap discover request.

This is fully implemented at client side.  
At server side this allow to customize `BootstrapHandler` behavior to send `BootstrapDiscoverRequest` if needed but the API should maybe be improved. I don't know really how for now ...  
This is how this looks like : 
```java
LeshanBootstrapServerBuilder builder = new LeshanBootstrapServerBuilder();
builder.setBootstrapHandlerFactory(new BootstrapHandlerFactory() {
    @Override
    public BootstrapHandler create(BootstrapConfigStore store, LwM2mBootstrapRequestSender sender,
            BootstrapSessionManager sessionManager) {
        return new DefaultBootstrapHandler(store, sender, sessionManager) {
            @Override
            protected void startBootstrap(final BootstrapSession session, final BootstrapConfig cfg) {
                send(session, request, new SafeResponseCallback<BootstrapDiscoverResponse>(session) {
                    @Override
                    public void safeOnResponse(BootstrapDiscoverResponse response) {
                        // Do what you want depending on response value.

                       // To continue bootstrap session
                       // (if you don't use anonymous class this is probably better to call super.startBootstrap())
                        delete(session, cfg, new ArrayList<>(cfg.toDelete));
                    }
                }, new SafeErrorCallback(session) {
                    @Override
                    public void safeOnError(Exception e) {
                        // do what you want on failure, here we just stop the session.
                        stopSession(session, BootstrapFailureCause.INTERNAL_SERVER_ERROR);
                    }
                });
            }
        };
    }
});
```