### PR TITLE
Add resources instances operations

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
@@ -28,6 +28,7 @@ import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
+import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.node.LwM2mResourceInstance;
@@ -173,6 +174,20 @@ public class BaseInstanceEnabler implements LwM2mInstanceEnabler {
     @Override
     public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstanceId,
             LwM2mResourceInstance value) {
+        // this is a sub-optimal default implementation
+        ReadResponse response = read(ServerIdentity.SYSTEM, resourceid);
+        if (response.isSuccess()) {
+            LwM2mNode content = response.getContent();
+            if (content instanceof LwM2mMultipleResource) {
+                LwM2mMultipleResource multiresource = ((LwM2mMultipleResource) content);
+                Map<Integer, LwM2mResourceInstance> instances = new HashMap<>(multiresource.getInstances());
+                if (instances.containsKey(resourceInstanceId)) {
+                    instances.put(resourceInstanceId, value);
+                    return write(identity, resourceid,
+                            new LwM2mMultipleResource(resourceInstanceId, value.getType(), instances.values()));
+                }
+            }
+        }
         return WriteResponse.notFound();
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
@@ -171,7 +171,8 @@ public class BaseInstanceEnabler implements LwM2mInstanceEnabler {
     }
 
     @Override
-    public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, Object value) {
+    public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstanceId,
+            LwM2mResourceInstance value) {
         return WriteResponse.notFound();
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseInstanceEnabler.java
@@ -27,8 +27,10 @@ import org.eclipse.leshan.client.LwM2mClient;
 import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
+import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -126,6 +128,20 @@ public class BaseInstanceEnabler implements LwM2mInstanceEnabler {
     }
 
     @Override
+    public ReadResponse read(ServerIdentity identity, int resourceId, int resourceInstance) {
+        ReadResponse response = read(identity, resourceId);
+        if (response.isFailure())
+            return response;
+        LwM2mMultipleResource resource = (LwM2mMultipleResource) response.getContent();
+        LwM2mResourceInstance resourceIn = resource.getInstance(resourceInstance);
+        if (resourceIn == null) {
+            return ReadResponse.notFound();
+        } else {
+            return ReadResponse.success(resourceIn);
+        }
+    }
+
+    @Override
     public WriteResponse write(ServerIdentity identity, boolean replace, LwM2mObjectInstance value) {
         Map<Integer, LwM2mResource> resourcesToWrite = new HashMap<>(value.getResources());
 
@@ -151,6 +167,11 @@ public class BaseInstanceEnabler implements LwM2mInstanceEnabler {
 
     @Override
     public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
+        return WriteResponse.notFound();
+    }
+
+    @Override
+    public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, Object value) {
         return WriteResponse.notFound();
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -158,12 +158,14 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
             }
 
             // check if the resource is readable.
-            if (path.isResource()) {
+            if (path.isResource() || path.isResourceInstance()) {
                 ResourceModel resourceModel = objectModel.resources.get(path.getResourceId());
                 if (resourceModel == null) {
                     return ReadResponse.notFound();
                 } else if (!resourceModel.operations.isReadable()) {
                     return ReadResponse.methodNotAllowed();
+                } else if (path.isResourceInstance() && !resourceModel.multiple) {
+                    return ReadResponse.badRequest("invalid path : resource is not multiple");
                 }
             }
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -197,7 +197,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
                 return WriteResponse.notFound();
             }
 
-            if (path.isResource()) {
+            if (path.isResource() || path.isResourceInstance()) {
                 // resource write:
                 // check if the resource is writable
                 if (LwM2mId.SECURITY != id) { // security resources are writable by SYSTEM
@@ -206,6 +206,8 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
                         return WriteResponse.notFound();
                     } else if (!resourceModel.operations.isWritable()) {
                         return WriteResponse.methodNotAllowed();
+                    } else if (path.isResourceInstance() && !resourceModel.multiple) {
+                        return WriteResponse.badRequest("invalid path : resource is not multiple");
                     }
                 }
             } else if (path.isObjectInstance()) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/DummyInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/DummyInstanceEnabler.java
@@ -27,6 +27,7 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
@@ -70,8 +71,9 @@ public class DummyInstanceEnabler extends SimpleInstanceEnabler {
     }
 
     @Override
-    public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, Object value) {
-        LOG.info("Write on {} Resource /{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid,
+    public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance,
+            LwM2mResourceInstance value) {
+        LOG.info("Write on {} Resource  Instance/{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid,
                 resourceInstance);
         return super.write(identity, resourceid, resourceInstance, value);
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/DummyInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/DummyInstanceEnabler.java
@@ -55,10 +55,11 @@ public class DummyInstanceEnabler extends SimpleInstanceEnabler {
         LOG.info("Read on {} Resource /{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid);
         return super.read(identity, resourceid);
     }
-    
+
     @Override
     public ReadResponse read(ServerIdentity identity, int resourceid, int resourceInstance) {
-        LOG.info("Read on {} Resource /{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid, resourceInstance);
+        LOG.info("Read on {} Resource /{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid,
+                resourceInstance);
         return super.read(identity, resourceid, resourceInstance);
     }
 
@@ -70,7 +71,8 @@ public class DummyInstanceEnabler extends SimpleInstanceEnabler {
 
     @Override
     public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, Object value) {
-        LOG.info("Write on {} Resource /{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid, resourceInstance);
+        LOG.info("Write on {} Resource /{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid,
+                resourceInstance);
         return super.write(identity, resourceid, resourceInstance, value);
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/DummyInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/DummyInstanceEnabler.java
@@ -55,11 +55,23 @@ public class DummyInstanceEnabler extends SimpleInstanceEnabler {
         LOG.info("Read on {} Resource /{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid);
         return super.read(identity, resourceid);
     }
+    
+    @Override
+    public ReadResponse read(ServerIdentity identity, int resourceid, int resourceInstance) {
+        LOG.info("Read on {} Resource /{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid, resourceInstance);
+        return super.read(identity, resourceid, resourceInstance);
+    }
 
     @Override
     public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
         LOG.info("Write on {} Resource /{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid);
         return super.write(identity, resourceid, value);
+    }
+
+    @Override
+    public WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, Object value) {
+        LOG.info("Write on {} Resource /{}/{}/{}/{} ", getModel().name, getModel().id, getId(), resourceid, resourceInstance);
+        return super.write(identity, resourceid, resourceInstance, value);
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
@@ -113,6 +113,19 @@ public interface LwM2mInstanceEnabler {
     ReadResponse read(ServerIdentity identity, int resourceId);
 
     /**
+     * Gets the current value of one of this LWM2M object instance's resources instance.
+     * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
+     * @param resourceId the ID of the resource to get the value of
+     * @param resourceInstance the ID of the resource instance to get the value of
+     * @return the response object representing the outcome of the operation. An implementation should set the result's
+     *         {@link ReadResponse#getCode() response code} to either reflect the success or reason for failure to
+     *         retrieve the value.
+     */
+    ReadResponse read(ServerIdentity identity, int resourceId, int resourceInstance);
+
+    /**
      * Sets all resources of this LWM2M object instance.
      * 
      * @param identity the identity of the requester. This could be an internal call in this case
@@ -137,6 +150,20 @@ public interface LwM2mInstanceEnabler {
      *         the value.
      */
     WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value);
+
+    /**
+     * Sets the value of one of this LWM2M object instance's resources instance.
+     * 
+     * @param identity the identity of the requester. This could be an internal call in this case
+     *        <code> identity == ServerIdentity.SYSTEM</code>.
+     * @param resourceid the ID of the resource to set the value for
+     * @param resourceInstance the ID of the resource instance to set the value of
+     * @param value the value to set the resource instance to
+     * @return the response object representing the outcome of the operation. An implementation should set the result's
+     *         {@link WriteResponse#getCode() response code} to either reflect the success or reason for failure to set
+     *         the value.
+     */
+    WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, Object value);
 
     /**
      * Executes the operation represented by one of this LWM2M object instance's resources.

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
@@ -25,6 +25,7 @@ import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.request.WriteRequest.Mode;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
@@ -163,7 +164,7 @@ public interface LwM2mInstanceEnabler {
      *         {@link WriteResponse#getCode() response code} to either reflect the success or reason for failure to set
      *         the value.
      */
-    WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, Object value);
+    WriteResponse write(ServerIdentity identity, int resourceid, int resourceInstance, LwM2mResourceInstance value);
 
     /**
      * Executes the operation represented by one of this LWM2M object instance's resources.

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -270,7 +270,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
 
         // Manage Resource Instance case
         return instance.write(identity, path.getResourceId(), path.getResourceInstanceId(),
-                ((LwM2mResourceInstance) request.getNode()).getValue());
+                ((LwM2mResourceInstance) request.getNode()));
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -30,7 +30,6 @@ import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.client.servers.ServersInfoExtractor;
 import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.model.ObjectModel;
-import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
@@ -219,17 +218,7 @@ public class ObjectEnabler extends BaseObjectEnabler {
         }
 
         // Manage Resource Instance case
-        // TODO optimization: create dedicated API to access to resource instance directly
-        ReadResponse response = instance.read(identity, path.getResourceId());
-        if (response.isFailure())
-            return response;
-        LwM2mMultipleResource resource = (LwM2mMultipleResource) response.getContent();
-        LwM2mResourceInstance resourceInstance = resource.getInstance(path.getResourceInstanceId());
-        if (resourceInstance == null) {
-            return ReadResponse.notFound();
-        } else {
-            return ReadResponse.success(resourceInstance);
-        }
+        return instance.read(identity, path.getResourceId(), path.getResourceInstanceId());
     }
 
     @Override
@@ -275,7 +264,13 @@ public class ObjectEnabler extends BaseObjectEnabler {
         }
 
         // Manage Resource case
-        return instance.write(identity, path.getResourceId(), (LwM2mResource) request.getNode());
+        if (path.getResourceInstanceId() == null) {
+            return instance.write(identity, path.getResourceId(), (LwM2mResource) request.getNode());
+        }
+
+        // Manage Resource Instance case
+        return instance.write(identity, path.getResourceId(), path.getResourceInstanceId(),
+                ((LwM2mResourceInstance) request.getNode()).getValue());
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
@@ -28,7 +28,6 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mResource;
-import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -76,44 +75,11 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
     }
 
     @Override
-    public ReadResponse read(ServerIdentity identity, int resourceId, int resourceInstance) {
-        if (resources.containsKey(resourceId)) {
-            LwM2mMultipleResource lwM2mResource = (LwM2mMultipleResource) resources.get(resourceId);
-            LwM2mResourceInstance resourceIn = lwM2mResource.getInstance(resourceInstance);
-            if (resourceIn == null) {
-                return ReadResponse.notFound();
-            } else {
-                return ReadResponse.success(resourceIn);
-            }
-        }
-        return ReadResponse.notFound();
-    }
-
-    @Override
     public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
         LwM2mResource previousValue = resources.put(resourceid, value);
         if (!value.equals(previousValue))
             fireResourcesChange(resourceid);
         return WriteResponse.success();
-    }
-
-    @Override
-    public WriteResponse write(ServerIdentity identity, int resourceId, int resourceInstance,
-            LwM2mResourceInstance value) {
-        if (resources.containsKey(resourceId)) {
-            LwM2mMultipleResource lwM2mResource = (LwM2mMultipleResource) resources.get(resourceId);
-
-            // Rewrite specific instance value
-            Map<Integer, LwM2mResourceInstance> newMap = new HashMap<>(lwM2mResource.getInstances());
-            newMap.put(resourceInstance, value);
-
-            LwM2mMultipleResource newResource = new LwM2mMultipleResource(resourceId, lwM2mResource.getType(),
-                    newMap.values());
-            return this.write(identity, resourceId, newResource);
-
-        }
-        return WriteResponse.notFound();
-
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
@@ -28,6 +28,7 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -75,11 +76,46 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
     }
 
     @Override
+    public ReadResponse read(ServerIdentity identity, int resourceId, int resourceInstance) {
+        if (resources.containsKey(resourceId)) {
+            LwM2mMultipleResource lwM2mResource = (LwM2mMultipleResource) resources.get(resourceId);
+            LwM2mResourceInstance resourceIn = lwM2mResource.getInstance(resourceInstance);
+            if (resourceIn == null) {
+                return ReadResponse.notFound();
+            } else {
+                return ReadResponse.success(resourceIn);
+            }
+        }
+        return ReadResponse.notFound();
+    }
+
+    @Override
     public WriteResponse write(ServerIdentity identity, int resourceid, LwM2mResource value) {
         LwM2mResource previousValue = resources.put(resourceid, value);
         if (!value.equals(previousValue))
             fireResourcesChange(resourceid);
         return WriteResponse.success();
+    }
+
+    @Override
+    public WriteResponse write(ServerIdentity identity, int resourceId, int resourceInstance, Object value) {
+        if (resources.containsKey(resourceId)) {
+            LwM2mMultipleResource lwM2mResource = (LwM2mMultipleResource) resources.get(resourceId);
+
+            Map<Integer, Object> newMap = new HashMap<>();
+            // Copy instances values to map
+            for (Map.Entry<Integer, LwM2mResourceInstance> entry : lwM2mResource.getInstances().entrySet()) {
+                newMap.put(entry.getKey(), entry.getValue().getValue());
+            }
+
+            // Rewrite specific instance value
+            newMap.put(resourceInstance, value);
+            LwM2mMultipleResource newResource = LwM2mMultipleResource.newResource(resourceId, newMap, lwM2mResource.getType());
+            return this.write(identity, resourceId,newResource);
+
+        }
+        return WriteResponse.notFound();
+
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
@@ -110,8 +110,9 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
 
             // Rewrite specific instance value
             newMap.put(resourceInstance, value);
-            LwM2mMultipleResource newResource = LwM2mMultipleResource.newResource(resourceId, newMap, lwM2mResource.getType());
-            return this.write(identity, resourceId,newResource);
+            LwM2mMultipleResource newResource = LwM2mMultipleResource.newResource(resourceId, newMap,
+                    lwM2mResource.getType());
+            return this.write(identity, resourceId, newResource);
 
         }
         return WriteResponse.notFound();

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/SimpleInstanceEnabler.java
@@ -98,20 +98,17 @@ public class SimpleInstanceEnabler extends BaseInstanceEnabler {
     }
 
     @Override
-    public WriteResponse write(ServerIdentity identity, int resourceId, int resourceInstance, Object value) {
+    public WriteResponse write(ServerIdentity identity, int resourceId, int resourceInstance,
+            LwM2mResourceInstance value) {
         if (resources.containsKey(resourceId)) {
             LwM2mMultipleResource lwM2mResource = (LwM2mMultipleResource) resources.get(resourceId);
 
-            Map<Integer, Object> newMap = new HashMap<>();
-            // Copy instances values to map
-            for (Map.Entry<Integer, LwM2mResourceInstance> entry : lwM2mResource.getInstances().entrySet()) {
-                newMap.put(entry.getKey(), entry.getValue().getValue());
-            }
-
             // Rewrite specific instance value
+            Map<Integer, LwM2mResourceInstance> newMap = new HashMap<>(lwM2mResource.getInstances());
             newMap.put(resourceInstance, value);
-            LwM2mMultipleResource newResource = LwM2mMultipleResource.newResource(resourceId, newMap,
-                    lwM2mResource.getType());
+
+            LwM2mMultipleResource newResource = new LwM2mMultipleResource(resourceId, lwM2mResource.getType(),
+                    newMap.values());
             return this.write(identity, resourceId, newResource);
 
         }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mMultipleResource.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mMultipleResource.java
@@ -30,7 +30,7 @@ import org.eclipse.leshan.core.util.Validate;
 /**
  * A resource which contains several resource instances.
  * 
- * A resource instance is defined by a numeric identifier and a value. There are accessible via {@link #getValues()}
+ * A resource instance is defined by a numeric identifier and a value. There are accessible via {@link #getInstances()}
  */
 public class LwM2mMultipleResource implements LwM2mResource {
 
@@ -159,24 +159,12 @@ public class LwM2mMultipleResource implements LwM2mResource {
     }
 
     /**
-     * @exception NoSuchElementException use {@link #getValue(int)} or {@link #getValue(int)} instead.
+     * @exception NoSuchElementException use {@link #getValue(int)} or {@link #getInstances()} or
+     *            {@link #getInstance(int)} instead.
      */
     @Override
     public Object getValue() {
         throw new NoSuchElementException("There is no 'value' on multiple resources, use getValues() instead.");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    @Override
-    public Map<Integer, ?> getValues() {
-        Map<Integer, Object> val = new HashMap<>();
-        for (Entry<Integer, LwM2mResourceInstance> entry : instances.entrySet()) {
-            val.put(entry.getKey(), entry.getValue().getValue());
-        }
-        return Collections.unmodifiableMap(val);
     }
 
     /**

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mNodeVisitor.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mNodeVisitor.java
@@ -26,4 +26,6 @@ public interface LwM2mNodeVisitor {
 
     void visit(LwM2mResource resource);
 
+    void visit(LwM2mResourceInstance instance);
+
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResource.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResource.java
@@ -68,6 +68,8 @@ public interface LwM2mResource extends LwM2mNode {
      * 
      * @return the values of each resource instances (key is the resource instance identifier).
      */
+    // TODO Remove this once we finished to implement resource instance operation
+    @Deprecated
     Map<Integer, ?> getValues();
 
     /**
@@ -85,4 +87,18 @@ public interface LwM2mResource extends LwM2mNode {
      * @return the value a resource instance with the given identifier.
      */
     Object getValue(int id);
+
+    /**
+     * This method is only available if {@link #isMultiInstances()} return <code>true</code>.
+     * 
+     * @return the resource instance with the given identifier.
+     */
+    LwM2mResourceInstance getInstance(int id);
+
+    /**
+     * This method is only available if {@link #isMultiInstances()} return <code>true</code>.
+     * 
+     * @return all resource instances.
+     */
+    Map<Integer, LwM2mResourceInstance> getInstances();
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResource.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResource.java
@@ -57,24 +57,6 @@ public interface LwM2mResource extends LwM2mNode {
     /**
      * This method is only available if {@link #isMultiInstances()} return <code>true</code>.
      * 
-     * The type of the right part of the returned map depends on the {@link #getType()} method.
-     * 
-     * If {@link #getType()} returns {@link Type#BOOLEAN}, the value is a {@link Boolean}.<br>
-     * If {@link #getType()} returns {@link Type#STRING}, the value is a {@link String}.<br>
-     * If {@link #getType()} returns {@link Type#OPAQUE}, the value is a byte array.<br>
-     * If {@link #getType()} returns {@link Type#TIME}, the value is a {@link Date}.<br>
-     * If {@link #getType()} returns {@link Type#INTEGER}, the value is a {@link Long}.<br>
-     * If {@link #getType()} returns {@link Type#FLOAT}, the value is a {@link Double}.<br>
-     * 
-     * @return the values of each resource instances (key is the resource instance identifier).
-     */
-    // TODO Remove this once we finished to implement resource instance operation
-    @Deprecated
-    Map<Integer, ?> getValues();
-
-    /**
-     * This method is only available if {@link #isMultiInstances()} return <code>true</code>.
-     * 
      * The type of the returned value depends on the {@link #getType()} method.
      * 
      * If {@link #getType()} returns {@link Type#BOOLEAN}, the value is a {@link Boolean}.<br>

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResourceInstance.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResourceInstance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Sierra Wireless and others.
+ * Copyright (c) 2020 Sierra Wireless and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,32 +17,28 @@ package org.eclipse.leshan.core.node;
 
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Map;
-import java.util.NoSuchElementException;
 
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 
 /**
- * A resource with a single value.
+ * An instance of {@link LwM2mMultipleResource}.
  */
-public class LwM2mSingleResource implements LwM2mResource {
+public class LwM2mResourceInstance implements LwM2mNode {
 
     private final int id;
-
     private final Object value;
-
     private final Type type;
 
-    protected LwM2mSingleResource(int id, Object value, Type type) {
+    protected LwM2mResourceInstance(int id, Object value, Type type) {
         LwM2mNodeUtil.validateNotNull(value, "value MUST NOT be null");
-        LwM2mNodeUtil.validateResourceId(id);
+        LwM2mNodeUtil.validateResourceInstanceId(id);
 
         this.id = id;
         this.value = value;
         this.type = type;
     }
 
-    public static LwM2mSingleResource newResource(int id, Object value, Type type) {
+    public static LwM2mResourceInstance newInstance(int id, Object value, Type type) {
         String doesNotMatchMessage = "Value does not match the given datatype";
         switch (type) {
         case INTEGER:
@@ -76,99 +72,48 @@ public class LwM2mSingleResource implements LwM2mResource {
         default:
             throw new LwM2mNodeException(String.format("Type %s is not supported", type.name()));
         }
-        return new LwM2mSingleResource(id, value, type);
+        return new LwM2mResourceInstance(id, value, type);
     }
 
-    public static LwM2mSingleResource newStringResource(int id, String value) {
-        return new LwM2mSingleResource(id, value, Type.STRING);
+    public static LwM2mResourceInstance newStringInstance(int id, String value) {
+        return new LwM2mResourceInstance(id, value, Type.STRING);
     }
 
-    public static LwM2mSingleResource newIntegerResource(int id, long value) {
-        return new LwM2mSingleResource(id, value, Type.INTEGER);
+    public static LwM2mResourceInstance newIntegerInstance(int id, long value) {
+        return new LwM2mResourceInstance(id, value, Type.INTEGER);
     }
 
-    public static LwM2mSingleResource newObjectLinkResource(int id, ObjectLink objlink) {
-        return new LwM2mSingleResource(id, objlink, Type.OBJLNK);
+    public static LwM2mResourceInstance newObjectLinkInstance(int id, ObjectLink objlink) {
+        return new LwM2mResourceInstance(id, objlink, Type.OBJLNK);
     }
 
-    public static LwM2mSingleResource newBooleanResource(int id, boolean value) {
-        return new LwM2mSingleResource(id, value, Type.BOOLEAN);
+    public static LwM2mResourceInstance newBooleanInstance(int id, boolean value) {
+        return new LwM2mResourceInstance(id, value, Type.BOOLEAN);
     }
 
-    public static LwM2mSingleResource newFloatResource(int id, double value) {
-        return new LwM2mSingleResource(id, value, Type.FLOAT);
+    public static LwM2mResourceInstance newFloatInstance(int id, double value) {
+        return new LwM2mResourceInstance(id, value, Type.FLOAT);
     }
 
-    public static LwM2mSingleResource newDateResource(int id, Date value) {
-        return new LwM2mSingleResource(id, value, Type.TIME);
+    public static LwM2mResourceInstance newDateInstance(int id, Date value) {
+        return new LwM2mResourceInstance(id, value, Type.TIME);
     }
 
-    public static LwM2mSingleResource newBinaryResource(int id, byte[] value) {
-        return new LwM2mSingleResource(id, value, Type.OPAQUE);
+    public static LwM2mResourceInstance newBinaryInstance(int id, byte[] value) {
+        return new LwM2mResourceInstance(id, value, Type.OPAQUE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int getId() {
         return id;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Type getType() {
-        return type;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public Object getValue() {
         return value;
     }
 
-    /**
-     * @exception NoSuchElementException use {@link #getValue()} instead.
-     */
-    @Override
-    public Map<Integer, ?> getValues() {
-        throw new NoSuchElementException("There is no 'values' on single resources, use getValue() instead.");
-    }
-
-    /**
-     * @exception NoSuchElementException use {@link #getValue()} instead.
-     */
-    @Override
-    public Object getValue(int id) {
-        throw new NoSuchElementException("There is no 'values' on single resources, use getValue() instead.");
-    }
-
-    /**
-     * @exception NoSuchElementException use {@link #getValue()} instead.
-     */
-    @Override
-    public LwM2mResourceInstance getInstance(int id) {
-        throw new NoSuchElementException("There is no 'instance' on single resources, use getValue() instead.");
-    }
-
-    /**
-     * @exception NoSuchElementException use {@link #getValue()} instead.
-     */
-    @Override
-    public Map<Integer, LwM2mResourceInstance> getInstances() {
-        throw new NoSuchElementException("There is no 'instances' on single resources, use getValue() instead.");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isMultiInstances() {
-        return false;
+    public Type getType() {
+        return type;
     }
 
     @Override
@@ -199,7 +144,7 @@ public class LwM2mSingleResource implements LwM2mResource {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        LwM2mSingleResource other = (LwM2mSingleResource) obj;
+        LwM2mResourceInstance other = (LwM2mResourceInstance) obj;
         if (id != other.id)
             return false;
         if (type != other.type)
@@ -219,8 +164,7 @@ public class LwM2mSingleResource implements LwM2mResource {
     public String toString() {
         // We don't print OPAQUE value as this could be credentials one.
         // Not ideal but didn't find better way for now.
-        return String.format("LwM2mSingleResource [id=%s, value=%s, type=%s]", id,
+        return String.format("LwM2mResourceInstance [id=%s, value=%s, type=%s]", id,
                 type == Type.OPAQUE ? ((byte[]) value).length + "Bytes" : value, type);
     }
-
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mSingleResource.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mSingleResource.java
@@ -135,14 +135,6 @@ public class LwM2mSingleResource implements LwM2mResource {
      * @exception NoSuchElementException use {@link #getValue()} instead.
      */
     @Override
-    public Map<Integer, ?> getValues() {
-        throw new NoSuchElementException("There is no 'values' on single resources, use getValue() instead.");
-    }
-
-    /**
-     * @exception NoSuchElementException use {@link #getValue()} instead.
-     */
-    @Override
     public Object getValue(int id) {
         throw new NoSuchElementException("There is no 'values' on single resources, use getValue() instead.");
     }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/DefaultLwM2mNodeDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/DefaultLwM2mNodeDecoder.java
@@ -26,6 +26,7 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
 import org.eclipse.leshan.core.node.codec.json.LwM2mNodeJsonDecoder;
 import org.eclipse.leshan.core.node.codec.opaque.LwM2mNodeOpaqueDecoder;
@@ -156,6 +157,8 @@ public class DefaultLwM2mNodeDecoder implements LwM2mNodeDecoder {
             return LwM2mObjectInstance.class;
         } else if (path.isResource()) {
             return LwM2mResource.class;
+        } else if (path.isResourceInstance()) {
+            return LwM2mResourceInstance.class;
         }
         throw new IllegalArgumentException("invalid path level: " + path);
     }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
@@ -41,8 +41,8 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
-import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.LwM2mResourceInstance;
+import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.util.Base64;
@@ -152,20 +152,20 @@ public class LwM2mNodeJsonDecoder {
                 // validate there is only 1 resource
                 if (resourcesMap.size() != 1)
                     throw new CodecException("One resource should be present in the payload [path:%s]", requestPath);
-                
+
                 LwM2mResource resource = resourcesMap.values().iterator().next();
                 if (!resource.isMultiInstances()) {
                     throw new CodecException("Resource should be multi Instances resource [path:%s]", requestPath);
                 }
-                
+
                 if (resource.getInstances().isEmpty()) {
                     throw new CodecException("Resource instances should not be not empty [path:%s]", requestPath);
                 }
-                
+
                 if (resource.getInstances().size() > 1) {
                     throw new CodecException("Resource instances should not be > 1 [path:%s]", requestPath);
                 }
-                
+
                 node = resource.getInstance(requestPath.getResourceInstanceId());
             } else {
                 throw new IllegalArgumentException("invalid node class: " + nodeClass);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonEncoder.java
@@ -187,8 +187,8 @@ public class LwM2mNodeJsonEncoder {
             ResourceModel rSpec = model.getResourceModel(objectId, instance.getId());
             Type expectedType = rSpec != null ? rSpec.type : instance.getType();
 
-            JsonArrayEntry jsonArrayEntry = createJsonArrayEntry(null, timestamp,
-                    instance.getType(), expectedType, instance.getValue());
+            JsonArrayEntry jsonArrayEntry = createJsonArrayEntry(null, timestamp, instance.getType(), expectedType,
+                    instance.getValue());
             resourceList = new ArrayList<>();
             resourceList.add(jsonArrayEntry);
         }
@@ -202,7 +202,7 @@ public class LwM2mNodeJsonEncoder {
 
             // create JSON resource element
             if (resource.isMultiInstances()) {
-                
+
                 for (Entry<Integer, LwM2mResourceInstance> entry : resource.getInstances().entrySet()) {
                     // compute resource instance path
                     String resourceInstancePath;
@@ -218,14 +218,15 @@ public class LwM2mNodeJsonEncoder {
                     resourcesList.add(jsonArrayEntry);
                 }
             } else {
-                JsonArrayEntry jsonArrayEntry = createJsonArrayEntry(resourcePath, timestamp,
-                        resource.getType(), expectedType, resource.getValue());
+                JsonArrayEntry jsonArrayEntry = createJsonArrayEntry(resourcePath, timestamp, resource.getType(),
+                        expectedType, resource.getValue());
                 resourcesList.add(jsonArrayEntry);
             }
             return resourcesList;
         }
 
-        private JsonArrayEntry createJsonArrayEntry(String name, Long timestamp, Type type, Type expectedType, Object value) {
+        private JsonArrayEntry createJsonArrayEntry(String name, Long timestamp, Type type, Type expectedType,
+                Object value) {
             // Create resource element
             JsonArrayEntry jsonResourceElt = new JsonArrayEntry();
             jsonResourceElt.setName(name);
@@ -233,8 +234,7 @@ public class LwM2mNodeJsonEncoder {
 
             // Convert value using expected type
             LwM2mPath lwM2mResourcePath = name != null ? new LwM2mPath(name) : null;
-            Object convertedValue = converter.convertValue(value, type, expectedType,
-                    lwM2mResourcePath);
+            Object convertedValue = converter.convertValue(value, type, expectedType, lwM2mResourcePath);
             this.setResourceValue(convertedValue, expectedType, jsonResourceElt, lwM2mResourcePath);
 
             return jsonResourceElt;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonEncoder.java
@@ -33,6 +33,7 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
@@ -172,6 +173,11 @@ public class LwM2mNodeJsonEncoder {
                 baseName = requestPath.toString();
             }
             resourceList = lwM2mResourceToJsonArrayEntry(null, timestamp, resource);
+        }
+
+        @Override
+        public void visit(LwM2mResourceInstance instance) {
+            throw new UnsupportedOperationException("not yet implemented");
         }
 
         private ArrayList<JsonArrayEntry> lwM2mResourceToJsonArrayEntry(String resourcePath, Long timestamp,

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/opaque/LwM2mNodeOpaqueEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/opaque/LwM2mNodeOpaqueEncoder.java
@@ -24,6 +24,7 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
 import org.eclipse.leshan.core.util.Validate;
@@ -77,6 +78,11 @@ public class LwM2mNodeOpaqueEncoder {
             LOG.trace("Encoding resource {} into text", resource);
             Object value = converter.convertValue(resource.getValue(), resource.getType(), Type.OPAQUE, path);
             encoded = (byte[]) value;
+        }
+
+        @Override
+        public void visit(LwM2mResourceInstance instance) {
+            throw new UnsupportedOperationException("not yet implemented");
         }
     }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLJsonEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLJsonEncoder.java
@@ -121,7 +121,7 @@ public class LwM2mNodeSenMLJsonEncoder {
         private void lwM2mResourceToSenMLRecord(String recordName, LwM2mResource resource) {
             // create resource element
             if (resource.isMultiInstances()) {
-                for (Entry<Integer, ?> entry : resource.getValues().entrySet()) {
+                for (Entry<Integer, LwM2mResourceInstance> entry : resource.getInstances().entrySet()) {
                     // compute record name for resource instance
                     String resourceInstanceRecordName;
                     if (recordName == null || recordName.isEmpty()) {
@@ -130,7 +130,7 @@ public class LwM2mNodeSenMLJsonEncoder {
                         resourceInstanceRecordName = recordName + "/" + entry.getKey();
                     }
 
-                    addSenMLRecord(resourceInstanceRecordName, resource, entry.getValue());
+                    addSenMLRecord(resourceInstanceRecordName, resource, entry.getValue().getValue());
                 }
             } else {
                 addSenMLRecord(recordName, resource, resource.getValue());

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLJsonEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLJsonEncoder.java
@@ -26,6 +26,7 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
 import org.eclipse.leshan.core.util.Base64;
@@ -110,6 +111,11 @@ public class LwM2mNodeSenMLJsonEncoder {
 
             // Using request path as base name, and record doesn't have name
             lwM2mResourceToSenMLRecord(null, resource);
+        }
+
+        @Override
+        public void visit(LwM2mResourceInstance instance) {
+            throw new UnsupportedOperationException("not yet implemented");
         }
 
         private void lwM2mResourceToSenMLRecord(String recordName, LwM2mResource resource) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextDecoder.java
@@ -24,8 +24,8 @@ import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
-import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.LwM2mResourceInstance;
+import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.util.Base64;
@@ -46,15 +46,15 @@ public class LwM2mNodeTextDecoder {
         if (path.isResource()) {
             if (rDesc != null) {
                 return LwM2mSingleResource.newResource(path.getResourceId(), parseTextValue(strValue, rDesc.type, path),
-                    rDesc.type);
+                        rDesc.type);
             }
             // unknown resource, returning a default string value
             return LwM2mSingleResource.newStringResource(path.getResourceId(), strValue);
         }
 
         if (rDesc != null) {
-            return LwM2mResourceInstance.newInstance(path.getResourceInstanceId(), parseTextValue(strValue, rDesc.type, path),
-                rDesc.type);
+            return LwM2mResourceInstance.newInstance(path.getResourceInstanceId(),
+                    parseTextValue(strValue, rDesc.type, path), rDesc.type);
         }
         // unknown resource, returning a default string value
         return LwM2mResourceInstance.newStringInstance(path.getResourceInstanceId(), strValue);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextEncoder.java
@@ -101,10 +101,10 @@ public class LwM2mNodeTextEncoder {
             ResourceModel rSpec = model.getResourceModel(path.getObjectId(), instance.getId());
             Type expectedType = rSpec != null ? rSpec.type : instance.getType();
             Object val = converter.convertValue(instance.getValue(), instance.getType(), expectedType, path);
-            
+
             if (expectedType == null) {
                 throw new CodecException(
-                    "Unable to encode value for resource {} without type(probably a executable one)", path);
+                        "Unable to encode value for resource {} without type(probably a executable one)", path);
             }
 
             String strValue = getStringValue(expectedType, val);
@@ -115,28 +115,28 @@ public class LwM2mNodeTextEncoder {
         private String getStringValue(Type expectedType, Object val) {
             String strValue;
             switch (expectedType) {
-                case INTEGER:
-                case FLOAT:
-                case STRING:
-                    strValue = String.valueOf(val);
-                    break;
-                case BOOLEAN:
-                    strValue = ((Boolean) val) ? "1" : "0";
-                    break;
-                case TIME:
-                    // number of seconds since 1970/1/1
-                    strValue = String.valueOf(((Date) val).getTime() / 1000L);
-                    break;
-                case OBJLNK:
-                    ObjectLink objlnk = (ObjectLink) val;
-                    strValue = String.valueOf(objlnk.getObjectId() + ":" + objlnk.getObjectInstanceId());
-                    break;
-                case OPAQUE:
-                    byte[] binaryValue = (byte[]) val;
-                    strValue = Base64.encodeBase64String(binaryValue);
-                    break;
-                default:
-                    throw new CodecException("Cannot encode %s in text format for %s", val, path);
+            case INTEGER:
+            case FLOAT:
+            case STRING:
+                strValue = String.valueOf(val);
+                break;
+            case BOOLEAN:
+                strValue = ((Boolean) val) ? "1" : "0";
+                break;
+            case TIME:
+                // number of seconds since 1970/1/1
+                strValue = String.valueOf(((Date) val).getTime() / 1000L);
+                break;
+            case OBJLNK:
+                ObjectLink objlnk = (ObjectLink) val;
+                strValue = String.valueOf(objlnk.getObjectId() + ":" + objlnk.getObjectInstanceId());
+                break;
+            case OPAQUE:
+                byte[] binaryValue = (byte[]) val;
+                strValue = Base64.encodeBase64String(binaryValue);
+                break;
+            default:
+                throw new CodecException("Cannot encode %s in text format for %s", val, path);
             }
             return strValue;
         }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextEncoder.java
@@ -27,6 +27,7 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
@@ -115,6 +116,11 @@ public class LwM2mNodeTextEncoder {
             }
 
             encoded = strValue.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void visit(LwM2mResourceInstance instance) {
+            throw new UnsupportedOperationException("not yet implemented");
         }
     }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
@@ -31,6 +31,7 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
@@ -166,6 +167,11 @@ public class LwM2mNodeTlvEncoder {
                         this.encodeTlvValue(convertedValue, expectedType, resourcePath), resource.getId());
             }
             return rTlv;
+        }
+
+        @Override
+        public void visit(LwM2mResourceInstance instance) {
+            throw new UnsupportedOperationException("not yet implemented");
         }
 
         private byte[] encodeTlvValue(Object value, Type type, LwM2mPath path) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
@@ -149,14 +149,11 @@ public class LwM2mNodeTlvEncoder {
 
             Tlv rTlv;
             if (resource.isMultiInstances()) {
-                Tlv[] instances = new Tlv[resource.getValues().size()];
+                Tlv[] instances = new Tlv[resource.getInstances().size()];
                 int i = 0;
-                for (Entry<Integer, ?> entry : resource.getValues().entrySet()) {
-                    LwM2mPath resourceInstancePath = resourcePath.append(entry.getKey());
-                    Object convertedValue = converter.convertValue(entry.getValue(), resource.getType(), expectedType,
-                            resourceInstancePath);
-                    instances[i] = new Tlv(TlvType.RESOURCE_INSTANCE, null,
-                            this.encodeTlvValue(convertedValue, expectedType, resourceInstancePath), entry.getKey());
+                for (LwM2mResourceInstance resourceInstance : resource.getInstances().values()) {
+                    LwM2mPath resourceInstancePath = resourcePath.append(resourceInstance.getId());
+                    instances[i] = encodeResourceInstance(resourceInstance, resourceInstancePath, expectedType);
                     i++;
                 }
                 rTlv = new Tlv(TlvType.MULTIPLE_RESOURCE, instances, null, resource.getId());
@@ -170,8 +167,27 @@ public class LwM2mNodeTlvEncoder {
         }
 
         @Override
-        public void visit(LwM2mResourceInstance instance) {
-            throw new UnsupportedOperationException("not yet implemented");
+        public void visit(LwM2mResourceInstance resourceInstance) {
+            LOG.trace("Encoding resource instance {} into TLV", resourceInstance);
+
+            ResourceModel rSpec = model.getResourceModel(path.getObjectId(), path.getResourceId());
+            Type expectedType = rSpec != null ? rSpec.type : resourceInstance.getType();
+
+            Tlv rTlv = encodeResourceInstance(resourceInstance, path, expectedType);
+
+            try {
+                out.write(TlvEncoder.encode(new Tlv[] { rTlv }).array());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private Tlv encodeResourceInstance(LwM2mResourceInstance resourceInstance, LwM2mPath resourceInstancePath,
+                Type expectedType) {
+            Object convertedValue = converter.convertValue(resourceInstance.getValue(), resourceInstance.getType(),
+                    expectedType, resourceInstancePath);
+            return new Tlv(TlvType.RESOURCE_INSTANCE, null,
+                    this.encodeTlvValue(convertedValue, expectedType, resourceInstancePath), resourceInstance.getId());
         }
 
         private byte[] encodeTlvValue(Object value, Type type, LwM2mPath path) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/AbstractDownlinkRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/AbstractDownlinkRequest.java
@@ -32,9 +32,6 @@ public abstract class AbstractDownlinkRequest<T extends LwM2mResponse> implement
         if (path == null)
             throw new InvalidRequestException("path is mandatory");
 
-        if (path.isResourceInstance())
-            throw new InvalidRequestException("downlink request cannot target resource instance path: %s ", path);
-
         this.path = path;
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/BootstrapWriteRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/BootstrapWriteRequest.java
@@ -38,6 +38,10 @@ public class BootstrapWriteRequest extends AbstractDownlinkRequest<BootstrapWrit
         if (target.isRoot())
             throw new InvalidRequestException("BootstrapWrite request cannot target root path");
 
+        if (target.isResourceInstance())
+            throw new InvalidRequestException("BootstrapWrite request cannot target resource instance path: %s ",
+                    target);
+
         if (node == null)
             throw new InvalidRequestException("new node value is mandatory for %s", target);
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/CancelObservationRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/CancelObservationRequest.java
@@ -38,6 +38,9 @@ public class CancelObservationRequest extends AbstractDownlinkRequest<CancelObse
         super(observation.getPath());
         if (getPath().isRoot())
             throw new InvalidRequestException("Observe request cannot target root path");
+        if (getPath().isResourceInstance())
+            throw new InvalidRequestException(
+                    "Observe request cannot target resource instance path: %s (not yet implemented)", getPath());
         this.observation = observation;
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/DiscoverRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/DiscoverRequest.java
@@ -69,6 +69,8 @@ public class DiscoverRequest extends AbstractDownlinkRequest<DiscoverResponse> {
         super(target);
         if (target.isRoot())
             throw new InvalidRequestException("Discover request cannot target root path");
+        if (target.isResourceInstance())
+            throw new InvalidRequestException("Discover request cannot target resource instance path: %s ", target);
     }
 
     @Override

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/ObserveRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/ObserveRequest.java
@@ -137,6 +137,9 @@ public class ObserveRequest extends AbstractDownlinkRequest<ObserveResponse> {
         super(target);
         if (target.isRoot())
             throw new InvalidRequestException("Observe request cannot target root path");
+        if (target.isResourceInstance())
+            throw new InvalidRequestException(
+                    "Observe request cannot target resource instance path: %s (not yet implemented)", target);
 
         this.format = format;
         if (context == null || context.isEmpty())

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
@@ -117,7 +117,9 @@ public class ReadRequest extends AbstractDownlinkRequest<ReadResponse> {
         super(target);
         if (target.isRoot())
             throw new InvalidRequestException("Read request cannot target root path");
-
+        if (target.isResourceInstance())
+            throw new InvalidRequestException(
+                    "Read request cannot target resource instance path: %s (not yet implemented)", target);
         this.format = format;
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
@@ -83,6 +83,18 @@ public class ReadRequest extends AbstractDownlinkRequest<ReadResponse> {
     /**
      * Creates a request for reading a specific resource from a client.
      * 
+     * @param objectId the object ID of the resource
+     * @param objectInstanceId the object instance ID
+     * @param resourceId the (individual) resource's ID
+     * @param resourceInstanceId the resource instance's ID
+     */
+    public ReadRequest(int objectId, int objectInstanceId, int resourceId, int resourceInstanceId) {
+        this(null, new LwM2mPath(objectId, objectInstanceId, resourceId, resourceInstanceId));
+    }
+
+    /**
+     * Creates a request for reading a specific resource from a client.
+     * 
      * @param format the desired format for the response (TLV, JSON, TEXT or OPAQUE)
      * @param objectId the object ID of the resource
      * @param objectInstanceId the object instance ID
@@ -90,6 +102,20 @@ public class ReadRequest extends AbstractDownlinkRequest<ReadResponse> {
      */
     public ReadRequest(ContentFormat format, int objectId, int objectInstanceId, int resourceId) {
         this(format, new LwM2mPath(objectId, objectInstanceId, resourceId));
+    }
+
+    /**
+     * Creates a request for reading a specific resource from a client.
+     * 
+     * @param format the desired format for the response (TLV, JSON, TEXT or OPAQUE)
+     * @param objectId the object ID of the resource
+     * @param objectInstanceId the object instance ID
+     * @param resourceId the (individual) resource's ID
+     * @param resourceInstanceId the resource instance's ID
+     */
+    public ReadRequest(ContentFormat format, int objectId, int objectInstanceId, int resourceId,
+            int resourceInstanceId) {
+        this(format, new LwM2mPath(objectId, objectInstanceId, resourceId, resourceInstanceId));
     }
 
     /**
@@ -117,9 +143,6 @@ public class ReadRequest extends AbstractDownlinkRequest<ReadResponse> {
         super(target);
         if (target.isRoot())
             throw new InvalidRequestException("Read request cannot target root path");
-        if (target.isResourceInstance())
-            throw new InvalidRequestException(
-                    "Read request cannot target resource instance path: %s (not yet implemented)", target);
         this.format = format;
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
@@ -46,6 +46,9 @@ public class WriteAttributesRequest extends AbstractDownlinkRequest<WriteAttribu
         super(path);
         if (path.isRoot())
             throw new InvalidRequestException("WriteAttributes request cannot target root path");
+        if (path.isResourceInstance())
+            throw new InvalidRequestException(
+                    "WriteAttributes request cannot target resource instance path: %s (not yet implemented)", path);
 
         if (attributes == null)
             throw new InvalidRequestException("attributes are mandatory for %s", path);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
@@ -21,11 +21,11 @@ import java.util.Map;
 
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
-import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
@@ -291,10 +291,10 @@ public class WriteRequest extends AbstractDownlinkRequest<WriteResponse> {
      * @param value the resource instance (id-&gt;value) to write.
      * @param type the data type of the resource.
      */
-    public WriteRequest(Mode mode, ContentFormat contentFormat, int objectId, int objectInstanceId,
-                        int resourceId, int resourceInstanceId, Object value, Type type) {
-        this(mode, contentFormat, new LwM2mPath(objectId, objectInstanceId,
-                resourceId, resourceInstanceId), LwM2mResourceInstance.newInstance(resourceInstanceId, value, type));
+    public WriteRequest(Mode mode, ContentFormat contentFormat, int objectId, int objectInstanceId, int resourceId,
+            int resourceInstanceId, Object value, Type type) {
+        this(mode, contentFormat, new LwM2mPath(objectId, objectInstanceId, resourceId, resourceInstanceId),
+                LwM2mResourceInstance.newInstance(resourceInstanceId, value, type));
     }
 
     /**
@@ -308,10 +308,10 @@ public class WriteRequest extends AbstractDownlinkRequest<WriteResponse> {
      * @param value the resource instance (id-&gt;value) to write.
      * @param type the data type of the resource.
      */
-    public WriteRequest(ContentFormat contentFormat, int objectId, int objectInstanceId,
-                        int resourceId, int resourceInstanceId, Object value, Type type) {
-        this(Mode.REPLACE, contentFormat, new LwM2mPath(objectId, objectInstanceId,
-                resourceId, resourceInstanceId), LwM2mResourceInstance.newInstance(resourceInstanceId, value, type));
+    public WriteRequest(ContentFormat contentFormat, int objectId, int objectInstanceId, int resourceId,
+            int resourceInstanceId, Object value, Type type) {
+        this(Mode.REPLACE, contentFormat, new LwM2mPath(objectId, objectInstanceId, resourceId, resourceInstanceId),
+                LwM2mResourceInstance.newInstance(resourceInstanceId, value, type));
     }
 
     // ***************** generic constructor ****************** //
@@ -361,27 +361,27 @@ public class WriteRequest extends AbstractDownlinkRequest<WriteResponse> {
         if (ContentFormat.TEXT == format || ContentFormat.OPAQUE == format) {
             if (!getPath().isResource() && !getPath().isResourceInstance()) {
                 throw new InvalidRequestException(
-                    "Invalid format for %s: %s format must be used only for single resources", target, format);
+                        "Invalid format for %s: %s format must be used only for single resources", target, format);
             } else {
-                if (node instanceof  LwM2mResource) {
+                if (node instanceof LwM2mResource) {
                     LwM2mResource resource = (LwM2mResource) node;
                     if (resource.isMultiInstances()) {
                         throw new InvalidRequestException(
-                            "Invalid format for path %s: format must be used only for single resources", target,
-                            format);
+                                "Invalid format for path %s: format must be used only for single resources", target,
+                                format);
                     } else if (resource.getType() != Type.OPAQUE && format == ContentFormat.OPAQUE) {
                         throw new InvalidRequestException(
-                            "Invalid format for %s: OPAQUE format must be used only for byte array single resources",
-                            target);
+                                "Invalid format for %s: OPAQUE format must be used only for byte array single resources",
+                                target);
                     }
                 }
 
-                if (node instanceof  LwM2mResourceInstance) {
+                if (node instanceof LwM2mResourceInstance) {
                     LwM2mResourceInstance resourceInstance = (LwM2mResourceInstance) node;
                     if (resourceInstance.getType() != Type.OPAQUE && format == ContentFormat.OPAQUE) {
                         throw new InvalidRequestException(
-                            "Invalid format for %s: OPAQUE format must be used only for byte array single resources",
-                            target);
+                                "Invalid format for %s: OPAQUE format must be used only for byte array single resources",
+                                target);
                     }
                 }
             }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
@@ -297,6 +297,9 @@ public class WriteRequest extends AbstractDownlinkRequest<WriteResponse> {
         super(target);
         if (target.isRoot())
             throw new InvalidRequestException("Write request cannot target root path");
+        if (target.isResourceInstance())
+            throw new InvalidRequestException(
+                    "Write request cannot target resource instance path: %s (not yet implemented)", target);
         if (mode == null)
             throw new InvalidRequestException("mode is mandatory for %s", target);
         if (node == null)

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
@@ -41,8 +41,8 @@ import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.tlv.Tlv;
-import org.eclipse.leshan.core.tlv.TlvEncoder;
 import org.eclipse.leshan.core.tlv.Tlv.TlvType;
+import org.eclipse.leshan.core.tlv.TlvEncoder;
 import org.eclipse.leshan.core.util.Hex;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -121,7 +121,7 @@ public class LwM2mNodeDecoderTest {
         assertEquals("1.0", oInstance.getResource(3).getValue());
         assertNull(oInstance.getResource(4));
         assertNull(oInstance.getResource(5));
-        assertEquals(2, oInstance.getResource(6).getValues().size());
+        assertEquals(2, oInstance.getResource(6).getInstances().size());
         assertEquals(1L, oInstance.getResource(6).getValue(0));
         assertEquals(5L, oInstance.getResource(6).getValue(1));
         assertEquals(3800L, oInstance.getResource(7).getValue(0));
@@ -130,7 +130,7 @@ public class LwM2mNodeDecoderTest {
         assertEquals(900L, oInstance.getResource(8).getValue(1));
         assertEquals(100L, oInstance.getResource(9).getValue());
         assertEquals(15L, oInstance.getResource(10).getValue());
-        assertEquals(1, oInstance.getResource(11).getValues().size());
+        assertEquals(1, oInstance.getResource(11).getInstances().size());
         assertEquals(0L, oInstance.getResource(11).getValue(0));
         assertNull(oInstance.getResource(12));
         assertEquals(new Date(1367491215000L), oInstance.getResource(13).getValue());
@@ -147,7 +147,7 @@ public class LwM2mNodeDecoderTest {
         LwM2mObjectInstance oInstance0 = oObject.getInstance(0);
         assertEquals(1L, oInstance0.getResource(0).getValue());
         assertEquals(0L, oInstance0.getResource(1).getValue());
-        assertEquals(1, oInstance0.getResource(2).getValues().size());
+        assertEquals(1, oInstance0.getResource(2).getInstances().size());
         assertEquals(7L, oInstance0.getResource(2).getValue(127));
         assertEquals(127L, oInstance0.getResource(3).getValue());
 
@@ -155,7 +155,7 @@ public class LwM2mNodeDecoderTest {
         LwM2mObjectInstance oInstance2 = oObject.getInstance(2);
         assertEquals(3L, oInstance2.getResource(0).getValue());
         assertEquals(0L, oInstance2.getResource(1).getValue());
-        assertEquals(2, oInstance2.getResource(2).getValues().size());
+        assertEquals(2, oInstance2.getResource(2).getInstances().size());
         assertEquals(7L, oInstance2.getResource(2).getValue(127));
         assertEquals(1L, oInstance2.getResource(2).getValue(310));
         assertEquals(127L, oInstance2.getResource(3).getValue());
@@ -176,7 +176,7 @@ public class LwM2mNodeDecoderTest {
         assertEquals(0, instance.getId());
 
         // instance 1
-        assertEquals(2, instance.getResource(0).getValues().size());
+        assertEquals(2, instance.getResource(0).getInstances().size());
         assertEquals(new ObjectLink(66, 0), instance.getResource(0).getValue(0));
         assertEquals(new ObjectLink(66, 1), instance.getResource(0).getValue(1));
         assertEquals("8613800755500", instance.getResource(1).getValue());
@@ -338,7 +338,7 @@ public class LwM2mNodeDecoderTest {
                 model);
 
         assertEquals(6, resource.getId());
-        assertEquals(2, resource.getValues().size());
+        assertEquals(2, resource.getInstances().size());
         assertEquals(1L, resource.getValue(0));
         assertEquals(5L, resource.getValue(1));
     }
@@ -353,7 +353,7 @@ public class LwM2mNodeDecoderTest {
                 model);
 
         assertEquals(6, resource.getId());
-        assertEquals(2, resource.getValues().size());
+        assertEquals(2, resource.getInstances().size());
         assertEquals(1L, resource.getValue(0));
         assertEquals(5L, resource.getValue(1));
     }
@@ -447,7 +447,7 @@ public class LwM2mNodeDecoderTest {
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
-        assertTrue(resource.getValues().isEmpty());
+        assertTrue(resource.getInstances().isEmpty());
     }
 
     @Test(expected = CodecException.class)
@@ -743,7 +743,7 @@ public class LwM2mNodeDecoderTest {
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
-        assertTrue(resource.getValues().isEmpty());
+        assertTrue(resource.getInstances().isEmpty());
 
         // with empty resources list and base name
         b = new StringBuilder();
@@ -753,7 +753,7 @@ public class LwM2mNodeDecoderTest {
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
-        assertTrue(resource.getValues().isEmpty());
+        assertTrue(resource.getInstances().isEmpty());
     }
 
     @Test
@@ -806,6 +806,6 @@ public class LwM2mNodeDecoderTest {
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(11, resource.getId());
-        assertTrue(resource.getValues().size() == 2);
+        assertTrue(resource.getInstances().size() == 2);
     }
 }

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeEncoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeEncoderTest.java
@@ -34,6 +34,7 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.util.Hex;
 import org.junit.Assert;
@@ -213,6 +214,25 @@ public class LwM2mNodeEncoderTest {
 
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"/1024/0/1\",\"e\":[");
+        b.append("{\"v\":22.9,\"t\":500},");
+        b.append("{\"v\":22.4,\"t\":510},");
+        b.append("{\"v\":24.1,\"t\":520}]}");
+
+        String expected = b.toString();
+        Assert.assertEquals(expected, new String(encoded));
+    }
+
+    @Test
+    public void json_timestamped_resource_instances() throws CodecException {
+        List<TimestampedLwM2mNode> data = new ArrayList<>();
+        data.add(new TimestampedLwM2mNode(500L, LwM2mResourceInstance.newFloatInstance(0, 22.9)));
+        data.add(new TimestampedLwM2mNode(510L, LwM2mResourceInstance.newFloatInstance(0, 22.4)));
+        data.add(new TimestampedLwM2mNode(520L, LwM2mResourceInstance.newFloatInstance(0, 24.1)));
+        
+        byte[] encoded = encoder.encodeTimestampedData(data, ContentFormat.JSON, new LwM2mPath(1024, 0, 1, 0), model);
+
+        StringBuilder b = new StringBuilder();
+        b.append("{\"bn\":\"/1024/0/1/0\",\"e\":[");
         b.append("{\"v\":22.9,\"t\":500},");
         b.append("{\"v\":22.4,\"t\":510},");
         b.append("{\"v\":24.1,\"t\":520}]}");

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeEncoderTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeEncoderTest.java
@@ -32,9 +32,9 @@ import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.TimestampedLwM2mNode;
-import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.util.Hex;
 import org.junit.Assert;
@@ -228,7 +228,7 @@ public class LwM2mNodeEncoderTest {
         data.add(new TimestampedLwM2mNode(500L, LwM2mResourceInstance.newFloatInstance(0, 22.9)));
         data.add(new TimestampedLwM2mNode(510L, LwM2mResourceInstance.newFloatInstance(0, 22.4)));
         data.add(new TimestampedLwM2mNode(520L, LwM2mResourceInstance.newFloatInstance(0, 24.1)));
-        
+
         byte[] encoded = encoder.encodeTimestampedData(data, ContentFormat.JSON, new LwM2mPath(1024, 0, 1, 0), model);
 
         StringBuilder b = new StringBuilder();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -264,7 +264,7 @@ public class BootstrapTest {
         LwM2mObjectInstance instance = acl.getInstance(0);
         assertEquals(3l, instance.getResource(0).getValue());
         assertEquals(0l, instance.getResource(1).getValue());
-        assertEquals(1l, instance.getResource(2).getValues().get(3333));
+        assertEquals(1l, instance.getResource(2).getValue(3333));
         assertEquals(2222l, instance.getResource(3).getValue());
         instance = acl.getInstance(1);
         assertEquals(4l, instance.getResource(0).getValue());

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -172,6 +172,7 @@ public class IntegrationTestHelper {
         // Build Client
         LeshanClientBuilder builder = new LeshanClientBuilder(currentEndpointIdentifier.get());
         builder.setDecoder(new DefaultLwM2mNodeDecoder(true));
+        builder.setEncoder(new DefaultLwM2mNodeEncoder(true));
         builder.setAdditionalAttributes(additionalAttributes);
         builder.setObjects(objects);
         client = builder.build();
@@ -186,6 +187,7 @@ public class IntegrationTestHelper {
 
     protected LeshanServerBuilder createServerBuilder() {
         LeshanServerBuilder builder = new LeshanServerBuilder();
+        builder.setDecoder(new DefaultLwM2mNodeDecoder(true));
         builder.setEncoder(new DefaultLwM2mNodeEncoder(true));
         builder.setObjectModelProvider(new StaticModelProvider(createObjectModels()));
         builder.setLocalAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -75,7 +75,9 @@ public class IntegrationTestHelper {
     public static final int OBJLNK_SINGLE_INSTANCE_RESOURCE_ID = 7;
     public static final int INTEGER_MANDATORY_RESOURCE_ID = 8;
     public static final int STRING_MANDATORY_RESOURCE_ID = 9;
-    public static final int STRING_RESOUCE_INSTANCE_ID = 10;
+    public static final int STRING_RESOURCE_INSTANCE_ID = 10;
+
+    public static final String MULTI_INSTANCE = "multiinstance";
 
     LeshanServer server;
     LeshanClient client;
@@ -113,7 +115,7 @@ public class IntegrationTestHelper {
                 Operations.RW, false, true, Type.INTEGER, null, null, null);
         ResourceModel stringmandatoryfield = new ResourceModel(STRING_MANDATORY_RESOURCE_ID, "stringmandatory",
                 Operations.RW, false, true, Type.STRING, null, null, null);
-        ResourceModel multiInstance = new ResourceModel(STRING_RESOUCE_INSTANCE_ID, "multiinstance", Operations.RW,
+        ResourceModel multiInstance = new ResourceModel(STRING_RESOURCE_INSTANCE_ID, MULTI_INSTANCE, Operations.RW,
                 true, false, Type.STRING, null, null, null);
         objectModels.add(new ObjectModel(TEST_OBJECT_ID, "testobject", null, ObjectModel.DEFAULT_VERSION, true, false,
                 stringfield, booleanfield, integerfield, floatfield, timefield, opaquefield, objlnkfield,

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -13,7 +13,6 @@
  * Contributors:
  *     Zebra Technologies - initial API and implementation
  *******************************************************************************/
-
 package org.eclipse.leshan.integration.tests;
 
 import static org.junit.Assert.*;

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -75,6 +75,7 @@ public class IntegrationTestHelper {
     public static final int OBJLNK_SINGLE_INSTANCE_RESOURCE_ID = 7;
     public static final int INTEGER_MANDATORY_RESOURCE_ID = 8;
     public static final int STRING_MANDATORY_RESOURCE_ID = 9;
+    public static final int STRING_RESOUCE_INSTANCE_ID = 10;
 
     LeshanServer server;
     LeshanClient client;
@@ -112,9 +113,11 @@ public class IntegrationTestHelper {
                 Operations.RW, false, true, Type.INTEGER, null, null, null);
         ResourceModel stringmandatoryfield = new ResourceModel(STRING_MANDATORY_RESOURCE_ID, "stringmandatory",
                 Operations.RW, false, true, Type.STRING, null, null, null);
+        ResourceModel multiInstance = new ResourceModel(STRING_RESOUCE_INSTANCE_ID, "multiinstance", Operations.RW,
+                true, false, Type.STRING, null, null, null);
         objectModels.add(new ObjectModel(TEST_OBJECT_ID, "testobject", null, ObjectModel.DEFAULT_VERSION, true, false,
                 stringfield, booleanfield, integerfield, floatfield, timefield, opaquefield, objlnkfield,
-                objlnkSinglefield, integermandatoryfield, stringmandatoryfield));
+                objlnkSinglefield, integermandatoryfield, stringmandatoryfield, multiInstance));
 
         return objectModels;
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
@@ -15,7 +15,6 @@
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for read security object
  *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
  *******************************************************************************/
-
 package org.eclipse.leshan.integration.tests;
 
 import static org.eclipse.leshan.core.ResponseCode.*;
@@ -157,18 +156,18 @@ public class ReadTest {
     public void cannot_read_non_multiple_resource_json_instance() throws InterruptedException {
         // read device model number
         ReadResponse response = helper.server.send(helper.getCurrentRegistration(),
-            new ReadRequest(ContentFormat.JSON, TEST_OBJECT_ID, 0, INTEGER_RESOURCE_ID, 0), 1000000);
+                new ReadRequest(ContentFormat.JSON, TEST_OBJECT_ID, 0, INTEGER_RESOURCE_ID, 0), 1000000);
 
         // verify result
         assertEquals(BAD_REQUEST, response.getCode());
-        assertEquals("invalid path : resource is not multiple",response.getErrorMessage());
+        assertEquals("invalid path : resource is not multiple", response.getErrorMessage());
     }
 
     @Test
     public void can_read_resource_text_instance() throws InterruptedException {
         // read device model number
         ReadResponse response = helper.server.send(helper.getCurrentRegistration(),
-            new ReadRequest(ContentFormat.TEXT, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0), 1000000);
+                new ReadRequest(ContentFormat.TEXT, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0), 1000000);
 
         // verify result
         assertEquals(CONTENT, response.getCode());

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
@@ -124,7 +124,7 @@ public class ReadTest {
     public void can_read_resource_instance() throws InterruptedException {
         // read device model number
         ReadResponse response = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(TEST_OBJECT_ID, 0, STRING_RESOUCE_INSTANCE_ID, 0), 1000000);
+                new ReadRequest(TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0), 1000000);
 
         // verify result
         assertEquals(CONTENT, response.getCode());
@@ -133,7 +133,52 @@ public class ReadTest {
 
         LwM2mResourceInstance resourceInstance = (LwM2mResourceInstance) response.getContent();
         assertEquals(0, resourceInstance.getId());
-        assertEquals("multiinstance", resourceInstance.getValue());
+        assertEquals(MULTI_INSTANCE, resourceInstance.getValue());
+    }
+
+    @Test
+    public void can_read_resource_json_instance() throws InterruptedException {
+        // read device model number
+        ReadResponse response = helper.server.send(helper.getCurrentRegistration(),
+                new ReadRequest(ContentFormat.JSON, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0), 1000000);
+
+        // verify result
+        assertEquals(CONTENT, response.getCode());
+        Response coapResponse = (Response) response.getCoapResponse();
+        assertNotNull(coapResponse);
+        assertThat(response.getCoapResponse(), is(instanceOf(Response.class)));
+
+        LwM2mResourceInstance resourceInstance = (LwM2mResourceInstance) response.getContent();
+        assertEquals(0, resourceInstance.getId());
+        assertEquals(MULTI_INSTANCE, resourceInstance.getValue());
+    }
+
+    @Test
+    public void cannot_read_non_multiple_resource_json_instance() throws InterruptedException {
+        // read device model number
+        ReadResponse response = helper.server.send(helper.getCurrentRegistration(),
+            new ReadRequest(ContentFormat.JSON, TEST_OBJECT_ID, 0, INTEGER_RESOURCE_ID, 0), 1000000);
+
+        // verify result
+        assertEquals(BAD_REQUEST, response.getCode());
+        assertEquals("invalid path : resource is not multiple",response.getErrorMessage());
+    }
+
+    @Test
+    public void can_read_resource_text_instance() throws InterruptedException {
+        // read device model number
+        ReadResponse response = helper.server.send(helper.getCurrentRegistration(),
+            new ReadRequest(ContentFormat.TEXT, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0), 1000000);
+
+        // verify result
+        assertEquals(CONTENT, response.getCode());
+        Response coapResponse = (Response) response.getCoapResponse();
+        assertNotNull(coapResponse);
+        assertThat(response.getCoapResponse(), is(instanceOf(Response.class)));
+
+        LwM2mResourceInstance resourceInstance = (LwM2mResourceInstance) response.getContent();
+        assertEquals(0, resourceInstance.getId());
+        assertEquals(MULTI_INSTANCE, resourceInstance.getValue());
     }
 
     @Test

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ReadTest.java
@@ -30,6 +30,7 @@ import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.ReadRequest;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -117,6 +118,22 @@ public class ReadTest {
         LwM2mResource resource = (LwM2mResource) response.getContent();
         assertEquals(1, resource.getId());
         assertEquals(IntegrationTestHelper.MODEL_NUMBER, resource.getValue());
+    }
+
+    @Test
+    public void can_read_resource_instance() throws InterruptedException {
+        // read device model number
+        ReadResponse response = helper.server.send(helper.getCurrentRegistration(),
+                new ReadRequest(TEST_OBJECT_ID, 0, STRING_RESOUCE_INSTANCE_ID, 0), 1000000);
+
+        // verify result
+        assertEquals(CONTENT, response.getCode());
+        assertNotNull(response.getCoapResponse());
+        assertThat(response.getCoapResponse(), is(instanceOf(Response.class)));
+
+        LwM2mResourceInstance resourceInstance = (LwM2mResourceInstance) response.getContent();
+        assertEquals(0, resourceInstance.getId());
+        assertEquals("multiinstance", resourceInstance.getValue());
     }
 
     @Test

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
@@ -108,7 +108,7 @@ public class WriteTest {
 
         // read resource to check the value changed
         ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(TEST_OBJECT_ID, 0, STRING_RESOURCE_ID));
+                new ReadRequest(format, TEST_OBJECT_ID, 0, STRING_RESOURCE_ID));
         LwM2mResource resource = (LwM2mResource) readResponse.getContent();
         assertEquals(expectedvalue, resource.getValue());
     }
@@ -151,7 +151,7 @@ public class WriteTest {
 
         // read resource to check the value changed
         ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(TEST_OBJECT_ID, 0, BOOLEAN_RESOURCE_ID));
+                new ReadRequest(format, TEST_OBJECT_ID, 0, BOOLEAN_RESOURCE_ID));
         LwM2mResource resource = (LwM2mResource) readResponse.getContent();
         assertEquals(expectedvalue, resource.getValue());
     }
@@ -181,37 +181,6 @@ public class WriteTest {
         write_integer_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
     }
 
-    @Test
-    public void write_string_resource_json_instance() throws InterruptedException {
-        assertStringResourceInstance(ContentFormat.JSON);
-    }
-
-    @Test
-    public void write_string_resource_text_instance() throws InterruptedException {
-        assertStringResourceInstance(ContentFormat.TEXT);
-    }
-
-    private void assertStringResourceInstance(ContentFormat format) throws InterruptedException {
-        // read device model number
-        String valueToWrite = "newValue";
-        WriteResponse response = helper.server.send(helper.getCurrentRegistration(),
-                new WriteRequest(format, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0, valueToWrite, Type.STRING),
-                1000000);
-
-        // verify result
-        assertEquals(CHANGED, response.getCode());
-        assertNotNull(response.getCoapResponse());
-        assertThat(response.getCoapResponse(), is(instanceOf(Response.class)));
-
-        // read resource to check the value changed
-        ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(format, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0), 1000000);
-
-        // verify result
-        LwM2mResourceInstance resource = (LwM2mResourceInstance) readResponse.getContent();
-        assertEquals(valueToWrite, resource.getValue());
-    }
-
     private void write_integer_resource(ContentFormat format) throws InterruptedException {
         // write resource
         long expectedvalue = 999l;
@@ -225,9 +194,55 @@ public class WriteTest {
 
         // read resource to check the value changed
         ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(TEST_OBJECT_ID, 0, INTEGER_RESOURCE_ID));
+                new ReadRequest(format, TEST_OBJECT_ID, 0, INTEGER_RESOURCE_ID));
         LwM2mResource resource = (LwM2mResource) readResponse.getContent();
         assertEquals(expectedvalue, resource.getValue());
+    }
+
+    @Test
+    public void can_write_string_resource_json_instance() throws InterruptedException {
+        write_string_resource_instance(ContentFormat.JSON);
+    }
+
+    @Test
+    public void can_write_string_resource_old_json_instance() throws InterruptedException {
+        write_string_resource_instance(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
+    }
+
+    @Test
+    public void can_write_string_resource_text_instance() throws InterruptedException {
+        write_string_resource_instance(ContentFormat.TEXT);
+    }
+
+    @Test
+    public void can_write_string_resource_tlv_instance() throws InterruptedException {
+        write_string_resource_instance(ContentFormat.TLV);
+    }
+
+    @Test
+    public void can_write_string_resource_old_tlv_instance() throws InterruptedException {
+        write_string_resource_instance(ContentFormat.fromCode(ContentFormat.OLD_TLV_CODE));
+    }
+
+    private void write_string_resource_instance(ContentFormat format) throws InterruptedException {
+        // read device model number
+        String valueToWrite = "newValue";
+        WriteResponse response = helper.server.send(helper.getCurrentRegistration(),
+                new WriteRequest(format, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0, valueToWrite, Type.STRING));
+
+        // verify result
+        assertEquals(CHANGED, response.getCode());
+        assertNotNull(response.getCoapResponse());
+        assertThat(response.getCoapResponse(), is(instanceOf(Response.class)));
+
+        // read resource to check the value changed
+        ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
+                new ReadRequest(format, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0));
+
+        // verify result
+        LwM2mResourceInstance resource = (LwM2mResourceInstance) readResponse.getContent();
+        System.out.println(resource);
+        assertEquals(valueToWrite, resource.getValue());
     }
 
     @Test
@@ -268,7 +283,7 @@ public class WriteTest {
 
         // read resource to check the value changed
         ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(TEST_OBJECT_ID, 0, FLOAT_RESOURCE_ID));
+                new ReadRequest(format, TEST_OBJECT_ID, 0, FLOAT_RESOURCE_ID));
         LwM2mResource resource = (LwM2mResource) readResponse.getContent();
         assertEquals(expectedvalue, resource.getValue());
     }
@@ -311,7 +326,7 @@ public class WriteTest {
 
         // read resource to check the value changed
         ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(TEST_OBJECT_ID, 0, TIME_RESOURCE_ID));
+                new ReadRequest(format, TEST_OBJECT_ID, 0, TIME_RESOURCE_ID));
         LwM2mResource resource = (LwM2mResource) readResponse.getContent();
         assertEquals(expectedvalue, resource.getValue());
     }
@@ -359,7 +374,7 @@ public class WriteTest {
 
         // read resource to check the value changed
         ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
-                new ReadRequest(TEST_OBJECT_ID, 0, OPAQUE_RESOURCE_ID));
+                new ReadRequest(format, TEST_OBJECT_ID, 0, OPAQUE_RESOURCE_ID));
         LwM2mResource resource = (LwM2mResource) readResponse.getContent();
         assertArrayEquals(expectedvalue, (byte[]) resource.getValue());
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
@@ -15,7 +15,6 @@
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for write security object
  *     Achim Kraus (Bosch Software Innovations GmbH) - add test for update and replace instances
  *******************************************************************************/
-
 package org.eclipse.leshan.integration.tests;
 
 import static org.eclipse.leshan.core.ResponseCode.CHANGED;

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/WriteTest.java
@@ -18,6 +18,7 @@
 
 package org.eclipse.leshan.integration.tests;
 
+import static org.eclipse.leshan.core.ResponseCode.CHANGED;
 import static org.eclipse.leshan.integration.tests.IntegrationTestHelper.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -34,6 +35,7 @@ import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.node.codec.CodecException;
@@ -178,6 +180,37 @@ public class WriteTest {
     @Test
     public void can_write_integer_resource_in_old_json() throws InterruptedException {
         write_integer_resource(ContentFormat.fromCode(ContentFormat.OLD_JSON_CODE));
+    }
+
+    @Test
+    public void write_string_resource_json_instance() throws InterruptedException {
+        assertStringResourceInstance(ContentFormat.JSON);
+    }
+
+    @Test
+    public void write_string_resource_text_instance() throws InterruptedException {
+        assertStringResourceInstance(ContentFormat.TEXT);
+    }
+
+    private void assertStringResourceInstance(ContentFormat format) throws InterruptedException {
+        // read device model number
+        String valueToWrite = "newValue";
+        WriteResponse response = helper.server.send(helper.getCurrentRegistration(),
+                new WriteRequest(format, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0, valueToWrite, Type.STRING),
+                1000000);
+
+        // verify result
+        assertEquals(CHANGED, response.getCode());
+        assertNotNull(response.getCoapResponse());
+        assertThat(response.getCoapResponse(), is(instanceOf(Response.class)));
+
+        // read resource to check the value changed
+        ReadResponse readResponse = helper.server.send(helper.getCurrentRegistration(),
+                new ReadRequest(format, TEST_OBJECT_ID, 0, STRING_RESOURCE_INSTANCE_ID, 0), 1000000);
+
+        // verify result
+        LwM2mResourceInstance resource = (LwM2mResourceInstance) readResponse.getContent();
+        assertEquals(valueToWrite, resource.getValue());
     }
 
     private void write_integer_resource(ContentFormat format) throws InterruptedException {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilder.java
@@ -258,6 +258,11 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         if (path.getResourceId() != null) {
             coapRequest.getOptions().addUriPath(Integer.toString(path.getResourceId()));
         }
+
+        // resourceInstanceId
+        if (path.getResourceInstanceId() != null) {
+            coapRequest.getOptions().addUriPath(Integer.toString(path.getResourceInstanceId()));
+        }
     }
 
     protected void applyLowerLayerConfig(Request coapRequest) {

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/LwM2mNodeSerializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/LwM2mNodeSerializer.java
@@ -22,6 +22,7 @@ import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.util.Hex;
 
 import com.google.gson.JsonElement;
@@ -45,12 +46,12 @@ public class LwM2mNodeSerializer implements JsonSerializer<LwM2mNode> {
             LwM2mResource rsc = (LwM2mResource) src;
             if (rsc.isMultiInstances()) {
                 JsonObject values = new JsonObject();
-                for (Entry<Integer, ?> entry : rsc.getValues().entrySet()) {
+                for (Entry<Integer, LwM2mResourceInstance> entry : rsc.getInstances().entrySet()) {
                     if (rsc.getType() == org.eclipse.leshan.core.model.ResourceModel.Type.OPAQUE) {
                         values.addProperty(entry.getKey().toString(),
-                                new String(Hex.encodeHex((byte[]) entry.getValue())));
+                                new String(Hex.encodeHex((byte[]) entry.getValue().getValue())));
                     } else {
-                        values.add(entry.getKey().toString(), context.serialize(entry.getValue()));
+                        values.add(entry.getKey().toString(), context.serialize(entry.getValue().getValue()));
                     }
                 }
                 element.add("values", values);


### PR DESCRIPTION
**In LWM2M 1.1,  operation on resource instances has been added.**

This concerns **requests** : 
 - read
 - write
 - observe and cancel observe
-  write attributes

and should impact all **decoder/encoder** : 
- TLV
- text
- opaque
- JSON
- senML+json and cbor (which are in a work in progress state)

The first commits aims to prepare the work to introduce this new feature and implement the read request with TLV content format.

(This PR is a work in progress.)