### PR TITLE
Add facility to deploy nightly build to eclipse nexus instance.

### DIFF
--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -100,6 +100,12 @@ Contributors:
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -114,13 +114,6 @@ Contributors:
         <jetty.version>9.4.26.v20200117</jetty.version>
     </properties>
 
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <profiles>
         <profile>
             <!-- This profile launch all redis integration tests -->
@@ -184,11 +177,66 @@ Contributors:
             </build>
         </profile>
         <profile>
+            <!-- Release nightly/snapshot build on eclipse nexus -->
+            <id>release-nightly</id>
+             <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>eclipse-repo</id>
+                    <name>Eclipse Repository</name>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <url>https://repo.eclipse.org/content/repositories/releases/</url>
+                </pluginRepository>
+            </pluginRepositories>
+            <distributionManagement>
+                <repository>
+                    <id>repo.eclipse.org</id>
+                    <name>Leshan Repository - Releases</name>
+                    <url>https://repo.eclipse.org/content/repositories/leshan-releases/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>repo.eclipse.org</id>
+                    <name>Leshan Repository - Snapshots</name>
+                    <url>https://repo.eclipse.org/content/repositories/leshan-snapshots/</url>
+                </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                        <artifactId>eclipse-jarsigner-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-jars</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+        </build>
+        </profile>
+        <profile>
             <!-- this profile generate all the needed artifact and signatures needed, then release it on maven central -->
             <id>release</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <distributionManagement>
+                <repository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
The idea is to be able to create jenkins jobs executed 1 time a day (or on demand) which will deploy a SNAPSHOT release of `master` and `1.x` in https://repo.eclipse.org/content/repositories/leshan-snapshots/.

First try : 
- jenkins job for master : https://ci.eclipse.org/leshan/job/leshan-nightly/
- https://repo.eclipse.org/content/repositories/leshan-snapshots/

SNAPSHOT should be available using : 
```xml
   <repositories>
        <repository>
            <id>eclipse-repo</id>
            <name>Eclipse Repository</name>
            <url>https://repo.eclipse.org/content/repositories/leshan-snapshots/</url>
            <releases>
                <enabled>false</enabled>
            </releases>
            <snapshots>
                <enabled>true</enabled>
            </snapshots>
        </repository>
    </repositories>
	<dependencies>
		<dependency>
			<groupId>org.eclipse.leshan</groupId>
			<artifactId>leshan-???-???f</artifactId>
			<version>2.0.0-SNAPSHOT</version>
		</dependency>
	</dependencies>
```
Using SNAPSHOT is pretty different than using RELEASE version.
- SNAPSHOT could change from one build to another.
- It is possible to depend on a specific version using something like [snapshotVersion](https://repo.eclipse.org/content/repositories/leshan-snapshots/org/eclipse/leshan/leshan-server-cf/2.0.0-SNAPSHOT/maven-metadata.xml)(e.g. 2.0.0-20200903.093116-2) instead of 2.0.0-SNAPSHOT but this version will not [be available for ever](https://wiki.eclipse.org/Services/Nexus#Eclipse_Nexus_Instance).
 - When you play with SNAPSHOT you should be interested by in ` mvn dependency:purge-local-repository` or `mvn clean install --update-snapshots` or [repository updatePolicy](https://maven.apache.org/settings.html#Repositories).