### PR TITLE
SecurityMode: Add missing "Certificate mode with EST" (4)

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/SecurityMode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/SecurityMode.java
@@ -19,7 +19,7 @@ package org.eclipse.leshan.core;
  * The different DTLS security modes
  */
 public enum SecurityMode {
-    PSK(0), RPK(1), X509(2), NO_SEC(3);
+    PSK(0), RPK(1), X509(2), NO_SEC(3), EST(4);
 
     public final int code;
 


### PR DESCRIPTION
This adds missing EST security mode enum value.

Now the list should be complete vs. specification.

This change relates to: https://github.com/eclipse/leshan/issues/859

Signed-off-by: Vesa Jääskeläinen <dachaac@gmail.com>