### PR TITLE
Remove ID Context inputs for OSCORE

### DIFF
--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
@@ -104,7 +104,6 @@
                     oscoreAeadAlgorithm : bsserverOscore.aeadAlgorithm,
                     oscoreHmacAlgorithm : bsserverOscore.hkdfAlgorithm,
                     oscoreMasterSalt : bsserverOscore.masterSalt,
-                    oscoreIdContext : bsserverOscore.idContext
                 }
                 var bsOscoreSecurityMode = 0; // link to bs oscore object
                 bsserver.secmode = "NO_SEC"; // act as no_sec from here

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/oscore-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/oscore-input.tag
@@ -20,17 +20,7 @@
             <p class="help-block" if={masterSalt.toolong}>The master salt is too long</p>
         </div>
     </div>
-    
-    <div class={ form-group:true, has-error: idContext.error }>
-        <label for="idContext" class="col-sm-4 control-label">ID Context</label>
-        <div class="col-sm-8">
-            <textarea class="form-control" style="resize:none" rows="1" id="idContext" ref="idContext" oninput={validate_idContext} onblur={validate_idContext} disabled={true}></textarea>
-            <p class="text-right text-muted small" style="margin:0">Not supported</p>
-            <p class="help-block" if={idContext.nothexa}>Hexadecimal format is expected</p>
-            <p class="help-block" if={idContext.toolong}>The ID context is too long</p>
-        </div>
-    </div>
-    
+
     <div class={ form-group:true, has-error: senderId.error }>
         <label for="senderId" class="col-sm-4 control-label">Sender ID</label>
         <div class="col-sm-8">
@@ -78,7 +68,6 @@
         // Tag internal state
         tag.masterSecret={};
         tag.masterSalt={};
-        tag.idContext={};
         tag.senderId={};
         tag.recipientId={};
         tag.aeadAlgorithm={};
@@ -87,7 +76,6 @@
         tag.defaultHkdfAlgorithm = "HKDF_HMAC_SHA_256";
         tag.validate_masterSecret = validate_masterSecret;
         tag.validate_masterSalt = validate_masterSalt;
-        tag.validate_idContext = validate_idContext;
         tag.validate_senderId = validate_senderId;
         tag.validate_recipientId = validate_recipientId;
         tag.validate_aeadAlgorithm = validate_aeadAlgorithm;
@@ -125,22 +113,6 @@
             }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
                 tag.masterSalt.error = true;
                 tag.masterSalt.nothexa = true;
-            }
-            tag.onchange();
-        }
-        
-        function validate_idContext(e){
-            var str = tag.refs.idContext.value;
-            tag.idContext.error = false;
-            tag.idContext.toolong = false;
-            tag.idContext.nothexa = false;
-            var isEmpty = !str || 0 === str.length;
-            if (str.length > 32){
-                tag.idContext.error = true;
-                tag.idContext.toolong = true;
-            }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
-                tag.idContext.error = true;
-                tag.idContext.nothexa = true;
             }
             tag.onchange();
         }
