### PR TITLE
Trust store updates

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -60,6 +60,7 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
     protected CoapEndpoint currentEndpoint;
 
     protected Builder dtlsConfigbuilder;
+    protected List<Certificate> trustStore;
     protected NetworkConfig coapConfig;
     protected InetSocketAddress localAddress;
     protected CoapServer coapServer;
@@ -67,9 +68,18 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
 
     public CaliforniumEndpointsManager(InetSocketAddress localAddress, NetworkConfig coapConfig,
             Builder dtlsConfigBuilder, EndpointFactory endpointFactory) {
+        this(localAddress, coapConfig, dtlsConfigBuilder, null, endpointFactory);
+    }
+
+    /**
+     * @since 2.0
+     */
+    public CaliforniumEndpointsManager(InetSocketAddress localAddress, NetworkConfig coapConfig,
+            Builder dtlsConfigBuilder, List<Certificate> trustStore, EndpointFactory endpointFactory) {
         this.localAddress = localAddress;
         this.coapConfig = coapConfig;
         this.dtlsConfigbuilder = dtlsConfigBuilder;
+        this.trustStore = trustStore;
         this.endpointFactory = endpointFactory;
     }
 

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.client.californium;
 
 import java.net.InetSocketAddress;
+import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -83,6 +84,16 @@ public class LeshanClient implements LwM2mClient {
             EndpointFactory endpointFactory, RegistrationEngineFactory engineFactory,
             Map<String, String> additionalAttributes, Map<String, String> bsAdditionalAttributes,
             LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder, ScheduledExecutorService sharedExecutor) {
+        this(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder, null, endpointFactory,
+                engineFactory, additionalAttributes, bsAdditionalAttributes, encoder, decoder, sharedExecutor);
+    }
+
+    /** @since 2.0 */
+    public LeshanClient(String endpoint, InetSocketAddress localAddress,
+            List<? extends LwM2mObjectEnabler> objectEnablers, NetworkConfig coapConfig, Builder dtlsConfigBuilder, List<Certificate> trustStore,
+            EndpointFactory endpointFactory, RegistrationEngineFactory engineFactory,
+            Map<String, String> additionalAttributes, Map<String, String> bsAdditionalAttributes,
+            LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder, ScheduledExecutorService sharedExecutor) {
 
         Validate.notNull(endpoint);
         Validate.notEmpty(objectEnablers);
@@ -91,7 +102,7 @@ public class LeshanClient implements LwM2mClient {
         objectTree = createObjectTree(objectEnablers);
         observers = createClientObserverDispatcher();
         bootstrapHandler = createBoostrapHandler(objectTree);
-        endpointsManager = createEndpointsManager(localAddress, coapConfig, dtlsConfigBuilder, endpointFactory);
+        endpointsManager = createEndpointsManager(localAddress, coapConfig, dtlsConfigBuilder, trustStore, endpointFactory);
         requestSender = createRequestSender(endpointsManager, sharedExecutor);
         engine = engineFactory.createRegistratioEngine(endpoint, objectTree, endpointsManager, requestSender,
                 bootstrapHandler, observers, additionalAttributes, bsAdditionalAttributes, sharedExecutor);
@@ -178,8 +189,8 @@ public class LeshanClient implements LwM2mClient {
     }
 
     protected CaliforniumEndpointsManager createEndpointsManager(InetSocketAddress localAddress,
-            NetworkConfig coapConfig, Builder dtlsConfigBuilder, EndpointFactory endpointFactory) {
-        return new CaliforniumEndpointsManager(localAddress, coapConfig, dtlsConfigBuilder, endpointFactory);
+            NetworkConfig coapConfig, Builder dtlsConfigBuilder, List<Certificate> trustStore, EndpointFactory endpointFactory) {
+        return new CaliforniumEndpointsManager(localAddress, coapConfig, dtlsConfigBuilder, trustStore, endpointFactory);
     }
 
     protected CaliforniumLwM2mRequestSender createRequestSender(CaliforniumEndpointsManager endpointsManager,

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.client.californium;
 
 import java.net.InetSocketAddress;
+import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -61,6 +62,7 @@ public class LeshanClientBuilder {
 
     private NetworkConfig coapConfig;
     private Builder dtlsConfigBuilder;
+    private List<Certificate> trustStore;
 
     private LwM2mNodeEncoder encoder;
     private LwM2mNodeDecoder decoder;
@@ -153,6 +155,15 @@ public class LeshanClientBuilder {
      */
     public LeshanClientBuilder setDtlsConfig(DtlsConnectorConfig.Builder config) {
         this.dtlsConfigBuilder = config;
+        return this;
+    }
+
+    /**
+     * Set optional trust store for verifying X.509 server certificates.
+     * @param trustStore List of trusted CA certificates
+     */
+    public LeshanClientBuilder setTrustStore(List<Certificate> trustStore) {
+        this.trustStore = trustStore;
         return this;
     }
 
@@ -309,7 +320,7 @@ public class LeshanClientBuilder {
         }
 
         return createLeshanClient(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder,
-                endpointFactory, engineFactory, additionalAttributes, encoder, decoder, executor);
+                this.trustStore, endpointFactory, engineFactory, additionalAttributes, encoder, decoder, executor);
     }
 
     /**
@@ -326,6 +337,7 @@ public class LeshanClientBuilder {
      *        client.
      * @param coapConfig The coap config used to create {@link CoapEndpoint} and {@link CoapServer}.
      * @param dtlsConfigBuilder The dtls config used to create the {@link DTLSConnector}.
+     * @param trustStore The optional trust store for verifying X.509 server certificates.
      * @param endpointFactory The factory which will create the {@link CoapEndpoint}.
      * @param engineFactory The factory which will create the {@link RegistrationEngine}.
      * @param additionalAttributes Some extra (out-of-spec) attributes to add to the register request.
@@ -337,10 +349,11 @@ public class LeshanClientBuilder {
      */
     protected LeshanClient createLeshanClient(String endpoint, InetSocketAddress localAddress,
             List<? extends LwM2mObjectEnabler> objectEnablers, NetworkConfig coapConfig, Builder dtlsConfigBuilder,
-            EndpointFactory endpointFactory, RegistrationEngineFactory engineFactory,
+            List<Certificate> trustStore, EndpointFactory endpointFactory, RegistrationEngineFactory engineFactory,
             Map<String, String> additionalAttributes, LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder,
             ScheduledExecutorService sharedExecutor) {
-        return new LeshanClient(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder, endpointFactory,
-                engineFactory, additionalAttributes, bsAdditionalAttributes, encoder, decoder, executor);
+        return new LeshanClient(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder, trustStore,
+                endpointFactory, engineFactory, additionalAttributes, bsAdditionalAttributes, encoder, decoder,
+                executor);
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -26,15 +26,10 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -47,6 +42,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.util.SslContextUtil;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.ClientHandshaker;
@@ -223,6 +219,21 @@ public class LeshanClientDemo {
                 "The path to your client certificate file.\n The certificate Common Name (CN) should generaly be equal to the client endpoint name (see -n option).\nThe certificate should be in X509v3 format (DER encoding).");
         options.addOption("scert", true,
                 "The path to your server certificate file.\n The certificate should be in X509v3 format (DER encoding).");
+
+        final StringBuilder trustStoreChapter = new StringBuilder();
+        trustStoreChapter.append("\n .");
+        trustStoreChapter.append("\n URI format: file://<path-to-trust-store-file>#<hex-strore-password>#<alias-pattern>");
+        trustStoreChapter.append("\n .");
+        trustStoreChapter.append("\n Where:");
+        trustStoreChapter.append("\n - path-to-trust-store-file is path to pkcs12 trust store file");
+        trustStoreChapter.append("\n - hex-store-password is HEX formatted password for store");
+        trustStoreChapter.append("\n - alias-pattern can be used to filter trusted certificates and can also be empty to get all");
+        trustStoreChapter.append("\n .");
+        trustStoreChapter.append("\n Default: All certificates are trusted which is only OK for a demo.");
+
+        options.addOption("truststore", true,
+                "The path to a root certificate file to trust or a folder containing all the trusted certificates in X509v3 format (DER encoding) or trust store URI."
+                        + trustStoreChapter);
 
         HelpFormatter formatter = new HelpFormatter();
         formatter.setWidth(90);
@@ -456,6 +467,52 @@ public class LeshanClientDemo {
             }
         }
 
+        // configure trust store if given
+        List<Certificate> trustStore = null;
+        if (cl.hasOption("truststore")) {
+            trustStore = new ArrayList<>();
+
+            String trustStoreName = cl.getOptionValue("truststore");
+
+            if (trustStoreName.startsWith("file://")) {
+                // Treat argument as Java trust store
+                try {
+                    Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(trustStoreName);
+                    trustStore.addAll(Arrays.asList(trustedCertificates));
+                } catch (Exception e) {
+                    System.err.println("Failed to load trust store : " + e.getMessage());
+                    e.printStackTrace();
+                    formatter.printHelp(USAGE, options);
+                    return;
+                }
+            } else {
+                // Treat argument as file or directory
+                File input = new File(cl.getOptionValue("truststore"));
+
+                // check input exists
+                if (!input.exists()) {
+                    System.err.println("Failed to load trust store - file or directory does not exist : " + input.toString());
+                    formatter.printHelp(USAGE, options);
+                    return;
+                }
+
+                // get input files.
+                File[] files;
+                if (input.isDirectory()) {
+                    files = input.listFiles();
+                } else {
+                    files = new File[] { input };
+                }
+                for (File file : files) {
+                    try {
+                        trustStore.add(SecurityUtil.certificate.readFromFile(file.getAbsolutePath()));
+                    } catch (Exception e) {
+                        LOG.warn("Unable to load X509 files {} : {} ", file.getAbsolutePath(), e.getMessage());
+                    }
+                }
+            }
+        }
+
         // get local address
         String localAddress = null;
         int localPort = 0;
@@ -503,9 +560,9 @@ public class LeshanClientDemo {
         try {
             createAndStartClient(endpoint, localAddress, localPort, cl.hasOption("b"), additionalAttributes,
                     bsAdditionalAttributes, lifetime, communicationPeriod, serverURI, pskIdentity, pskKey,
-                    clientPrivateKey, clientPublicKey, serverPublicKey, clientCertificate, serverCertificate, latitude,
-                    longitude, scaleFactor, cl.hasOption("ocf"), cl.hasOption("oc"), cl.hasOption("r"),
-                    cl.hasOption("f"), modelsFolderPath, ciphers);
+                    clientPrivateKey, clientPublicKey, serverPublicKey, clientCertificate, serverCertificate,
+                    trustStore, latitude, longitude, scaleFactor, cl.hasOption("ocf"), cl.hasOption("oc"),
+                    cl.hasOption("r"), cl.hasOption("f"), modelsFolderPath, ciphers);
         } catch (Exception e) {
             System.err.println("Unable to create and start client ...");
             e.printStackTrace();
@@ -517,9 +574,10 @@ public class LeshanClientDemo {
             Map<String, String> additionalAttributes, Map<String, String> bsAdditionalAttributes, int lifetime,
             Integer communicationPeriod, String serverURI, byte[] pskIdentity, byte[] pskKey,
             PrivateKey clientPrivateKey, PublicKey clientPublicKey, PublicKey serverPublicKey,
-            X509Certificate clientCertificate, X509Certificate serverCertificate, Float latitude, Float longitude,
-            float scaleFactor, boolean supportOldFormat, boolean supportDeprecatedCiphers, boolean reconnectOnUpdate,
-            boolean forceFullhandshake, String modelsFolderPath, List<CipherSuite> ciphers) throws Exception {
+            X509Certificate clientCertificate, X509Certificate serverCertificate, List<Certificate> trustStore,
+            Float latitude, Float longitude, float scaleFactor, boolean supportOldFormat,
+            boolean supportDeprecatedCiphers, boolean reconnectOnUpdate, boolean forceFullhandshake,
+            String modelsFolderPath, List<CipherSuite> ciphers) throws Exception {
 
         locationInstance = new MyLocation(latitude, longitude, scaleFactor);
 
@@ -676,6 +734,7 @@ public class LeshanClientDemo {
         builder.setLocalAddress(localAddress, localPort);
         builder.setObjects(enablers);
         builder.setCoapConfig(coapConfig);
+        builder.setTrustStore(trustStore);
         builder.setDtlsConfig(dtlsConfig);
         builder.setRegistrationEngineFactory(engineFactory);
         builder.setEndpointFactory(endpointFactory);


### PR DESCRIPTION
These commits adds support to load trust store form Java trust store as what is common in Java applications.

Also adds support for LeshanClient to have trust store defined -- actual usage comes with later changes.

For use of Java trust store argument format utilizes Californium's URI format for specifying trust store.
    
-truststore
file:///full/path/truststore.p12#hex-store-password#aliaspattern

Where aliaspattern can be empty.

First this is added to LeshanServerDemo and then same logic is applied to LeshanClientDemo and to LeshanBootstrapServerDemo.

