### PR TITLE
Add LowerLayerSetter class to allow to tweak coap level parameter for requests

### DIFF
--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServer.java
@@ -68,7 +68,9 @@ import org.eclipse.leshan.server.registration.RegistrationService;
 import org.eclipse.leshan.server.registration.RegistrationServiceImpl;
 import org.eclipse.leshan.server.registration.RegistrationStore;
 import org.eclipse.leshan.server.registration.RegistrationUpdate;
+import org.eclipse.leshan.server.request.LowerLayerConfig;
 import org.eclipse.leshan.server.request.LwM2mRequestSender;
+import org.eclipse.leshan.server.request.LwM2mRequestSender2;
 import org.eclipse.leshan.server.security.Authorizer;
 import org.eclipse.leshan.server.security.EditableSecurityStore;
 import org.eclipse.leshan.server.security.SecurityInfo;
@@ -87,6 +89,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The {@link LeshanServerBuilder} should be the preferred way to build an instance of {@link LeshanServer}.
  */
+@SuppressWarnings("deprecation")
 public class LeshanServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(LeshanServer.class);
@@ -474,7 +477,7 @@ public class LeshanServer {
      */
     public <T extends LwM2mResponse> T send(Registration destination, DownlinkRequest<T> request)
             throws InterruptedException {
-        return requestSender.send(destination, request, DEFAULT_TIMEOUT);
+        return send(destination, request, DEFAULT_TIMEOUT);
     }
 
     /**
@@ -500,7 +503,42 @@ public class LeshanServer {
      */
     public <T extends LwM2mResponse> T send(Registration destination, DownlinkRequest<T> request, long timeoutInMs)
             throws InterruptedException {
-        return requestSender.send(destination, request, timeoutInMs);
+        return send(destination, request, null, timeoutInMs);
+    }
+
+    /**
+     * Send a Lightweight M2M request synchronously. Will block until a response is received from the remote server.
+     * <p>
+     * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
+     * way.
+     * 
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param lowerLayerConfig to tweak lower layer request (e.g. coap request)
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @return the LWM2M response. The response can be <code>null</code> if the timeout expires (see
+     *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
+     * 
+     * @throws CodecException if request payload can not be encoded.
+     * @throws InterruptedException if the thread was interrupted.
+     * @throws RequestRejectedException if the request is rejected by foreign peer.
+     * @throws RequestCanceledException if the request is cancelled.
+     * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
+     * @throws InvalidResponseException if the response received is malformed.
+     * @throws ClientSleepingException if client is currently sleeping.
+     */
+    public <T extends LwM2mResponse> T send(Registration destination, DownlinkRequest<T> request,
+            LowerLayerConfig lowerLayerConfig, long timeoutInMs) throws InterruptedException {
+        if (requestSender instanceof LwM2mRequestSender2) {
+            return ((LwM2mRequestSender2) requestSender).send(destination, request, lowerLayerConfig, timeoutInMs);
+        } else {
+            if (lowerLayerConfig != null) {
+                LOG.warn("{} should implement the new interface LwM2mRequestSender2",
+                        requestSender.getClass().getCanonicalName());
+            }
+            return requestSender.send(destination, request, timeoutInMs);
+        }
     }
 
     /**
@@ -533,7 +571,7 @@ public class LeshanServer {
      */
     public <T extends LwM2mResponse> void send(Registration destination, DownlinkRequest<T> request,
             ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
-        requestSender.send(destination, request, DEFAULT_TIMEOUT, responseCallback, errorCallback);
+        send(destination, request, DEFAULT_TIMEOUT, responseCallback, errorCallback);
     }
 
     /**
@@ -565,7 +603,52 @@ public class LeshanServer {
      */
     public <T extends LwM2mResponse> void send(Registration destination, DownlinkRequest<T> request, long timeoutInMs,
             ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
-        requestSender.send(destination, request, timeoutInMs, responseCallback, errorCallback);
+        send(destination, request, null, timeoutInMs, responseCallback, errorCallback);
+    }
+
+    /**
+     * Send a Lightweight M2M {@link DownlinkRequest} asynchronously to a LWM2M client.
+     * <p>
+     * The Californium API does not ensure that message callback are exclusive. E.g. In some race condition, you can get
+     * a onReponse call and a onCancel one. This method ensures that you will receive only one event. Meaning, you get
+     * either 1 response or 1 error.
+     * 
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
+     * @param request The request to send to the client.
+     * @param lowerLayerConfig to tweak lower layer request (e.g. coap request)
+     * @param timeoutInMs The global timeout to wait in milliseconds (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param responseCallback a callback called when a response is received (successful or error response). This
+     *        callback MUST NOT be null.
+     * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
+     *        <ul>
+     *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
+     *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
+     *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
+     *        <li>{@link InvalidResponseException} if the response received is malformed.</li>
+     *        <li>{@link ClientSleepingException} if client is currently sleeping.</li>
+     *        <li>{@link TimeoutException} if the timeout expires (see
+     *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
+     *        <li>or any other RuntimeException for unexpected issue.
+     *        </ul>
+     *        This callback MUST NOT be null.
+     * @throws CodecException if request payload can not be encoded.
+     * 
+     * @since 1.2
+     */
+    public <T extends LwM2mResponse> void send(Registration destination, DownlinkRequest<T> request,
+            LowerLayerConfig lowerLayerConfig, long timeoutInMs, ResponseCallback<T> responseCallback,
+            ErrorCallback errorCallback) {
+        if (requestSender instanceof LwM2mRequestSender2) {
+            ((LwM2mRequestSender2) requestSender).send(destination, request, lowerLayerConfig, timeoutInMs,
+                    responseCallback, errorCallback);
+        } else {
+            if (lowerLayerConfig != null) {
+                LOG.warn("{} should implement the new interface LwM2mRequestSender2",
+                        requestSender.getClass().getCanonicalName());
+            }
+            requestSender.send(destination, request, timeoutInMs, responseCallback, errorCallback);
+        }
     }
 
     /**

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumQueueModeRequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CaliforniumQueueModeRequestSender.java
@@ -26,10 +26,12 @@ import org.eclipse.leshan.server.queue.PresenceServiceImpl;
 import org.eclipse.leshan.server.queue.QueueModeLwM2mRequestSender;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.request.LwM2mRequestSender;
+import org.eclipse.leshan.server.request.LwM2mRequestSender2;
 
 /**
- * A {@link LwM2mRequestSender} and {@link CoapRequestSender} which supports LWM2M Queue Mode.
+ * A {@link LwM2mRequestSender2} and {@link CoapRequestSender} which supports LWM2M Queue Mode.
  */
+@SuppressWarnings("deprecation")
 public class CaliforniumQueueModeRequestSender extends QueueModeLwM2mRequestSender
         implements CoapRequestSender, Destroyable {
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestConfig.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestConfig.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.request;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.stack.ReliabilityLayerParameters;
+import org.eclipse.leshan.server.request.LowerLayerConfig;
+
+public class CoapRequestConfig implements LowerLayerConfig {
+
+    private final ReliabilityLayerParameters reliabilityLayerParameters;
+
+    private CoapRequestConfig(ReliabilityLayerParameters reliabilityLayerParameters) {
+        this.reliabilityLayerParameters = reliabilityLayerParameters;
+    }
+
+    @Override
+    public void apply(Object lowerRequest) {
+        if (lowerRequest instanceof Request) {
+            apply((Request) lowerRequest);
+        }
+    }
+
+    protected void apply(Request coapRequest) {
+        if (reliabilityLayerParameters != null)
+            coapRequest.setReliabilityLayerParameters(reliabilityLayerParameters);
+    }
+
+    public static CoapRequestConfig reliabilityConfig(ReliabilityLayerParameters.Builder reliabilityParametersBuilder) {
+        return builder().setReliabilityLayerParameters(reliabilityParametersBuilder.build()).build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private ReliabilityLayerParameters reliabilityLayerParameters;
+
+        private Builder() {
+        }
+
+        public Builder setReliabilityLayerParameters(ReliabilityLayerParameters reliabilityLayerParameters) {
+            this.reliabilityLayerParameters = reliabilityLayerParameters;
+            return this;
+        }
+
+        public CoapRequestConfig build() {
+            return new CoapRequestConfig(reliabilityLayerParameters);
+        }
+    }
+}

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
@@ -90,7 +90,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         ReadRequest request = new ReadRequest(3, 0);
         builder.visit(request);
 
@@ -108,7 +108,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         ReadRequest request = new ReadRequest(3, 0, 1);
         builder.visit(request);
 
@@ -123,7 +123,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         ReadRequest request = new ReadRequest(3);
         builder.visit(request);
 
@@ -138,7 +138,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         DiscoverRequest request = new DiscoverRequest(3, 0);
         builder.visit(request);
 
@@ -157,7 +157,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         WriteRequest request = new WriteRequest(Mode.UPDATE, 3, 0, LwM2mSingleResource.newStringResource(15, "value"));
         builder.visit(request);
 
@@ -181,7 +181,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         WriteRequest request = new WriteRequest(3, 0, 14, "value");
         builder.visit(request);
 
@@ -196,7 +196,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         AttributeSet attributes = new AttributeSet(new Attribute(Attribute.MINIMUM_PERIOD, 10L),
                 new Attribute(Attribute.MAXIMUM_PERIOD, 100L));
         WriteAttributesRequest request = new WriteAttributesRequest(3, 0, 14, attributes);
@@ -216,7 +216,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         AttributeSet attributes = new AttributeSet(new Attribute(Attribute.MINIMUM_PERIOD),
                 new Attribute(Attribute.MAXIMUM_PERIOD));
         WriteAttributesRequest request = new WriteAttributesRequest(3, 0, 14, attributes);
@@ -236,7 +236,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         ExecuteRequest request = new ExecuteRequest(3, 0, 12, "params");
         builder.visit(request);
 
@@ -255,7 +255,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         CreateRequest request = new CreateRequest(12, LwM2mSingleResource.newStringResource(0, "value"));
         builder.visit(request);
 
@@ -278,7 +278,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         CreateRequest request = new CreateRequest(12,
                 new LwM2mObjectInstance(26, LwM2mSingleResource.newStringResource(0, "value")));
         builder.visit(request);
@@ -303,7 +303,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         DeleteRequest request = new DeleteRequest(12, 0);
         builder.visit(request);
 
@@ -321,7 +321,7 @@ public class CoapRequestBuilderTest {
 
         // test
         CoapRequestBuilder builder = new CoapRequestBuilder(reg.getIdentity(), reg.getRootPath(), reg.getId(),
-                reg.getEndpoint(), model, encoder, false);
+                reg.getEndpoint(), model, encoder, false, null);
         ObserveRequest request = new ObserveRequest(12, 0);
         builder.visit(request);
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LowerLayerConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LowerLayerConfig.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.request;
+
+/**
+ * Allow to apply custom configuration to lower layer.
+ * <p>
+ * If you are using LWM2M over CoAP this will help you to apply CoAP setting to you request.
+ * 
+ * @since 1.2
+ */
+public interface LowerLayerConfig {
+
+    /**
+     * @param lowerRequest the lower layer request on which the configuration should be applied. E.g. could be a CoAP
+     *        request.
+     */
+    void apply(Object lowerRequest);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender.java
@@ -32,7 +32,10 @@ import org.eclipse.leshan.server.registration.Registration;
 
 /**
  * A {@link LwM2mRequestSender} is responsible to send LWM2M {@link DownlinkRequest} for a given {@link Registration}.
+ * 
+ * @deprecated use {@link LwM2mRequestSender2} instead
  */
+@Deprecated
 public interface LwM2mRequestSender {
 
     /**

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender2.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/request/LwM2mRequestSender2.java
@@ -11,54 +11,32 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
  * Contributors:
- *     Zebra Technologies - initial API and implementation
+ *     Sierra Wireless - initial API and implementation
+ *     Bosch Software Innovations GmbH - extension of ticket based asynchronous call.
  *******************************************************************************/
-package org.eclipse.leshan.server.californium.bootstrap;
+package org.eclipse.leshan.server.request;
 
-import org.eclipse.californium.core.network.Endpoint;
-import org.eclipse.leshan.core.model.LwM2mModel;
-import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.codec.CodecException;
-import org.eclipse.leshan.core.node.codec.LwM2mNodeDecoder;
-import org.eclipse.leshan.core.node.codec.LwM2mNodeEncoder;
 import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.exception.ClientSleepingException;
 import org.eclipse.leshan.core.request.exception.InvalidResponseException;
 import org.eclipse.leshan.core.request.exception.RequestCanceledException;
 import org.eclipse.leshan.core.request.exception.RequestRejectedException;
 import org.eclipse.leshan.core.request.exception.SendFailedException;
 import org.eclipse.leshan.core.request.exception.TimeoutException;
+import org.eclipse.leshan.core.request.exception.UnconnectedPeerException;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
-import org.eclipse.leshan.server.Destroyable;
-import org.eclipse.leshan.server.bootstrap.BootstrapSession;
-import org.eclipse.leshan.server.bootstrap.LwM2mBootstrapRequestSender;
-import org.eclipse.leshan.server.californium.request.RequestSender;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.eclipse.leshan.server.registration.Registration;
 
 /**
- * An implementation of {@link LwM2mBootstrapRequestSender} based on Californium.
+ * A recent version of {@link LwM2mRequestSender} which add support to {@link LowerLayerConfig}
+ * 
+ * @since 1.2
  */
-public class CaliforniumLwM2mBootstrapRequestSender implements LwM2mBootstrapRequestSender, Destroyable {
-
-    static final Logger LOG = LoggerFactory.getLogger(CaliforniumLwM2mBootstrapRequestSender.class);
-
-    private final LwM2mModel model;
-    private final RequestSender sender;
-
-    /**
-     * @param secureEndpoint The endpoint used to send coaps request.
-     * @param nonSecureEndpoint The endpoint used to send coap request.
-     * @param model the {@link LwM2mModel} used to encode/decode {@link LwM2mNode}.
-     * @param encoder The {@link LwM2mNodeEncoder} used to encode {@link LwM2mNode}.
-     * @param decoder The {@link LwM2mNodeDecoder} used to encode {@link LwM2mNode}.
-     */
-    public CaliforniumLwM2mBootstrapRequestSender(Endpoint secureEndpoint, Endpoint nonSecureEndpoint, LwM2mModel model,
-            LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder) {
-        this.model = model;
-        this.sender = new RequestSender(secureEndpoint, nonSecureEndpoint, encoder, decoder);
-    }
+@SuppressWarnings("deprecation")
+public interface LwM2mRequestSender2 extends LwM2mRequestSender {
 
     /**
      * Send a Lightweight M2M request synchronously. Will block until a response is received from the remote server.
@@ -66,10 +44,12 @@ public class CaliforniumLwM2mBootstrapRequestSender implements LwM2mBootstrapReq
      * The synchronous way could block a thread during a long time so it is more recommended to use the asynchronous
      * way.
      * 
-     * @param destination The {@link BootstrapSession} associate to the device we want to sent the request.
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
      * @param request The request to send to the client.
+     * @param lowerLayerConfig to tweak lower layer request (e.g. coap request)
      * @param timeoutInMs The global timeout to wait in milliseconds (see
      *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
+     * @param <T> The expected type of the response received.
      * @return the LWM2M response. The response can be <code>null</code> if the timeout expires (see
      *         https://github.com/eclipse/leshan/wiki/Request-Timeout).
      * 
@@ -79,33 +59,33 @@ public class CaliforniumLwM2mBootstrapRequestSender implements LwM2mBootstrapReq
      * @throws RequestCanceledException if the request is cancelled.
      * @throws SendFailedException if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.
      * @throws InvalidResponseException if the response received is malformed.
+     * @throws UnconnectedPeerException if client is not connected (no dtls connection available).
+     * @throws ClientSleepingException if client is currently sleeping.
      */
-    @Override
-    public <T extends LwM2mResponse> T send(BootstrapSession destination, DownlinkRequest<T> request, long timeoutInMs)
-            throws InterruptedException {
-        return sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(), model,
-                null, request, null, timeoutInMs, false);
-    }
+    <T extends LwM2mResponse> T send(Registration destination, DownlinkRequest<T> request,
+            LowerLayerConfig lowerLayerConfig, long timeoutInMs) throws InterruptedException;
 
     /**
      * Send a Lightweight M2M {@link DownlinkRequest} asynchronously to a LWM2M client.
      * 
-     * The Californium API does not ensure that message callback are exclusive. E.g. In some race condition, you can get
-     * a onReponse call and a onCancel one. This method ensures that you will receive only one event. Meaning, you get
-     * either 1 response or 1 error.
+     * {@link ResponseCallback} and {@link ErrorCallback} are exclusively called.
      * 
-     * @param destination The {@link BootstrapSession} associate to the device we want to sent the request.
+     * @param destination The {@link Registration} associate to the device we want to sent the request.
      * @param request The request to send to the client.
+     * @param lowerLayerConfig to tweak lower layer request (e.g. coap request)
      * @param timeoutInMs The global timeout to wait in milliseconds (see
      *        https://github.com/eclipse/leshan/wiki/Request-Timeout)
      * @param responseCallback a callback called when a response is received (successful or error response). This
      *        callback MUST NOT be null.
+     * @param <T> The expected type of the response received.
      * @param errorCallback a callback called when an error or exception occurred when response is received. It can be :
      *        <ul>
      *        <li>{@link RequestRejectedException} if the request is rejected by foreign peer.</li>
      *        <li>{@link RequestCanceledException} if the request is cancelled.</li>
      *        <li>{@link SendFailedException} if the request can not be sent. E.g. error at CoAP or DTLS/UDP layer.</li>
      *        <li>{@link InvalidResponseException} if the response received is malformed.</li>
+     *        <li>{@link UnconnectedPeerException} if client is not connected (no dtls connection available).</li>
+     *        <li>{@link ClientSleepingException} if client is currently sleeping.</li>
      *        <li>{@link TimeoutException} if the timeout expires (see
      *        https://github.com/eclipse/leshan/wiki/Request-Timeout).</li>
      *        <li>or any other RuntimeException for unexpected issue.
@@ -113,25 +93,7 @@ public class CaliforniumLwM2mBootstrapRequestSender implements LwM2mBootstrapReq
      *        This callback MUST NOT be null.
      * @throws CodecException if request payload can not be encoded.
      */
-    @Override
-    public <T extends LwM2mResponse> void send(BootstrapSession destination, DownlinkRequest<T> request,
-            long timeoutInMs, ResponseCallback<T> responseCallback, ErrorCallback errorCallback) {
-        sender.sendLwm2mRequest(destination.getEndpoint(), destination.getIdentity(), destination.getId(), model, null,
-                request, null, timeoutInMs, responseCallback, errorCallback, false);
-    }
-
-    /**
-     * Cancel all ongoing requests for a given bootstrap session.
-     * 
-     * @param session the bootstrap session for which we need to cancel requests.
-     */
-    @Override
-    public void cancelOngoingRequests(BootstrapSession session) {
-        sender.cancelRequests(session.getId());
-    }
-
-    @Override
-    public void destroy() {
-        sender.destroy();
-    }
+    <T extends LwM2mResponse> void send(Registration destination, DownlinkRequest<T> request,
+            LowerLayerConfig lowerLayerConfig, long timeoutInMs, ResponseCallback<T> responseCallback,
+            ErrorCallback errorCallback);
 }


### PR DESCRIPTION
This aims to implements #875.

An example of use : 
```java
// configure reliability parameters
Builder reliabilityParams = ReliabilityLayerParameters.builder();
reliabilityParams.ackRandomFactor(1).ackTimeout(100).ackTimeoutScale(1).maxRetransmit(1);
// send requests
ReadResponse response = server.send(registration,
                                    new ReadRequest("3/0/1"),  
                                    CoapRequestSetter.reliabilitySetter(reliabilityParams), 
                                    timeout);
``` 