@@ -202,7 +174,6 @@
         function has_error(){
             return  typeof tag.masterSecret.error === "undefined" || tag.masterSecret.error
             || tag.masterSalt.error
-            || tag.idContext.error
             || tag.senderId.error
             || tag.recipientId.error
             || tag.aeadAlgorithm.error
@@ -248,7 +219,6 @@
         function get_value(){
             return { masterSecret:tag.refs.masterSecret.value,
                 masterSalt:tag.refs.masterSalt.value,
-                idContext:tag.refs.idContext.value,
                 senderId:tag.refs.senderId.value,
                 recipientId:tag.refs.recipientId.value,
                 aeadAlgorithm:parse_aeadAlgorithm(tag.refs.aeadAlgorithm.value),

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
@@ -112,7 +112,6 @@
                                 
                 config.oscore.masterSecret = oscoreVals.masterSecret;
                 config.oscore.masterSalt = oscoreVals.masterSalt;
-                config.oscore.idContext = oscoreVals.idContext;
                 config.oscore.senderId = oscoreVals.senderId;
                 config.oscore.recipientId = oscoreVals.recipientId;
                 config.oscore.aeadAlgorithm = oscoreVals.aeadAlgorithm;

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -195,8 +195,9 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
             }
 
             try {
+                byte[] idContext = null;
                 OSCoreCtx ctx = new OSCoreCtx(serverInfo.masterSecret, true, aeadAlg, serverInfo.senderId,
-                        serverInfo.recipientId, hkdfAlg, 32, serverInfo.masterSalt, serverInfo.idContext);
+                        serverInfo.recipientId, hkdfAlg, 32, serverInfo.masterSalt, idContext);
                 db.addContext(serverInfo.getFullUri().toASCIIString(), ctx);
 
                 // Also add the context by the IP of the server since requests may use that

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
@@ -49,8 +49,6 @@ public class Oscore extends BaseInstanceEnabler {
     private int aeadAlgorithm;
     private int hkdfAlgorithm;
     private String masterSalt;
-    // TODO OSCORE : never used and not part of OSCORE object
-    private String idContext;
 
     public Oscore() {
 
@@ -68,7 +66,6 @@ public class Oscore extends BaseInstanceEnabler {
         this.aeadAlgorithm = aeadAlgorithm;
         this.hkdfAlgorithm = hkdfAlgorithm;
         this.masterSalt = masterSalt;
-        this.idContext = "";
     }
 
     /**

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
@@ -61,7 +61,6 @@ public class ServerInfo {
     public long aeadAlgorithm;
     public long hkdfAlgorithm;
     public byte[] masterSalt;
-    public byte[] idContext;
 
     public InetSocketAddress getAddress() {
         return getAddress(serverUri);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -113,7 +113,6 @@ public class ServersInfoExtractor {
                             info.aeadAlgorithm = getAeadAlgorithm(oscoreInstance);
                             info.hkdfAlgorithm = getHkdfAlgorithm(oscoreInstance);
                             info.masterSalt = getMasterSalt(oscoreInstance);
-                            info.idContext = getIdContext(oscoreInstance);
                         } else if (info.secureMode == SecurityMode.PSK) {
                             info.pskId = getPskIdentity(security);
                             info.pskKey = getPskKey(security);
@@ -157,7 +156,6 @@ public class ServersInfoExtractor {
                         info.aeadAlgorithm = getAeadAlgorithm(oscoreInstance);
                         info.hkdfAlgorithm = getHkdfAlgorithm(oscoreInstance);
                         info.masterSalt = getMasterSalt(oscoreInstance);
-                        info.idContext = getIdContext(oscoreInstance);
                     } else if (info.secureMode == SecurityMode.PSK) {
                         info.pskId = getPskIdentity(security);
                         info.pskKey = getPskKey(security);
@@ -362,9 +360,5 @@ public class ServersInfoExtractor {
         } else {
             return Hex.decodeHex(value.toCharArray());
         }
-    }
-
-    public static byte[] getIdContext(LwM2mObjectInstance oscoreInstance) {
-        return null;
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -230,8 +230,6 @@ public class LeshanClientDemo {
                 "The OSCORE pre-shared key used between the Client and LwM2M Server/Bootstrap Server.");
         options.addOption("msalt", true,
                 "The OSCORE master salt used between the Client and LwM2M Server or Bootstrap Server.\nDefault: Empty");
-        options.addOption("idctx", true,
-                "The OSCORE ID Context used between the Client and LwM2M Server or Bootstrap Server.\nDefault: Empty");
         options.addOption("sid", true,
                 "The OSCORE Sender ID used by the client to the LwM2M Server or Bootstrap Server.");
         options.addOption("rid", true,
@@ -521,13 +519,6 @@ public class LeshanClientDemo {
                 mastersaltStr = "";
             }
 
-            String idcontextStr = cl.getOptionValue("idctx");
-            if (idcontextStr != null) {
-                System.err.println("The OSCORE ID Context parameter is not yet supported");
-                formatter.printHelp(USAGE, options);
-                return;
-            }
-
             String senderidStr = cl.getOptionValue("sid");
             if (senderidStr == null) {
                 System.err.println("The OSCORE Sender ID must be indicated");
@@ -583,7 +574,7 @@ public class LeshanClientDemo {
             }
 
             // Save the configured OSCORE parameters
-            oscoreSettings = new OSCoreSettings(mastersecretStr, mastersaltStr, idcontextStr, senderidStr,
+            oscoreSettings = new OSCoreSettings(mastersecretStr, mastersaltStr, senderidStr,
                     recipientidStr, aeadInt, hkdfInt);
         }
 
@@ -929,7 +920,7 @@ public class LeshanClientDemo {
         public int aeadAlgorithm;
         public int hkdfAlgorithm;
 
-        public OSCoreSettings(String masterSecret, String masterSalt, String idContext, String senderId,
+        public OSCoreSettings(String masterSecret, String masterSalt, String senderId,
                 String recipientId, int aeadAlgorithm, int hkdfAlgorithm) {
             this.masterSecret = masterSecret;
             this.masterSalt = masterSalt;

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
@@ -131,14 +131,8 @@ public class SecurityDeserializer implements JsonDeserializer<SecurityInfo> {
                     }
                 }
 
+                // ID Context not supported
                 byte[] idContext = null;
-                if (oscore.get("idContext") != null) {
-                    idContext = Hex.decodeHex(oscore.get("idContext").getAsString().toCharArray());
-
-                    if (idContext.length == 0) {
-                        idContext = null;
-                    }
-                }
 
                 // Parse AEAD Algorithm
                 AlgorithmID aeadAlgorithm = null;

--- a/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
@@ -105,8 +105,8 @@ angular.module('securityControllers', [])
                 } else if($scope.securityMode == "oscore") {
                     // Information for OSCORE
                     var security = {endpoint: $scope.endpoint, oscore : { masterSecret : $scope.masterSecret, masterSalt : $scope.masterSalt,
-                        idContext : $scope.idContext, senderId : $scope.senderId, recipientId : $scope.recipientId,
-                        aeadAlgorithm : $scope.aeadAlgorithm || $scope.defaultAeadAlgorithm, hkdfAlgorithm : $scope.hkdfAlgorithm || $scope.defaultHkdfAlgorithm }};
+                        senderId : $scope.senderId, recipientId : $scope.recipientId, aeadAlgorithm : $scope.aeadAlgorithm || $scope.defaultAeadAlgorithm,
+                        hkdfAlgorithm : $scope.hkdfAlgorithm || $scope.defaultHkdfAlgorithm }};
                     } else {
                     var security = {endpoint: $scope.endpoint, x509 : true};
                 }

--- a/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
@@ -63,7 +63,6 @@
 			<td ng-if="security.oscore">
 				Master Secret : <code>{{ security.oscore.masterSecret }}</code><br/>
 				Master Salt : <code>{{ security.oscore.masterSalt }}</code><br/>
-				ID Context : <code>{{ security.oscore.idContext }}</code><br/>
 				Sender ID : <code>{{ security.oscore.senderId }}</code><br/>
 				Recipient ID : <code>{{ security.oscore.recipientId }}</code><br/>
 				AEAD Algorithm : <code>{{ security.oscore.aeadAlgorithm }}</code><br/>
@@ -159,17 +158,6 @@
 							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
 							<p class="help-block" ng-if="form.masterSalt.$error.pattern">Hexadecimal format is expected</p>
 							<p class="help-block" ng-if="form.masterSalt.$error.maxlength">Master Salt is too long</p>
-						</div>
-					</div>
-
-					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
-						<label for="idContextValue" class="col-sm-4 control-label">ID Context</label>
-						<div class="col-sm-8">
-							<textarea class="form-control" style="resize:none" rows="1" id="idContextValue" name="idContext" 
-							ng-model="idContext" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="32" disabled={true}></textarea>
-							<p class="text-right text-muted small" style="margin:0">Not supported</p>
-							<p class="help-block" ng-if="form.idContext.$error.pattern">Hexadecimal format is expected</p>
-							<p class="help-block" ng-if="form.idContext.$error.maxlength">ID Context is too long</p>
 						</div>
 					</div>
 


### PR DESCRIPTION
The possibility to input an ID Context for OSCORE on the client-demo, bsserver-demo and server demo has now been removed.

As we discussed since the ID Context is currently not part of the LWM2M OSCORE object it is better to not use.