### PR TITLE
LeshanClientDemo: Fix coaps usage for named server

### DIFF
--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -360,7 +360,7 @@ public class LeshanClientDemo {
         // Get server URI
         String serverURI;
         if (cl.hasOption("u")) {
-            if (cl.hasOption("i") || cl.hasOption("cpubk"))
+            if (cl.hasOption("i") || cl.hasOption("cpubk") || cl.hasOption("ccert"))
                 serverURI = "coaps://" + cl.getOptionValue("u");
             else
                 serverURI = "coap://" + cl.getOptionValue("u");


### PR DESCRIPTION
If server is named with -u <hostname> and client certificate is provided we
also want to do coaps.

Signed-off-by: Vesa Jääskeläinen <dachaac@gmail.com>