### PR TITLE
Certificate usage support

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.util.SecurityUtil;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
@@ -113,7 +114,7 @@ public class BootstrapConfigSecurityStore implements BootstrapSecurityStore {
             }
             // Extract X509 security info
             else if (value.bootstrapServer && value.securityMode == SecurityMode.X509) {
-                SecurityInfo securityInfo = SecurityInfo.newX509CertInfo(endpoint);
+                SecurityInfo securityInfo = SecurityInfo.newX509CertInfo(endpoint, value.certificateUsage);
                 return Arrays.asList(securityInfo).iterator();
             }
         }

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
@@ -104,6 +104,7 @@
                     shortId : 123,
                     security : {
                         bootstrapServer : false,
+                        certificateUsage: lwserver.certificateUsage,
                         clientOldOffTime : 1,
                         publicKeyOrId : lwserver.id,
                         secretKey : lwserver.key,
@@ -120,6 +121,7 @@
                  bs:[{
                     security : {
                         bootstrapServer : true,
+                        certificateUsage: bsserver.certificateUsage,
                         clientOldOffTime : 1,
                         publicKeyOrId : bsserver.id,
                         secretKey : bsserver.key,

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
@@ -58,6 +58,9 @@
                         <p>
                             <strong>{ security.uri }</strong><br/>
                             security mode : {security.securityMode}<br/>
+                            <span if={security.certificateUsage}>
+                            certificate usage : {security.certificateUsage}<br/>
+                            </span>
                             <span if={security.securityMode === 'PSK'}>
                                 Identity : <code code style=display:block;white-space:pre-wrap>{wrap(toAscii(security.publicKeyOrId))}</code>
                                 Key : <code code style=display:block;white-space:pre-wrap>{wrap(toHex(security.secretKey))}</code>
@@ -70,6 +73,9 @@
                         <p>
                             <strong>{security.uri}</strong><br/>
                             security mode : {security.securityMode}<br/>
+                            <span if={security.certificateUsage}>
+                            certificate usage : {security.certificateUsage}<br/>
+                            </span>
                             <span if={security.securityMode === 'PSK'}>
                                 Identity : <code code style=display:block;white-space:pre-wrap>{wrap(toAscii(security.publicKeyOrId))}</code>
                                 key : <code code style=display:block;white-space:pre-wrap>{wrap(toHex(security.secretKey))}</code>

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
@@ -35,11 +35,24 @@
         <x509-input ref="x509" onchange={onchange} disable={disable} servercertificate={servercertificate}></x509-input>
     </div>
 
+    <div class="form-group">
+        <label for="certificateUsage" class="col-sm-4 control-label">Certificate usage</label>
+        <div class="col-sm-8">
+            <select class="form-control" id="certificateUsage" ref="certificateUsage">
+                <option value="CA_CONSTRAINT"                      >CA constraint</option>
+                <option value="SERVICE_CERTIFICATE_CONSTRAINT"     >service certificate constraint</option>
+                <option value="TRUST_ANCHOR_ASSERTION"             >trust anchor assertion</option>
+                <option value="DOMAIN_ISSUER_CERTIFICATE" selected >domain-issued certificate</option>
+            </select>
+        </div>
+    </div>
+
     <script>
         // Tag definition
         var tag = this;
         // Tag Params
         tag.secmode = opts.secmode || {no_sec:true};
+        tag.certificateUsage = opts.certificateUsage || "";
         tag.disable = opts.disable || {};
         tag.serverpubkey = opts.serverpubkey || "";
         tag.servercertificate = opts.servercertificate || "";
@@ -98,6 +111,9 @@
                 config.key = fromHex(x509.key);
                 config.serverKey = fromHex(x509.servCert);
             }
+
+            // set Certificate Usage
+            config.certificateUsage = tag.refs.certificateUsage.value;
 
             return config;
         }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -123,7 +123,7 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
                         false, true);
             } else if (serverInfo.secureMode == SecurityMode.X509) {
                 // set identity
-                newBuilder.setIdentity(serverInfo.privateKey, new Certificate[] { serverInfo.clientCertificate });
+                newBuilder.setIdentity(serverInfo.privateKey, serverInfo.clientCertificateChain);
 
                 // LWM2M v1.1.1 - 5.2.8.7. Certificate Usage Field
                 //

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -125,6 +125,11 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
                 // set identity
                 newBuilder.setIdentity(serverInfo.privateKey, serverInfo.clientCertificateChain);
 
+                // enable SNI by default if not set
+                if (dtlsConfigbuilder.getIncompleteConfig().isSniEnabled() == null) {
+                    newBuilder.setSniEnabled(true);
+                }
+
                 // LWM2M v1.1.1 - 5.2.8.7. Certificate Usage Field
                 //
                 // 0: Certificate usage 0 ("CA constraint")

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -317,10 +317,9 @@ public class LeshanClientBuilder {
             dtlsConfigBuilder.setReceiverThreadCount(1);
         }
 
-        // Deactivate SNI by default
-        // TODO should we support SNI ?
-        if (incompleteConfig.isSniEnabled() == null) {
-            dtlsConfigBuilder.setSniEnabled(false);
+        // Only set SNI if it is configured (leaving it off by default)
+        if (incompleteConfig.isSniEnabled() != null) {
+            dtlsConfigBuilder.setSniEnabled(incompleteConfig.isSniEnabled());
         }
 
         return createLeshanClient(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder,

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -17,6 +17,10 @@ package org.eclipse.leshan.client.object;
 
 import static org.eclipse.leshan.core.LwM2mId.*;
 
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -32,6 +36,7 @@ import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
 import org.eclipse.leshan.core.util.datatype.ULong;
+import org.eclipse.leshan.core.util.X509CertUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,6 +115,20 @@ public class Security extends BaseInstanceEnabler {
     }
 
     /**
+     * Returns a new security instance (X509) for a bootstrap server.
+     */
+    public static Security x509Bootstrap(String serverUri, X509Certificate[] clientCertificateChain, PrivateKey clientPrivateKey,
+            X509Certificate serverCertificate, CertificateUsage certificateUsage) throws CertificateEncodingException {
+        byte [] serverIdentity = null;
+        if (serverCertificate != null) {
+            serverIdentity = serverCertificate.getEncoded().clone();
+        }
+        byte [] clientIdentity = X509CertUtil.asPem(clientCertificateChain).getBytes(StandardCharsets.UTF_8);
+        return new Security(serverUri, true, SecurityMode.X509.code, clientIdentity, serverIdentity,
+                clientPrivateKey.getEncoded().clone(), 0, certificateUsage.code);
+    }
+
+    /**
      * Returns a new security instance (NoSec) for a device management server.
      */
     public static Security noSec(String serverUri, int shortServerId) {
@@ -151,6 +170,21 @@ public class Security extends BaseInstanceEnabler {
             byte[] serverPublicKey, ULong certificateUsage) {
         return new Security(serverUri, false, SecurityMode.X509.code, clientCertificate.clone(),
                 serverPublicKey.clone(), clientPrivateKey.clone(), shortServerId, certificateUsage);
+    }
+
+    /**
+     * Returns a new security instance (X509) for a device management server.
+     */
+    public static Security x509(String serverUri, int shortServerId, X509Certificate[] clientCertificateChain,
+            PrivateKey clientPrivateKey, X509Certificate serverCertificate, CertificateUsage certificateUsage)
+            throws CertificateEncodingException {
+        byte [] serverIdentity = null;
+        if (serverCertificate != null) {
+            serverIdentity = serverCertificate.getEncoded().clone();
+        }
+        byte [] clientIdentity = X509CertUtil.asPem(clientCertificateChain).getBytes(StandardCharsets.UTF_8);
+        return new Security(serverUri, false, SecurityMode.X509.code, clientIdentity, serverIdentity,
+                clientPrivateKey.getEncoded().clone(), shortServerId, certificateUsage.code);
     }
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
@@ -49,7 +49,7 @@ public class ServerInfo {
     public PublicKey publicKey;
     public PublicKey serverPublicKey;
 
-    public Certificate clientCertificate;
+    public Certificate[] clientCertificateChain;
     public Certificate serverCertificate;
 
     public PrivateKey privateKey;

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -93,7 +93,7 @@ public class ServersInfoExtractor {
                             info.privateKey = getPrivateKey(security);
                             info.serverPublicKey = getServerPublicKey(security);
                         } else if (info.secureMode == SecurityMode.X509) {
-                            info.clientCertificate = getClientCertificate(security);
+                            info.clientCertificateChain = getClientCertificateChain(security);
                             info.serverCertificate = getServerCertificate(security);
                             info.privateKey = getPrivateKey(security);
                             info.certificateUsage = getCertificateUsage(security);
@@ -115,7 +115,7 @@ public class ServersInfoExtractor {
                         info.privateKey = getPrivateKey(security);
                         info.serverPublicKey = getServerPublicKey(security);
                     } else if (info.secureMode == SecurityMode.X509) {
-                        info.clientCertificate = getClientCertificate(security);
+                        info.clientCertificateChain = getClientCertificateChain(security);
                         info.serverCertificate = getServerCertificate(security);
                         info.privateKey = getPrivateKey(security);
                         info.certificateUsage = getCertificateUsage(security);
@@ -276,6 +276,19 @@ public class ServersInfoExtractor {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             try (ByteArrayInputStream in = new ByteArrayInputStream(encodedCert)) {
                 return cf.generateCertificate(in);
+            }
+        } catch (CertificateException | IOException e) {
+            LOG.debug("Failed to decode X.509 certificate", e);
+            return null;
+        }
+    }
+
+    private static Certificate[] getClientCertificateChain(LwM2mObjectInstance securityInstance) {
+        byte[] encodedCert = (byte[]) securityInstance.getResource(SEC_PUBKEY_IDENTITY).getValue();
+        try {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            try (ByteArrayInputStream in = new ByteArrayInputStream(encodedCert)) {
+                return cf.generateCertificates(in).toArray(new Certificate[0]);
             }
         } catch (CertificateException | IOException e) {
             LOG.debug("Failed to decode X.509 certificate", e);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -62,6 +62,7 @@ import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;
+import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.LwM2m;
 import org.eclipse.leshan.core.californium.DefaultEndpointFactory;
 import org.eclipse.leshan.core.model.LwM2mModel;
@@ -225,6 +226,9 @@ public class LeshanClientDemo {
         options.addOption("truststore", true,
                 "The path to a root certificate file to trust or a folder containing all the trusted certificates in X509v3 format (DER encoding) or trust store URI."
                         + trustStoreChapter);
+
+        options.addOption("cu", "certificate-usage", true,
+                "Certificate Usage (as integer) for security object.\n Default: domain issued certificate (3).");
 
         HelpFormatter formatter = new HelpFormatter();
         formatter.setWidth(90);
@@ -504,6 +508,11 @@ public class LeshanClientDemo {
             }
         }
 
+        CertificateUsage certificateUsage = CertificateUsage.DOMAIN_ISSUER_CERTIFICATE;
+        if (cl.hasOption("cu")) {
+            certificateUsage = CertificateUsage.fromCode(Integer.parseInt(cl.getOptionValue("cu")));
+        }
+
         // get local address
         String localAddress = null;
         int localPort = 0;
@@ -552,8 +561,8 @@ public class LeshanClientDemo {
             createAndStartClient(endpoint, localAddress, localPort, cl.hasOption("b"), additionalAttributes,
                     bsAdditionalAttributes, lifetime, communicationPeriod, serverURI, pskIdentity, pskKey,
                     clientPrivateKey, clientPublicKey, serverPublicKey, clientCertificate, serverCertificate,
-                    trustStore, latitude, longitude, scaleFactor, cl.hasOption("ocf"), cl.hasOption("oc"),
-                    cl.hasOption("r"), cl.hasOption("f"), modelsFolderPath, ciphers);
+                    trustStore, certificateUsage, latitude, longitude, scaleFactor, cl.hasOption("ocf"),
+                    cl.hasOption("oc"), cl.hasOption("r"), cl.hasOption("f"), modelsFolderPath, ciphers);
         } catch (Exception e) {
             System.err.println("Unable to create and start client ...");
             e.printStackTrace();
@@ -566,9 +575,9 @@ public class LeshanClientDemo {
             Integer communicationPeriod, String serverURI, byte[] pskIdentity, byte[] pskKey,
             PrivateKey clientPrivateKey, PublicKey clientPublicKey, PublicKey serverPublicKey,
             X509Certificate clientCertificate, X509Certificate serverCertificate, List<Certificate> trustStore,
-            Float latitude, Float longitude, float scaleFactor, boolean supportOldFormat,
-            boolean supportDeprecatedCiphers, boolean reconnectOnUpdate, boolean forceFullhandshake,
-            String modelsFolderPath, List<CipherSuite> ciphers) throws Exception {
+            CertificateUsage certificateUsage, Float latitude, Float longitude, float scaleFactor,
+            boolean supportOldFormat, boolean supportDeprecatedCiphers, boolean reconnectOnUpdate,
+            boolean forceFullhandshake, String modelsFolderPath, List<CipherSuite> ciphers) throws Exception {
 
         locationInstance = new MyLocation(latitude, longitude, scaleFactor);
 
@@ -608,7 +617,7 @@ public class LeshanClientDemo {
                 initializer.setInstancesForObject(SERVER, new Server(123, lifetime));
             } else if (clientCertificate != null) {
                 initializer.setInstancesForObject(SECURITY, x509(serverURI, 123, clientCertificate.getEncoded(),
-                        clientPrivateKey.getEncoded(), serverCertificate.getEncoded()));
+                        clientPrivateKey.getEncoded(), serverCertificate.getEncoded(), certificateUsage.code));
                 initializer.setInstancesForObject(SERVER, new Server(123, lifetime));
             } else {
                 initializer.setInstancesForObject(SECURITY, noSec(serverURI, 123));

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
@@ -91,8 +91,8 @@ public class EndpointContextUtil {
         }
 
         if (peerIdentity != null && allowConnectionInitiation) {
-            return new MapBasedEndpointContext(identity.getPeerAddress(), peerIdentity,
-                    DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_AUTO);
+            return new MapBasedEndpointContext(identity.getPeerAddress(), identity.getPeerAddress().getHostName(),
+                    peerIdentity, DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_AUTO);
         }
         return new AddressEndpointContext(identity.getPeerAddress(), peerIdentity);
     }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/util/SecurityUtil.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/util/SecurityUtil.java
@@ -100,4 +100,19 @@ public class SecurityUtil {
             return x509Certificates.toArray(new X509Certificate[0]);
         }
     };
+
+    public static X509Certificate[] asX509Certificates(Certificate[] certificates) throws CertificateException {
+        ArrayList<X509Certificate> x509Certificates = new ArrayList<>();
+
+        for (Certificate cert : certificates) {
+            if (!(cert instanceof X509Certificate)) {
+                throw new CertificateException(
+                        String.format("%s certificate format is not supported, Only X.509 certificate is supported",
+                                cert.getType()));
+            }
+            x509Certificates.add((X509Certificate)cert);
+        }
+
+        return x509Certificates.toArray(new X509Certificate[0]);
+    }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/util/X509CertUtil.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/util/X509CertUtil.java
@@ -2,7 +2,9 @@ package org.eclipse.leshan.core.util;
 
 import javax.security.auth.x500.X500Principal;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.*;
@@ -314,5 +316,31 @@ public class X509CertUtil {
             // Ignore exception and just return no match
         }
         return false;
+    }
+
+    private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----\n";
+    private static final String END_CERTIFICATE = "-----END CERTIFICATE-----\n";
+
+    public static String asPem(X509Certificate certificate) throws CertificateEncodingException {
+        StringBuilder output = new StringBuilder();
+
+        output.append(BEGIN_CERTIFICATE);
+
+        byte[] encoded = Base64.encodeBase64Chunked(certificate.getEncoded());
+        output.append(new String(encoded, StandardCharsets.UTF_8));
+
+        output.append(END_CERTIFICATE);
+
+        return output.toString();
+    }
+
+    public static String asPem(X509Certificate[] certificateChain) throws CertificateEncodingException {
+        StringBuilder output = new StringBuilder();
+
+        for (X509Certificate certificate : certificateChain) {
+            output.append(asPem(certificate));
+        }
+
+        return output.toString();
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -23,8 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.util.datatype.ULong;
 
 /**
  * A client configuration to apply to a device during a bootstrap session.
@@ -223,14 +225,26 @@ public class BootstrapConfig implements Serializable {
          */
         public Integer bootstrapServerAccountTimeout = 0;
 
+        /**
+         * The Certificate Usage Resource specifies the semantic of the certificate or raw public key stored in the
+         * Server Public Key Resource, which is used to match the certificate presented in the TLS/DTLS handshake.
+         * <ul>
+         * <li>0: CA constraint
+         * <li>1: service certificate constraint
+         * <li>2: trust anchor assertion
+         * <li>3: domain-issued certificate (default if missing)
+         * </ul>
+         */
+        public CertificateUsage certificateUsage;
+
         @Override
         public String toString() {
             // Note : secretKey and smsBindingKeySecret are explicitly excluded from the display for security purposes
             return String.format(
-                    "ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s]",
+                    "ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s, certificateUsage=%s]",
                     uri, bootstrapServer, securityMode, Arrays.toString(publicKeyOrId),
                     Arrays.toString(serverPublicKey), smsSecurityMode, Arrays.toString(smsBindingKeyParam),
-                    serverSmsNumber, serverId, clientOldOffTime, bootstrapServerAccountTimeout);
+                    serverSmsNumber, serverId, clientOldOffTime, bootstrapServerAccountTimeout, certificateUsage);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
@@ -66,6 +66,8 @@ public class BootstrapUtil {
             resources.add(LwM2mSingleResource.newIntegerResource(11, securityConfig.clientOldOffTime));
         if (securityConfig.bootstrapServerAccountTimeout != null)
             resources.add(LwM2mSingleResource.newIntegerResource(12, securityConfig.bootstrapServerAccountTimeout));
+        if (securityConfig.certificateUsage != null)
+            resources.add(LwM2mSingleResource.newUnsignedIntegerResource(15, securityConfig.certificateUsage.code));
 
         return new LwM2mObjectInstance(instanceId, resources);
     }

--- a/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/SecurityInfoSerDes.java
+++ b/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/SecurityInfoSerDes.java
@@ -30,6 +30,7 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
 
+import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.server.security.SecurityInfo;
 
@@ -44,6 +45,9 @@ public class SecurityInfoSerDes {
     public static byte[] serialize(SecurityInfo s) {
         JsonObject o = Json.object();
         o.set("ep", s.getEndpoint());
+        if (s.getCertificateUsage() != null) {
+            o.set("cu", s.getCertificateUsage().code.intValue());
+        }
         if (s.getIdentity() != null) {
             o.set("id", s.getIdentity());
         }
@@ -85,11 +89,14 @@ public class SecurityInfoSerDes {
 
         SecurityInfo i;
         String ep = o.getString("ep", null);
+
+        int cu = o.getInt("cu", CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code.intValue());
+        CertificateUsage certificateUsage = CertificateUsage.fromCode(cu);
         if (o.get("psk") != null) {
             i = SecurityInfo.newPreSharedKeyInfo(ep, o.getString("id", null),
                     Hex.decodeHex(o.getString("psk", null).toCharArray()));
         } else if (o.get("x509") != null) {
-            i = SecurityInfo.newX509CertInfo(ep);
+            i = SecurityInfo.newX509CertInfo(ep, certificateUsage);
         } else {
             JsonObject rpk = (JsonObject) o.get("rpk");
             PublicKey key;


### PR DESCRIPTION
LWM2M 1.1 brings certificate usage support.

In order for certificate usage support to be more practical these commits also add other features.

Certificate chain support is being added for client to allow supplying certificate chain with intermediate CA's. Problem with LWM2M is that it can support in X.509 mode only one level CA setup (unless server's trust store has all needed intermediates where only Root CA's should be in trust stores). In EST mode certificate delivery is different and can easily support intermediate CA setups. X.509 problem comes from Security Objects certificate field is X.509 certificate encoded as DER. If it would have been PKCS#7 certificate bundle encoded as DER then it would have worked better.

Note: It is industry best practice to have Root CA in offline environment and Intermediate CA in online environment (like what would be used by EST server or by device manufacturing flows).

Note: Actual EST support is to be coming in future and is not part of these commits.

Note: redis support has not really been tested -- it has just been adapted with match changes.

These commits fix server certificate checking to support subjectAlternativeNames which is today's requirement for TLS Server Certificates (vs. using Subject DN's CN field). At the same time support is added for DNS, IPv4 and IPv6 addresses for TLS Server Certificates.

Fixes: https://github.com/eclipse/leshan/issues/893
Relates to: https://github.com/eclipse/leshan/issues/859