### PR TITLE
DefaultEndpointFactory: Add new endpoint context matcher for clients

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -257,7 +257,7 @@ public class LeshanClientBuilder {
             engineFactory = new DefaultRegistrationEngineFactory();
         }
         if (endpointFactory == null) {
-            endpointFactory = new DefaultEndpointFactory("LWM2M Client") {
+            endpointFactory = new DefaultEndpointFactory("LWM2M Client", true) {
                 @Override
                 protected Connector createSecuredConnector(DtlsConnectorConfig dtlsConfig) {
                     DTLSConnector dtlsConnector = new DTLSConnector(dtlsConfig);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -596,7 +596,7 @@ public class LeshanClientDemo {
         engineFactory.setResumeOnConnect(!forceFullhandshake);
 
         // configure EndpointFactory
-        DefaultEndpointFactory endpointFactory = new DefaultEndpointFactory("LWM2M CLIENT") {
+        DefaultEndpointFactory endpointFactory = new DefaultEndpointFactory("LWM2M CLIENT", true) {
             @Override
             protected Connector createSecuredConnector(DtlsConnectorConfig dtlsConfig) {
 

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.californium;
 
 import java.net.InetSocketAddress;
+import java.security.Principal;
 
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.CoapEndpoint.Builder;
@@ -24,6 +25,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.ObservationStore;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.EndpointContextMatcher;
+import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
 import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
@@ -46,7 +48,15 @@ public class DefaultEndpointFactory implements EndpointFactory {
     }
 
     public DefaultEndpointFactory(String loggingTag) {
-        securedContextMatcher = createSecuredContextMatcher();
+        this(loggingTag, false);
+    }
+
+    /**
+     * @param loggingTag Logging tag
+     * @param isClient Indication whether this factory is for client or for server.
+     */
+    public DefaultEndpointFactory(String loggingTag, boolean isClient) {
+        securedContextMatcher = createSecuredContextMatcher(isClient);
         unsecuredContextMatcher = createUnsecuredContextMatcher();
         if (loggingTag != null) {
             this.loggingTag = loggingTag;
@@ -54,14 +64,27 @@ public class DefaultEndpointFactory implements EndpointFactory {
     }
 
     /**
-     * By default a {@link Lwm2mEndpointContextMatcher} is created.
+     * For server {@link Lwm2mEndpointContextMatcher} is created.
+     * For client {@link PrincipalEndpointContextMatcher} is created.
      * <p>
      * This method is intended to be overridden.
      * 
      * @return the {@link EndpointContextMatcher} used for secured communication
+     * @param isClient Indication whether to use client side endpoint context matcher of server side.
      */
-    protected EndpointContextMatcher createSecuredContextMatcher() {
-        return new Lwm2mEndpointContextMatcher();
+    protected EndpointContextMatcher createSecuredContextMatcher(boolean isClient) {
+        if (isClient) {
+            return new PrincipalEndpointContextMatcher() {
+                @Override
+                protected boolean matchPrincipals(Principal requestedPrincipal, Principal availablePrincipal) {
+                    // Client always knows where it is connected -> no need to match principals.
+                    // For DTLS connections handshake has already been performed which verifies peer identity.
+                    return true;
+                }
+            };
+        } else {
+            return new Lwm2mEndpointContextMatcher();
+        }
     }
 
     /**

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -429,7 +429,7 @@ public class LeshanServerBuilder {
         if (registrationIdProvider == null)
             registrationIdProvider = new RandomStringRegistrationIdProvider();
         if (endpointFactory == null) {
-            endpointFactory = new DefaultEndpointFactory("LWM2M Server");
+            endpointFactory = new DefaultEndpointFactory("LWM2M Server", false);
         }
 
         // handle dtlsConfig

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
@@ -426,7 +426,7 @@ public class LeshanBootstrapServerBuilder {
             coapConfig = createDefaultNetworkConfig();
         }
         if (endpointFactory == null) {
-            endpointFactory = new DefaultEndpointFactory("LWM2M BS Server");
+            endpointFactory = new DefaultEndpointFactory("LWM2M BS Server", false);
         }
         if (encoder == null)
             encoder = new DefaultLwM2mNodeEncoder();


### PR DESCRIPTION
There is separation between LWM2M Client and Server side
EndpointContextMatchers as when client is performing initial connection it
doesn't know real peer identity due to flexibility of certificate usage
configuration.

With certificate usage the server identity may be the intermediate CA or root
CA. LWM2M client also knows where it is connecting and peer identity is
verified for DTLS secured connections during DTLS handshake phase.

When server is receiving DTLS connection it always knows the whole peer
identity as DTLS handshake is performed first before any message is being sent
to client and then EndpointContext is built with real client information.
Matcher is needed in server side as one datagram server socket received
connections from multiple clients.

Signed-off-by: Vesa Jääskeläinen <dachaac@gmail.com>