### PR TITLE
Update BindingMode to be LWM2M 1.1 compliant and support Q parameter. 

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/JSONFileBootstrapStore.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/JSONFileBootstrapStore.java
@@ -22,16 +22,19 @@ import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.util.Validate;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
 import org.eclipse.leshan.server.bootstrap.EditableBootstrapConfigStore;
 import org.eclipse.leshan.server.bootstrap.InMemoryBootstrapConfigStore;
 import org.eclipse.leshan.server.bootstrap.InvalidConfigurationException;
+import org.eclipse.leshan.server.bootstrap.demo.json.BindingModeTypeAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +72,9 @@ public class JSONFileBootstrapStore extends InMemoryBootstrapConfigStore {
         Validate.notEmpty(filename);
         GsonBuilder builder = new GsonBuilder();
         builder.setPrettyPrinting();
+        builder.registerTypeAdapter(new TypeToken<EnumSet<BindingMode>>() {
+        }.getType(), new BindingModeTypeAdapter());
+
         this.gson = builder.create();
         this.gsonType = new TypeToken<Map<String, BootstrapConfig>>() {
         }.getType();

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/json/BindingModeTypeAdapter.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/json/BindingModeTypeAdapter.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap.demo.json;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import org.eclipse.leshan.core.request.BindingMode;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class BindingModeTypeAdapter extends TypeAdapter<EnumSet<BindingMode>> {
+
+    @Override
+    public void write(JsonWriter out, EnumSet<BindingMode> value) throws IOException {
+        out.value(BindingMode.toString(value));
+    }
+
+    @Override
+    public EnumSet<BindingMode> read(JsonReader in) throws IOException {
+        return BindingMode.parse(in.nextString());
+    }
+}

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/servlet/BootstrapServlet.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/servlet/BootstrapServlet.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -27,9 +28,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
 import org.eclipse.leshan.server.bootstrap.EditableBootstrapConfigStore;
 import org.eclipse.leshan.server.bootstrap.InvalidConfigurationException;
+import org.eclipse.leshan.server.bootstrap.demo.json.BindingModeTypeAdapter;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -41,6 +44,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 
 /**
  * Servlet for REST API in charge of adding bootstrap information to the bootstrap server.
@@ -70,8 +74,10 @@ public class BootstrapServlet extends HttpServlet {
     public BootstrapServlet(EditableBootstrapConfigStore bsStore) {
         this.bsStore = bsStore;
 
-        this.gson = new GsonBuilder().registerTypeHierarchyAdapter(Byte.class, new SignedByteUnsignedByteAdapter())
-                .create();
+        this.gson = new GsonBuilder()//
+                .registerTypeAdapter(new TypeToken<EnumSet<BindingMode>>() {
+                }.getType(), new BindingModeTypeAdapter()) //
+                .registerTypeHierarchyAdapter(Byte.class, new SignedByteUnsignedByteAdapter()).create();
     }
 
     @Override

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -256,9 +256,9 @@ public class LeshanClientBuilder {
             ObjectsInitializer initializer = new ObjectsInitializer();
             initializer.setInstancesForObject(LwM2mId.SECURITY,
                     Security.noSec("coap://leshan.eclipseprojects.io:5683", 12345));
-            initializer.setInstancesForObject(LwM2mId.SERVER,
-                    new Server(12345, 5 * 60, EnumSet.of(BindingMode.U), false));
-            initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", "model12345", "12345", "U"));
+            initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, 5 * 60));
+            initializer.setInstancesForObject(LwM2mId.DEVICE,
+                    new Device("Eclipse Leshan", "model12345", "12345", EnumSet.of(BindingMode.U)));
             objectEnablers = initializer.createAll();
         }
         if (encoder == null)

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.client.californium;
 
 import java.net.InetSocketAddress;
 import java.security.cert.Certificate;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
@@ -160,6 +161,7 @@ public class LeshanClientBuilder {
 
     /**
      * Set optional trust store for verifying X.509 server certificates.
+     * 
      * @param trustStore List of trusted CA certificates
      */
     public LeshanClientBuilder setTrustStore(List<Certificate> trustStore) {
@@ -207,6 +209,7 @@ public class LeshanClientBuilder {
 
     /**
      * Set the additionalAttributes for {@link BootstrapRequest}
+     * 
      * @since 1.1
      */
     public LeshanClientBuilder setBootstrapAdditionalAttributes(Map<String, String> additionalAttributes) {
@@ -253,7 +256,8 @@ public class LeshanClientBuilder {
             ObjectsInitializer initializer = new ObjectsInitializer();
             initializer.setInstancesForObject(LwM2mId.SECURITY,
                     Security.noSec("coap://leshan.eclipseprojects.io:5683", 12345));
-            initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, 5 * 60, BindingMode.U, false));
+            initializer.setInstancesForObject(LwM2mId.SERVER,
+                    new Server(12345, 5 * 60, EnumSet.of(BindingMode.U), false));
             initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", "model12345", "12345", "U"));
             objectEnablers = initializer.createAll();
         }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/request/CoapRequestBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/request/CoapRequestBuilder.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.request;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
@@ -85,12 +86,20 @@ public class CoapRequestBuilder implements UplinkRequestVisitor {
         if (lwVersion != null)
             attributes.put("lwm2m", lwVersion);
 
-        BindingMode bindingMode = request.getBindingMode();
+        EnumSet<BindingMode> bindingMode = request.getBindingMode();
         if (bindingMode != null)
-            attributes.put("b", bindingMode.toString());
+            attributes.put("b", BindingMode.toString(bindingMode));
+
+        Boolean queueMode = request.getQueueMode();
+        if (queueMode != null && queueMode)
+            attributes.put("Q", null);
 
         for (Entry<String, String> attr : attributes.entrySet()) {
-            coapRequest.getOptions().addUriQuery(attr.getKey() + "=" + attr.getValue());
+            if (attr.getValue() != null) {
+                coapRequest.getOptions().addUriQuery(attr.getKey() + "=" + attr.getValue());
+            } else {
+                coapRequest.getOptions().addUriQuery(attr.getKey());
+            }
         }
 
         Link[] objectLinks = request.getObjectLinks();
@@ -113,9 +122,9 @@ public class CoapRequestBuilder implements UplinkRequestVisitor {
         if (smsNumber != null)
             coapRequest.getOptions().addUriQuery("sms=" + smsNumber);
 
-        BindingMode bindingMode = request.getBindingMode();
+        EnumSet<BindingMode> bindingMode = request.getBindingMode();
         if (bindingMode != null)
-            coapRequest.getOptions().addUriQuery("b=" + bindingMode.toString());
+            coapRequest.getOptions().addUriQuery("b=" + BindingMode.toString(bindingMode));
 
         Link[] linkObjects = request.getObjectLinks();
         if (linkObjects != null) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdate.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdate.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client;
 
+import java.util.EnumSet;
 import java.util.Map;
 
 import org.eclipse.leshan.core.Link;
@@ -27,12 +28,12 @@ public class RegistrationUpdate {
 
     private final Long lifeTimeInSec;
     private final String smsNumber;
-    private final BindingMode bindingMode;
+    private final EnumSet<BindingMode> bindingMode;
     private final Link[] objectLinks;
     private final Map<String, String> additionalAttributes;
 
-    public RegistrationUpdate(Long lifeTimeInSec, String smsNumber, BindingMode bindingMode, Link[] objectLinks,
-            Map<String, String> additionalAttributes) {
+    public RegistrationUpdate(Long lifeTimeInSec, String smsNumber, EnumSet<BindingMode> bindingMode,
+            Link[] objectLinks, Map<String, String> additionalAttributes) {
         this.lifeTimeInSec = lifeTimeInSec;
         this.smsNumber = smsNumber;
         this.bindingMode = bindingMode;
@@ -52,7 +53,7 @@ public class RegistrationUpdate {
         this(null, smsNumber, null, null, null);
     }
 
-    public RegistrationUpdate(BindingMode bindingMode) {
+    public RegistrationUpdate(EnumSet<BindingMode> bindingMode) {
         this(null, null, bindingMode, null, null);
     }
 
@@ -72,7 +73,7 @@ public class RegistrationUpdate {
         return smsNumber;
     }
 
-    public BindingMode getBindingMode() {
+    public EnumSet<BindingMode> getBindingMode() {
         return bindingMode;
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdateHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdateHandler.java
@@ -76,27 +76,35 @@ public class RegistrationUpdateHandler {
             public void resourceChanged(LwM2mObjectEnabler object, int instanceId, int... resourceIds) {
                 if (!bsHandler.isBootstrapping())
                     if (object.getId() == LwM2mId.SERVER) {
-                        Long lifetime = null;
-                        EnumSet<BindingMode> bindingMode = null;
+                        // handle lifetime changes
                         for (int i = 0; i < resourceIds.length; i++) {
                             if (resourceIds[i] == LwM2mId.SRV_LIFETIME) {
-                                lifetime = ServersInfoExtractor.getLifeTime(object, instanceId);
-                            } else if (resourceIds[i] == LwM2mId.SRV_BINDING) {
-                                bindingMode = ServersInfoExtractor.getBindingMode(object, instanceId);
+                                Long lifetime = ServersInfoExtractor.getLifeTime(object, instanceId);
+                                Long serverId = ServersInfoExtractor.getServerId(object, instanceId);
+                                if (lifetime != null && serverId != null) {
+                                    ServerIdentity server = engine.getRegisteredServer(serverId);
+                                    if (server != null) {
+                                        engine.triggerRegistrationUpdate(server,
+                                                new RegistrationUpdate(lifetime, null, null, null, null));
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    } else if (object.getId() == LwM2mId.DEVICE) {
+                        // handle supported binding changes
+                        EnumSet<BindingMode> bindingMode = null;
+                        for (int i = 0; i < resourceIds.length; i++) {
+                            if (resourceIds[i] == LwM2mId.DVC_SUPPORTED_BINDING) {
+                                bindingMode = ServersInfoExtractor.getDeviceSupportedBindingMode(object, instanceId);
                             }
                         }
 
-                        if (bindingMode != null || lifetime != null) {
-                            Long serverId = null;
-                            serverId = ServersInfoExtractor.getServerId(object, instanceId);
-                            if (serverId != null) {
-                                ServerIdentity server = engine.getRegisteredServer(serverId);
-                                if (server != null)
-                                    engine.triggerRegistrationUpdate(server,
-                                            new RegistrationUpdate(lifetime, null, bindingMode, null, null));
-                            }
+                        if (bindingMode != null) {
+                            engine.triggerRegistrationUpdate(
+                                    new RegistrationUpdate(null, null, bindingMode, null, null));
+                            return;
                         }
-
                     }
             }
         });

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdateHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdateHandler.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.client;
 
+import java.util.EnumSet;
+
 import org.eclipse.leshan.client.bootstrap.BootstrapHandler;
 import org.eclipse.leshan.client.engine.RegistrationEngine;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
@@ -75,7 +77,7 @@ public class RegistrationUpdateHandler {
                 if (!bsHandler.isBootstrapping())
                     if (object.getId() == LwM2mId.SERVER) {
                         Long lifetime = null;
-                        BindingMode bindingMode = null;
+                        EnumSet<BindingMode> bindingMode = null;
                         for (int i = 0; i < resourceIds.length; i++) {
                             if (resourceIds[i] == LwM2mId.SRV_LIFETIME) {
                                 lifetime = ServersInfoExtractor.getLifeTime(object, instanceId);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
@@ -88,6 +88,8 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
     private boolean reconnectOnUpdate;
     // True if client should try to resume connection if possible.
     private boolean resumeOnConnect;
+    // True if client use queueMode : for now this just add Q parameter on register request.
+    private final boolean queueMode;
 
     private static enum Status {
         SUCCESS, FAILURE, TIMEOUT
@@ -124,7 +126,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
             Integer communicationPeriodInMs, boolean reconnectOnUpdate, boolean resumeOnConnect) {
         this(endpoint, objectTree, endpointsManager, requestSender, bootstrapState, observer, additionalAttributes,
                 null, executor, requestTimeoutInMs, deregistrationTimeoutInMs, bootstrapSessionTimeoutInSec,
-                retryWaitingTimeInMs, communicationPeriodInMs, reconnectOnUpdate, resumeOnConnect);
+                retryWaitingTimeInMs, communicationPeriodInMs, reconnectOnUpdate, resumeOnConnect, false);
     }
 
     /** @since 1.1 */
@@ -133,7 +135,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
             Map<String, String> additionalAttributes, Map<String, String> bsAdditionalAttributes,
             ScheduledExecutorService executor, long requestTimeoutInMs, long deregistrationTimeoutInMs,
             int bootstrapSessionTimeoutInSec, int retryWaitingTimeInMs, Integer communicationPeriodInMs,
-            boolean reconnectOnUpdate, boolean resumeOnConnect) {
+            boolean reconnectOnUpdate, boolean resumeOnConnect, boolean useQueueMode) {
         this.endpoint = endpoint;
         this.objectEnablers = objectTree.getObjectEnablers();
         this.bootstrapHandler = bootstrapState;
@@ -151,6 +153,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
         this.communicationPeriodInMs = communicationPeriodInMs;
         this.reconnectOnUpdate = reconnectOnUpdate;
         this.resumeOnConnect = resumeOnConnect;
+        this.queueMode = useQueueMode;
 
         if (executor == null) {
             schedExecutor = createScheduledExecutor();
@@ -299,7 +302,8 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
         RegisterRequest request = null;
         try {
             request = new RegisterRequest(endpoint, dmInfo.lifetime, Version.lastSupported().toString(), dmInfo.binding,
-                    null, LinkFormatHelper.getClientDescription(objectEnablers.values(), null), additionalAttributes);
+                    queueMode, null, LinkFormatHelper.getClientDescription(objectEnablers.values(), null),
+                    additionalAttributes);
             if (observer != null) {
                 observer.onRegistrationStarted(server, request);
             }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.client.engine;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -41,7 +42,9 @@ import org.eclipse.leshan.client.servers.ServerInfo;
 import org.eclipse.leshan.client.servers.ServersInfoExtractor;
 import org.eclipse.leshan.client.util.LinkFormatHelper;
 import org.eclipse.leshan.core.LwM2m.Version;
+import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.ResponseCode;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.BootstrapRequest;
 import org.eclipse.leshan.core.request.DeregisterRequest;
 import org.eclipse.leshan.core.request.Identity;
@@ -301,9 +304,11 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
         LOG.info("Trying to register to {} ...", server.getUri());
         RegisterRequest request = null;
         try {
-            request = new RegisterRequest(endpoint, dmInfo.lifetime, Version.lastSupported().toString(), dmInfo.binding,
-                    queueMode, null, LinkFormatHelper.getClientDescription(objectEnablers.values(), null),
-                    additionalAttributes);
+            EnumSet<BindingMode> supportedBindingMode = ServersInfoExtractor
+                    .getDeviceSupportedBindingMode(objectEnablers.get(LwM2mId.DEVICE), 0);
+            request = new RegisterRequest(endpoint, dmInfo.lifetime, Version.lastSupported().toString(),
+                    supportedBindingMode, queueMode, null,
+                    LinkFormatHelper.getClientDescription(objectEnablers.values(), null), additionalAttributes);
             if (observer != null) {
                 observer.onRegistrationStarted(server, request);
             }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngineFactory.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngineFactory.java
@@ -38,6 +38,7 @@ public class DefaultRegistrationEngineFactory implements RegistrationEngineFacto
     private Integer communicationPeriodInMs = null;
     private boolean reconnectOnUpdate = false;
     private boolean resumeOnConnect = true;
+    private boolean queueMode = false;
 
     public DefaultRegistrationEngineFactory() {
     }
@@ -50,7 +51,7 @@ public class DefaultRegistrationEngineFactory implements RegistrationEngineFacto
         return new DefaultRegistrationEngine(endpoint, objectTree, endpointsManager, requestSender, bootstrapState,
                 observer, additionalAttributes, bsAdditionalAttributes, sharedExecutor, requestTimeoutInMs,
                 deregistrationTimeoutInMs, bootstrapSessionTimeoutInSec, retryWaitingTimeInMs, communicationPeriodInMs,
-                reconnectOnUpdate, resumeOnConnect);
+                reconnectOnUpdate, resumeOnConnect, queueMode);
     }
 
     /**
@@ -148,6 +149,19 @@ public class DefaultRegistrationEngineFactory implements RegistrationEngineFacto
      */
     public DefaultRegistrationEngineFactory setResumeOnConnect(boolean resumeOnConnect) {
         this.resumeOnConnect = resumeOnConnect;
+        return this;
+    }
+
+    /**
+     * Configure client to use queueMode.
+     * <p>
+     * Default value is false
+     * 
+     * @param enable True if client must use queueMode
+     * @return this for fluent API
+     */
+    public DefaultRegistrationEngineFactory setQueueMode(boolean enable) {
+        this.queueMode = enable;
         return this;
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Device.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Device.java
@@ -20,6 +20,7 @@ package org.eclipse.leshan.client.object;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
@@ -30,6 +31,7 @@ import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
@@ -44,7 +46,7 @@ public class Device extends BaseInstanceEnabler {
     private String manufacturer;
     private String modelNumber;
     private String serialNumber;
-    private String supportedBinding;
+    private EnumSet<BindingMode> supportedBinding;
 
     private String timezone = TimeZone.getDefault().getID();
     private String utcOffset = new SimpleDateFormat("X").format(Calendar.getInstance().getTime());
@@ -53,7 +55,14 @@ public class Device extends BaseInstanceEnabler {
         // should never be used
     }
 
-    public Device(String manufacturer, String modelNumber, String serialNumber, String supportedBinding) {
+    public Device(String manufacturer, String modelNumber, String serialNumber) {
+        this.manufacturer = manufacturer;
+        this.modelNumber = modelNumber;
+        this.serialNumber = serialNumber;
+        this.supportedBinding = EnumSet.of(BindingMode.U);
+    }
+
+    public Device(String manufacturer, String modelNumber, String serialNumber, EnumSet<BindingMode> supportedBinding) {
         this.manufacturer = manufacturer;
         this.modelNumber = modelNumber;
         this.serialNumber = serialNumber;
@@ -83,7 +92,7 @@ public class Device extends BaseInstanceEnabler {
             return ReadResponse.success(resourceid, timezone);
 
         case 16: // supported binding and modes
-            return ReadResponse.success(resourceid, supportedBinding);
+            return ReadResponse.success(resourceid, BindingMode.toString(supportedBinding));
 
         default:
             return super.read(identity, resourceid);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
@@ -18,6 +18,7 @@
 package org.eclipse.leshan.client.object;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -47,14 +48,14 @@ public class Server extends BaseInstanceEnabler {
     private long lifetime;
     private Long defaultMinPeriod;
     private Long defaultMaxPeriod;
-    private BindingMode binding;
+    private EnumSet<BindingMode> binding;
     private boolean notifyWhenDisable;
 
     public Server() {
         // should only be used at bootstrap time
     }
 
-    public Server(int shortServerId, long lifetime, BindingMode binding, boolean notifyWhenDisable) {
+    public Server(int shortServerId, long lifetime, EnumSet<BindingMode> binding, boolean notifyWhenDisable) {
         this.shortServerId = shortServerId;
         this.lifetime = lifetime;
         this.binding = binding;
@@ -87,7 +88,7 @@ public class Server extends BaseInstanceEnabler {
             return ReadResponse.success(resourceid, notifyWhenDisable);
 
         case 7: // binding
-            return ReadResponse.success(resourceid, binding.toString());
+            return ReadResponse.success(resourceid, BindingMode.toString(binding));
 
         default:
             return super.read(identity, resourceid);
@@ -155,9 +156,9 @@ public class Server extends BaseInstanceEnabler {
                 return WriteResponse.badRequest("invalid type");
             }
             try {
-                BindingMode previousBinding = binding;
-                binding = BindingMode.valueOf((String) value.getValue());
-                if (!Objects.equals(previousBinding, binding))
+                EnumSet<BindingMode> previousBinding = binding;
+                binding = BindingMode.parse((String) value.getValue());
+                if (!previousBinding.equals(binding))
                     fireResourcesChange(resourceid);
                 return WriteResponse.success();
             } catch (IllegalArgumentException e) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/DmServerInfo.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/DmServerInfo.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
+import java.util.EnumSet;
+
 import org.eclipse.leshan.core.request.BindingMode;
 
 /**
@@ -26,11 +28,12 @@ import org.eclipse.leshan.core.request.BindingMode;
 public class DmServerInfo extends ServerInfo {
 
     public long lifetime;
-    public BindingMode binding;
+    public EnumSet<BindingMode> binding;
     // TODO add missing information like SMS number
 
     @Override
     public String toString() {
-        return String.format("DM Server [uri=%s, lifetime=%s, binding=%s]", serverUri, lifetime, binding);
+        return String.format("DM Server [uri=%s, lifetime=%s, binding=%s]", serverUri, lifetime,
+                BindingMode.toString(binding));
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -160,9 +160,19 @@ public class ServersInfoExtractor {
         }
     }
 
-    public static EnumSet<BindingMode> getBindingMode(LwM2mObjectEnabler serverEnabler, int instanceId) {
+    public static EnumSet<BindingMode> getServerBindingMode(LwM2mObjectEnabler serverEnabler, int instanceId) {
         ReadResponse response = serverEnabler.read(ServerIdentity.SYSTEM,
                 new ReadRequest(SERVER, instanceId, SRV_BINDING));
+        if (response.isSuccess()) {
+            return BindingMode.parse((String) ((LwM2mResource) response.getContent()).getValue());
+        } else {
+            return null;
+        }
+    }
+
+    public static EnumSet<BindingMode> getDeviceSupportedBindingMode(LwM2mObjectEnabler serverEnabler, int instanceId) {
+        ReadResponse response = serverEnabler.read(ServerIdentity.SYSTEM,
+                new ReadRequest(DEVICE, instanceId, DVC_SUPPORTED_BINDING));
         if (response.isSuccess()) {
             return BindingMode.parse((String) ((LwM2mResource) response.getContent()).getValue());
         } else {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -33,6 +33,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.EnumSet;
 import java.util.Map;
 
 import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
@@ -119,7 +120,7 @@ public class ServersInfoExtractor {
                     for (LwM2mObjectInstance server : servers.getInstances().values()) {
                         if (info.serverId == (Long) server.getResource(SRV_SERVER_ID).getValue()) {
                             info.lifetime = (long) server.getResource(SRV_LIFETIME).getValue();
-                            info.binding = BindingMode.valueOf((String) server.getResource(SRV_BINDING).getValue());
+                            info.binding = BindingMode.parse((String) server.getResource(SRV_BINDING).getValue());
 
                             infos.deviceManagements.put(info.serverId, info);
                             break;
@@ -159,11 +160,11 @@ public class ServersInfoExtractor {
         }
     }
 
-    public static BindingMode getBindingMode(LwM2mObjectEnabler serverEnabler, int instanceId) {
+    public static EnumSet<BindingMode> getBindingMode(LwM2mObjectEnabler serverEnabler, int instanceId) {
         ReadResponse response = serverEnabler.read(ServerIdentity.SYSTEM,
                 new ReadRequest(SERVER, instanceId, SRV_BINDING));
         if (response.isSuccess()) {
-            return BindingMode.valueOf((String) ((LwM2mResource) response.getContent()).getValue());
+            return BindingMode.parse((String) ((LwM2mResource) response.getContent()).getValue());
         } else {
             return null;
         }

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
@@ -18,7 +18,6 @@ package org.eclipse.leshan.client.util;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,6 @@ import org.eclipse.leshan.core.Link;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.model.ObjectLoader;
 import org.eclipse.leshan.core.model.ObjectModel;
-import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.junit.Test;
 
@@ -190,7 +188,7 @@ public class LinkFormatHelperTest {
     @Test
     public void encode_bootstrap_server_object() {
         Map<Integer, LwM2mInstanceEnabler> instancesMap = new HashMap<>();
-        instancesMap.put(0, new Server(333, 120, EnumSet.of(BindingMode.U, BindingMode.Q), false));
+        instancesMap.put(0, new Server(333, 120));
         ObjectEnabler objectEnabler = new ObjectEnabler(1, getObjectModel(1), instancesMap, null,
                 ContentFormat.DEFAULT);
 
@@ -203,7 +201,7 @@ public class LinkFormatHelperTest {
     @Test
     public void encode_bootstrap_server_object_with_version() {
         Map<Integer, LwM2mInstanceEnabler> instancesMap = new HashMap<>();
-        instancesMap.put(0, new Server(333, 120, EnumSet.of(BindingMode.U, BindingMode.Q), false));
+        instancesMap.put(0, new Server(333, 120));
         ObjectEnabler objectEnabler = new ObjectEnabler(1, getVersionedObjectModel(1, "2.0"), instancesMap, null,
                 ContentFormat.DEFAULT);
 
@@ -246,7 +244,7 @@ public class LinkFormatHelperTest {
 
         // object 1
         Map<Integer, LwM2mInstanceEnabler> serverInstances = new HashMap<>();
-        serverInstances.put(0, new Server(333, 120, EnumSet.of(BindingMode.U, BindingMode.Q), false));
+        serverInstances.put(0, new Server(333, 120));
         ObjectEnabler serverObjectEnabler = new ObjectEnabler(1, getVersionedObjectModel(1, "2.0"), serverInstances,
                 null, ContentFormat.DEFAULT);
         objectEnablers.add(serverObjectEnabler);

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.client.util;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -189,7 +190,7 @@ public class LinkFormatHelperTest {
     @Test
     public void encode_bootstrap_server_object() {
         Map<Integer, LwM2mInstanceEnabler> instancesMap = new HashMap<>();
-        instancesMap.put(0, new Server(333, 120, BindingMode.UQ, false));
+        instancesMap.put(0, new Server(333, 120, EnumSet.of(BindingMode.U, BindingMode.Q), false));
         ObjectEnabler objectEnabler = new ObjectEnabler(1, getObjectModel(1), instancesMap, null,
                 ContentFormat.DEFAULT);
 
@@ -202,7 +203,7 @@ public class LinkFormatHelperTest {
     @Test
     public void encode_bootstrap_server_object_with_version() {
         Map<Integer, LwM2mInstanceEnabler> instancesMap = new HashMap<>();
-        instancesMap.put(0, new Server(333, 120, BindingMode.UQ, false));
+        instancesMap.put(0, new Server(333, 120, EnumSet.of(BindingMode.U, BindingMode.Q), false));
         ObjectEnabler objectEnabler = new ObjectEnabler(1, getVersionedObjectModel(1, "2.0"), instancesMap, null,
                 ContentFormat.DEFAULT);
 
@@ -245,7 +246,7 @@ public class LinkFormatHelperTest {
 
         // object 1
         Map<Integer, LwM2mInstanceEnabler> serverInstances = new HashMap<>();
-        serverInstances.put(0, new Server(333, 120, BindingMode.UQ, false));
+        serverInstances.put(0, new Server(333, 120, EnumSet.of(BindingMode.U, BindingMode.Q), false));
         ObjectEnabler serverObjectEnabler = new ObjectEnabler(1, getVersionedObjectModel(1, "2.0"), serverInstances,
                 null, ContentFormat.DEFAULT);
         objectEnablers.add(serverObjectEnabler);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -610,18 +610,18 @@ public class LeshanClientDemo {
         } else {
             if (pskIdentity != null) {
                 initializer.setInstancesForObject(SECURITY, psk(serverURI, 123, pskIdentity, pskKey));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
             } else if (clientPublicKey != null) {
                 initializer.setInstancesForObject(SECURITY, rpk(serverURI, 123, clientPublicKey.getEncoded(),
                         clientPrivateKey.getEncoded(), serverPublicKey.getEncoded()));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
             } else if (clientCertificate != null) {
                 initializer.setInstancesForObject(SECURITY, x509(serverURI, 123, clientCertificate.getEncoded(),
                         clientPrivateKey.getEncoded(), serverCertificate.getEncoded()));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
             } else {
                 initializer.setInstancesForObject(SECURITY, noSec(serverURI, 123));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
             }
         }
         initializer.setInstancesForObject(DEVICE, new MyDevice());

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -70,7 +70,6 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.StaticModel;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
-import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.SecurityUtil;
 import org.slf4j.Logger;
@@ -610,18 +609,18 @@ public class LeshanClientDemo {
         } else {
             if (pskIdentity != null) {
                 initializer.setInstancesForObject(SECURITY, psk(serverURI, 123, pskIdentity, pskKey));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime));
             } else if (clientPublicKey != null) {
                 initializer.setInstancesForObject(SECURITY, rpk(serverURI, 123, clientPublicKey.getEncoded(),
                         clientPrivateKey.getEncoded(), serverPublicKey.getEncoded()));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime));
             } else if (clientCertificate != null) {
                 initializer.setInstancesForObject(SECURITY, x509(serverURI, 123, clientCertificate.getEncoded(),
                         clientPrivateKey.getEncoded(), serverCertificate.getEncoded()));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime));
             } else {
                 initializer.setInstancesForObject(SECURITY, noSec(serverURI, 123));
-                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, EnumSet.of(BindingMode.U), false));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime));
             }
         }
         initializer.setInstancesForObject(DEVICE, new MyDevice());

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
@@ -44,7 +44,8 @@ public class MyDevice extends BaseInstanceEnabler {
 
     @Override
     public ReadResponse read(ServerIdentity identity, int resourceid) {
-        LOG.info("Read on Device resource /{}/{}/{}", getModel().id, getId(), resourceid);
+        if (!identity.isSystem())
+            LOG.info("Read on Device resource /{}/{}/{}", getModel().id, getId(), resourceid);
         switch (resourceid) {
         case 0:
             return ReadResponse.success(resourceid, getManufacturer());

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
@@ -60,7 +60,7 @@ public interface LwM2m {
                 return "version  MUST NOT be null or empty";
             String[] versionPart = version.split("\\.");
             if (versionPart.length != 2) {
-                throw new IllegalArgumentException(String.format("version (%s) MUST be composed of 2 parts", version));
+                return String.format("version (%s) MUST be composed of 2 parts", version);
             }
             for (int i = 0; i < 2; i++) {
                 try {
@@ -128,6 +128,10 @@ public interface LwM2m {
 
         public boolean newerThan(Version version) {
             return this.compareTo(version) > 0;
+        }
+
+        public boolean olderThan(Version version) {
+            return this.compareTo(version) < 0;
         }
 
         public boolean newerThan(String version) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2mId.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2mId.java
@@ -47,4 +47,8 @@ public interface LwM2mId {
     public static final int SRV_SERVER_ID = 0;
     public static final int SRV_LIFETIME = 1;
     public static final int SRV_BINDING = 7;
+
+    /* DEVICE RESOURCES */
+
+    public static final int DVC_SUPPORTED_BINDING = 16;
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
@@ -17,10 +17,12 @@ package org.eclipse.leshan.core.request;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.leshan.core.Link;
+import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.UpdateResponse;
 
@@ -32,7 +34,7 @@ public class UpdateRequest implements UplinkRequest<UpdateResponse> {
 
     private final Long lifeTimeInSec;
     private final String smsNumber;
-    private final BindingMode bindingMode;
+    private final EnumSet<BindingMode> bindingMode;
     private final String registrationId;
     private final Link[] objectLinks;
     private final Map<String, String> additionalAttributes;
@@ -47,7 +49,7 @@ public class UpdateRequest implements UplinkRequest<UpdateResponse> {
      * @param objectLinks the objects and object instances the client hosts/supports
      * @exception InvalidRequestException if the registrationId is empty.
      */
-    public UpdateRequest(String registrationId, Long lifetime, String smsNumber, BindingMode binding,
+    public UpdateRequest(String registrationId, Long lifetime, String smsNumber, EnumSet<BindingMode> binding,
             Link[] objectLinks, Map<String, String> additionalAttributes) throws InvalidRequestException {
 
         if (registrationId == null || registrationId.isEmpty())
@@ -80,12 +82,21 @@ public class UpdateRequest implements UplinkRequest<UpdateResponse> {
         return smsNumber;
     }
 
-    public BindingMode getBindingMode() {
+    public EnumSet<BindingMode> getBindingMode() {
         return bindingMode;
     }
 
     public Map<String, String> getAdditionalAttributes() {
         return additionalAttributes;
+    }
+
+    public void validate(String targetedVersion) {
+        if (bindingMode != null) {
+            String err = BindingMode.isValidFor(bindingMode, Version.get(targetedVersion));
+            if (err != null) {
+                throw new InvalidRequestException("Invalid Binding mode: %s", err);
+            }
+        }
     }
 
     @Override

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
@@ -234,7 +234,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
         // Initialize LWM2M Object Tree
         initializer.setInstancesForObject(LwM2mId.SECURITY, security);
         initializer.setInstancesForObject(LwM2mId.DEVICE,
-                new Device("Eclipse Leshan", IntegrationTestHelper.MODEL_NUMBER, "12345", "U"));
+                new Device("Eclipse Leshan", IntegrationTestHelper.MODEL_NUMBER, "12345"));
         initializer.setClassForObject(LwM2mId.SERVER, DummyInstanceEnabler.class);
         createClient(initializer, additionalAttributes);
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/FailingTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/FailingTest.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.integration.tests;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.EnumSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -71,8 +72,8 @@ public class FailingTest {
     public void sync_send_without_acknowleged() throws Exception {
         // Register client
         LockStepLwM2mClient client = new LockStepLwM2mClient(helper.server.getUnsecuredAddress());
-        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, null, BindingMode.U, null,
-                Link.parse("</1>,</2>,</3>".getBytes()), null));
+        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, "1.1", EnumSet.of(BindingMode.U),
+                null, null, Link.parse("</1>,</2>,</3>".getBytes()), null));
         client.expectResponse().go();
         helper.waitForRegistrationAtServerSide(1);
 
@@ -93,8 +94,8 @@ public class FailingTest {
     public void sync_send_with_acknowleged_request_without_response() throws Exception {
         // Register client
         LockStepLwM2mClient client = new LockStepLwM2mClient(helper.server.getUnsecuredAddress());
-        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, null, BindingMode.U, null,
-                Link.parse("</1>,</2>,</3>".getBytes()), null));
+        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, "1.1", EnumSet.of(BindingMode.U),
+                null, null, Link.parse("</1>,</2>,</3>".getBytes()), null));
         client.expectResponse().go();
         helper.waitForRegistrationAtServerSide(1);
 
@@ -122,8 +123,8 @@ public class FailingTest {
     public void async_send_without_acknowleged() throws Exception {
         // register client
         LockStepLwM2mClient client = new LockStepLwM2mClient(helper.server.getUnsecuredAddress());
-        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, null, BindingMode.U, null,
-                Link.parse("</1>,</2>,</3>".getBytes()), null));
+        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, "1.1", EnumSet.of(BindingMode.U),
+                null, null, Link.parse("</1>,</2>,</3>".getBytes()), null));
         client.expectResponse().go();
         helper.waitForRegistrationAtServerSide(1);
 
@@ -141,8 +142,8 @@ public class FailingTest {
     public void async_send_with_acknowleged_request_without_response() throws Exception {
         // register client
         LockStepLwM2mClient client = new LockStepLwM2mClient(helper.server.getUnsecuredAddress());
-        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, null, BindingMode.U, null,
-                Link.parse("</1>,</2>,</3>".getBytes()), null));
+        client.sendLwM2mRequest(new RegisterRequest(helper.getCurrentEndpoint(), 60l, "1.1", EnumSet.of(BindingMode.U),
+                null, null, Link.parse("</1>,</2>,</3>".getBytes()), null));
         client.expectResponse().go();
         helper.waitForRegistrationAtServerSide(1);
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -33,6 +32,7 @@ import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
+import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
@@ -47,7 +47,6 @@ import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.model.StaticModel;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
-import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.server.californium.LeshanServer;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
@@ -152,8 +151,8 @@ public class IntegrationTestHelper {
             super();
         }
 
-        public TestDevice(String manufacturer, String modelNumber, String serialNumber, String supportedBinding) {
-            super(manufacturer, modelNumber, serialNumber, supportedBinding);
+        public TestDevice(String manufacturer, String modelNumber, String serialNumber) {
+            super(manufacturer, modelNumber, serialNumber);
         }
 
         @Override
@@ -172,9 +171,8 @@ public class IntegrationTestHelper {
         initializer.setInstancesForObject(LwM2mId.SECURITY, Security.noSec(
                 "coap://" + server.getUnsecuredAddress().getHostString() + ":" + server.getUnsecuredAddress().getPort(),
                 12345));
-        initializer.setInstancesForObject(LwM2mId.SERVER,
-                new org.eclipse.leshan.client.object.Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
-        initializer.setInstancesForObject(LwM2mId.DEVICE, new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         initializer.setInstancesForObject(TEST_OBJECT_ID, new DummyInstanceEnabler(0),
                 new SimpleInstanceEnabler(1, OPAQUE_RESOURCE_ID, new byte[0]));

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/IntegrationTestHelper.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -172,7 +173,7 @@ public class IntegrationTestHelper {
                 "coap://" + server.getUnsecuredAddress().getHostString() + ":" + server.getUnsecuredAddress().getPort(),
                 12345));
         initializer.setInstancesForObject(LwM2mId.SERVER,
-                new org.eclipse.leshan.client.object.Server(12345, LIFETIME, BindingMode.U, false));
+                new org.eclipse.leshan.client.object.Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         initializer.setInstancesForObject(TEST_OBJECT_ID, new DummyInstanceEnabler(0),

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
@@ -18,11 +18,13 @@ package org.eclipse.leshan.integration.tests;
 
 import static org.junit.Assert.*;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
+import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
@@ -65,15 +67,16 @@ public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
         initializer.setInstancesForObject(LwM2mId.SECURITY, Security.noSec(
                 "coap://" + server.getUnsecuredAddress().getHostString() + ":" + server.getUnsecuredAddress().getPort(),
                 12345));
-        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.UQ, false));
-        initializer.setInstancesForObject(LwM2mId.DEVICE,
-                new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345", "UQ"));
+        initializer.setInstancesForObject(LwM2mId.SERVER,
+                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         initializer.setDummyInstancesForObject(2000);
         List<LwM2mObjectEnabler> objects = initializer.createAll();
 
         // Build Client
         LeshanClientBuilder builder = new LeshanClientBuilder(currentEndpointIdentifier.get());
+        builder.setRegistrationEngineFactory(new DefaultRegistrationEngineFactory().setQueueMode(true));
         builder.setObjects(objects);
         client = builder.build();
         setupClientMonitoring();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeIntegrationTestHelper.java
@@ -18,7 +18,6 @@ package org.eclipse.leshan.integration.tests;
 
 import static org.junit.Assert.*;
 
-import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -32,7 +31,6 @@ import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.model.StaticModel;
-import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.queue.StaticClientAwakeTimeProvider;
@@ -67,9 +65,8 @@ public class QueueModeIntegrationTestHelper extends IntegrationTestHelper {
         initializer.setInstancesForObject(LwM2mId.SECURITY, Security.noSec(
                 "coap://" + server.getUnsecuredAddress().getHostString() + ":" + server.getUnsecuredAddress().getPort(),
                 12345));
-        initializer.setInstancesForObject(LwM2mId.SERVER,
-                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
-        initializer.setInstancesForObject(LwM2mId.DEVICE, new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         initializer.setDummyInstancesForObject(2000);
         List<LwM2mObjectEnabler> objects = initializer.createAll();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
@@ -37,7 +37,6 @@ import java.security.spec.ECPoint;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.KeySpec;
-import java.util.EnumSet;
 import java.util.List;
 
 import javax.crypto.SecretKey;
@@ -62,7 +61,6 @@ import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.californium.EndpointFactory;
-import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.X509CertUtil;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
@@ -207,9 +205,8 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                         "coaps://" + server.getSecuredAddress().getHostString() + ":"
                                 + server.getSecuredAddress().getPort(),
                         12345, GOOD_PSK_ID.getBytes(StandardCharsets.UTF_8), GOOD_PSK_KEY));
-        initializer.setInstancesForObject(LwM2mId.SERVER,
-                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
-        initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345"));
         initializer.setDummyInstancesForObject(LwM2mId.ACCESS_CONTROL);
         List<LwM2mObjectEnabler> objects = initializer.createAll();
 
@@ -272,9 +269,8 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                 "coaps://" + server.getSecuredAddress().getHostString() + ":" + server.getSecuredAddress().getPort(),
                 12345, clientPublicKey.getEncoded(), clientPrivateKey.getEncoded(),
                 useServerCertificate ? serverX509Cert.getPublicKey().getEncoded() : serverPublicKey.getEncoded()));
-        initializer.setInstancesForObject(LwM2mId.SERVER,
-                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
-        initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         List<LwM2mObjectEnabler> objects = initializer.createAll();
 
@@ -318,9 +314,8 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                                 + server.getSecuredAddress().getPort(),
                         12345, clientCertificate.getEncoded(), privatekey.getEncoded(),
                         serverCertificate.getEncoded()));
-        initializer.setInstancesForObject(LwM2mId.SERVER,
-                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
-        initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         List<LwM2mObjectEnabler> objects = initializer.createAll();
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
@@ -37,6 +37,7 @@ import java.security.spec.ECPoint;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.KeySpec;
+import java.util.EnumSet;
 import java.util.List;
 
 import javax.crypto.SecretKey;
@@ -52,6 +53,7 @@ import org.eclipse.californium.scandium.dtls.PskPublicInformation;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
+import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.object.Server;
@@ -206,13 +208,14 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                                 + server.getSecuredAddress().getPort(),
                         12345, GOOD_PSK_ID.getBytes(StandardCharsets.UTF_8), GOOD_PSK_KEY));
         initializer.setInstancesForObject(LwM2mId.SERVER,
-                new Server(12345, LIFETIME, queueMode ? BindingMode.UQ : BindingMode.U, false));
+                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         initializer.setDummyInstancesForObject(LwM2mId.ACCESS_CONTROL);
         List<LwM2mObjectEnabler> objects = initializer.createAll();
 
         InetSocketAddress clientAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
         LeshanClientBuilder builder = new LeshanClientBuilder(getCurrentEndpoint());
+        builder.setRegistrationEngineFactory(new DefaultRegistrationEngineFactory().setQueueMode(queueMode));
         builder.setLocalAddress(clientAddress.getHostString(), clientAddress.getPort());
         builder.setObjects(objects);
         builder.setDtlsConfig(
@@ -269,7 +272,8 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                 "coaps://" + server.getSecuredAddress().getHostString() + ":" + server.getSecuredAddress().getPort(),
                 12345, clientPublicKey.getEncoded(), clientPrivateKey.getEncoded(),
                 useServerCertificate ? serverX509Cert.getPublicKey().getEncoded() : serverPublicKey.getEncoded()));
-        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.U, false));
+        initializer.setInstancesForObject(LwM2mId.SERVER,
+                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         List<LwM2mObjectEnabler> objects = initializer.createAll();
@@ -314,7 +318,8 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
                                 + server.getSecuredAddress().getPort(),
                         12345, clientCertificate.getEncoded(), privatekey.getEncoded(),
                         serverCertificate.getEncoded()));
-        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME, BindingMode.U, false));
+        initializer.setInstancesForObject(LwM2mId.SERVER,
+                new Server(12345, LIFETIME, EnumSet.of(BindingMode.U), false));
         initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345", "U"));
         initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
         List<LwM2mObjectEnabler> objects = initializer.createAll();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SynchronousRegistrationListener.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SynchronousRegistrationListener.java
@@ -34,6 +34,8 @@ public class SynchronousRegistrationListener implements RegistrationListener {
 
     @Override
     public void registered(Registration reg, Registration previousReg, Collection<Observation> previousObsersations) {
+        System.out.println(reg);
+
         if (accept(reg)) {
             lastRegistration = reg;
             registerLatch.countDown();
@@ -42,6 +44,7 @@ public class SynchronousRegistrationListener implements RegistrationListener {
 
     @Override
     public void updated(RegistrationUpdate update, Registration updatedReg, Registration previousReg) {
+        System.out.println(updatedReg);
         if (accept(updatedReg))
             updateLatch.countDown();
     }
@@ -49,6 +52,8 @@ public class SynchronousRegistrationListener implements RegistrationListener {
     @Override
     public void unregistered(Registration reg, Collection<Observation> observations, boolean expired,
             Registration newReg) {
+        System.out.println(reg);
+
         if (accept(reg))
             deregisterLatch.countDown();
     }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.server.californium.registration;
 
 import static org.eclipse.leshan.core.californium.ResponseCodeUtil.toCoapResponseCode;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,8 @@ public class RegisterResource extends LwM2mCoapResource {
     private static final String QUERY_PARAM_SMS = "sms=";
 
     private static final String QUERY_PARAM_LIFETIME = "lt=";
+
+    private static final String QUERY_PARAM_QUEUEMMODE = "Q"; // since LWM2M 1.1
 
     private static final Logger LOG = LoggerFactory.getLogger(RegisterResource.class);
 
@@ -128,7 +131,8 @@ public class RegisterResource extends LwM2mCoapResource {
         Long lifetime = null;
         String smsNumber = null;
         String lwVersion = null;
-        BindingMode binding = null;
+        EnumSet<BindingMode> binding = null;
+        Boolean queueMode = null;
 
         // Get object Links
         Link[] objectLinks = Link.parse(request.getPayload());
@@ -146,7 +150,9 @@ public class RegisterResource extends LwM2mCoapResource {
             } else if (param.startsWith(QUERY_PARAM_LWM2M_VERSION)) {
                 lwVersion = param.substring(6);
             } else if (param.startsWith(QUERY_PARAM_BINDING_MODE)) {
-                binding = BindingMode.valueOf(param.substring(2));
+                binding = BindingMode.parse(param.substring(2));
+            } else if (param.equals(QUERY_PARAM_QUEUEMMODE)) {
+                queueMode = true;
             } else {
                 String[] tokens = param.split("\\=");
                 if (tokens != null && tokens.length == 2) {
@@ -156,8 +162,8 @@ public class RegisterResource extends LwM2mCoapResource {
         }
 
         // Create request
-        RegisterRequest registerRequest = new RegisterRequest(endpoint, lifetime, lwVersion, binding, smsNumber,
-                objectLinks, additionalParams);
+        RegisterRequest registerRequest = new RegisterRequest(endpoint, lifetime, lwVersion, binding, queueMode,
+                smsNumber, objectLinks, additionalParams);
 
         // Handle request
         // -------------------------------
@@ -183,7 +189,7 @@ public class RegisterResource extends LwM2mCoapResource {
         // Create LwM2m request from CoAP request
         Long lifetime = null;
         String smsNumber = null;
-        BindingMode binding = null;
+        EnumSet<BindingMode> binding = null;
         Link[] objectLinks = null;
         Map<String, String> additionalParams = new HashMap<>();
 
@@ -193,7 +199,7 @@ public class RegisterResource extends LwM2mCoapResource {
             } else if (param.startsWith(QUERY_PARAM_SMS)) {
                 smsNumber = param.substring(4);
             } else if (param.startsWith(QUERY_PARAM_BINDING_MODE)) {
-                binding = BindingMode.valueOf(param.substring(2));
+                binding = BindingMode.parse(param.substring(2));
             } else {
                 String[] tokens = param.split("\\=");
                 if (tokens != null && tokens.length == 2) {

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerTest.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.server.californium;
 import static org.junit.Assert.assertEquals;
 
 import java.net.InetSocketAddress;
+import java.util.EnumSet;
 
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.Identity;
@@ -82,7 +83,7 @@ public class LeshanServerTest {
 
     private void forceThreadsCreation(LeshanServer server) {
         Registration reg = new Registration.Builder("id", "endpoint", Identity.unsecure(new InetSocketAddress(5555)))
-                .bindingMode(BindingMode.UQ).build();
+                .bindingMode(EnumSet.of(BindingMode.U, BindingMode.Q)).build();
         // Force timer thread creation of preference service.
         ((PresenceServiceImpl) server.getPresenceService()).setAwake(reg);
         // Force time thread creation of CoapAsyncRequestObserver

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/registration/InMemoryRegistrationStoreTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/registration/InMemoryRegistrationStoreTest.java
@@ -17,11 +17,11 @@ package org.eclipse.leshan.server.californium.registration;
 
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
 
 import org.eclipse.leshan.core.Link;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.Identity;
-import org.eclipse.leshan.server.californium.registration.InMemoryRegistrationStore;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.RegistrationStore;
 import org.eclipse.leshan.server.registration.RegistrationUpdate;
@@ -38,7 +38,7 @@ public class InMemoryRegistrationStoreTest {
     int port = 23452;
     Long lifetime = 10000L;
     String sms = "0171-32423545";
-    BindingMode binding = BindingMode.UQS;
+    EnumSet<BindingMode> binding = EnumSet.of(BindingMode.U, BindingMode.Q, BindingMode.S);
     Link[] objectLinks = Link.parse("</3>".getBytes(StandardCharsets.UTF_8));
     String registrationId = "4711";
     Registration registration;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.server.bootstrap;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,7 @@ public class BootstrapConfig implements Serializable {
          * This Resource defines the transport binding configured for the LwM2M Client. If the LwM2M Client supports the
          * binding specified in this Resource, the LwM2M Client MUST use that transport for the Current Binding Mode.
          */
-        public BindingMode binding = BindingMode.U;
+        public EnumSet<BindingMode> binding = EnumSet.of(BindingMode.U);
 
         @Override
         public String toString() {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
@@ -27,6 +27,7 @@ import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
@@ -89,7 +90,7 @@ public class BootstrapUtil {
             resources.add(LwM2mSingleResource.newIntegerResource(5, serverConfig.disableTimeout));
         resources.add(LwM2mSingleResource.newBooleanResource(6, serverConfig.notifIfDisabled));
         if (serverConfig.binding != null)
-            resources.add(LwM2mSingleResource.newStringResource(7, serverConfig.binding.name()));
+            resources.add(LwM2mSingleResource.newStringResource(7, BindingMode.toString(serverConfig.binding)));
 
         return new LwM2mObjectInstance(instanceId, resources);
     }
@@ -121,13 +122,12 @@ public class BootstrapUtil {
         return new BootstrapWriteRequest(path, securityInstance, contentFormat);
     }
 
-    public static List<BootstrapDownlinkRequest<? extends LwM2mResponse>> toRequests(
-            BootstrapConfig bootstrapConfig) {
+    public static List<BootstrapDownlinkRequest<? extends LwM2mResponse>> toRequests(BootstrapConfig bootstrapConfig) {
         return toRequests(bootstrapConfig, ContentFormat.TLV);
     }
 
-    public static List<BootstrapDownlinkRequest<? extends LwM2mResponse>> toRequests(
-            BootstrapConfig bootstrapConfig, ContentFormat contentFormat) {
+    public static List<BootstrapDownlinkRequest<? extends LwM2mResponse>> toRequests(BootstrapConfig bootstrapConfig,
+            ContentFormat contentFormat) {
         List<BootstrapDownlinkRequest<? extends LwM2mResponse>> requests = new ArrayList<>();
         // handle delete
         for (String path : bootstrapConfig.toDelete) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -56,8 +56,9 @@ public class RegistrationHandler {
                 registrationIdProvider.getRegistrationId(registerRequest), registerRequest.getEndpointName(), sender);
 
         builder.lwM2mVersion(registerRequest.getLwVersion()).lifeTimeInSec(registerRequest.getLifetime())
-                .bindingMode(registerRequest.getBindingMode()).objectLinks(registerRequest.getObjectLinks())
-                .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
+                .bindingMode(registerRequest.getBindingMode()).queueMode(registerRequest.getQueueMode())
+                .objectLinks(registerRequest.getObjectLinks()).smsNumber(registerRequest.getSmsNumber())
+                .registrationDate(new Date()).lastUpdate(new Date())
                 .additionalRegistrationAttributes(registerRequest.getAdditionalAttributes());
 
         // We must check if the client is using the right identity.
@@ -99,6 +100,9 @@ public class RegistrationHandler {
         if (authorizer.isAuthorized(updateRequest, registration, sender) == null) {
             return new SendableResponse<>(UpdateResponse.badRequest("forbidden"));
         }
+
+        // validate request
+        updateRequest.validate(registration.getLwM2mVersion());
 
         // Create update
         final RegistrationUpdate update = new RegistrationUpdate(updateRequest.getRegistrationId(), sender,

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,12 +39,12 @@ public class RegistrationUpdate {
     private final Identity identity;
     private final Long lifeTimeInSec;
     private final String smsNumber;
-    private final BindingMode bindingMode;
+    private final EnumSet<BindingMode> bindingMode;
     private final Link[] objectLinks;
     private final Map<String, String> additionalAttributes;
 
     public RegistrationUpdate(String registrationId, Identity identity, Long lifeTimeInSec, String smsNumber,
-            BindingMode bindingMode, Link[] objectLinks, Map<String, String> additionalAttributes) {
+            EnumSet<BindingMode> bindingMode, Link[] objectLinks, Map<String, String> additionalAttributes) {
         Validate.notNull(registrationId);
         Validate.notNull(identity);
         this.registrationId = registrationId;
@@ -68,7 +69,7 @@ public class RegistrationUpdate {
         Identity identity = this.identity != null ? this.identity : registration.getIdentity();
         Link[] linkObject = this.objectLinks != null ? this.objectLinks : registration.getObjectLinks();
         long lifeTimeInSec = this.lifeTimeInSec != null ? this.lifeTimeInSec : registration.getLifeTimeInSec();
-        BindingMode bindingMode = this.bindingMode != null ? this.bindingMode : registration.getBindingMode();
+        EnumSet<BindingMode> bindingMode = this.bindingMode != null ? this.bindingMode : registration.getBindingMode();
         String smsNumber = this.smsNumber != null ? this.smsNumber : registration.getSmsNumber();
 
         Map<String, String> additionalAttributes = this.additionalAttributes.isEmpty()
@@ -83,8 +84,9 @@ public class RegistrationUpdate {
                 identity);
 
         builder.lwM2mVersion(registration.getLwM2mVersion()).lifeTimeInSec(lifeTimeInSec).smsNumber(smsNumber)
-                .bindingMode(bindingMode).objectLinks(linkObject).registrationDate(registration.getRegistrationDate())
-                .lastUpdate(lastUpdate).additionalRegistrationAttributes(additionalAttributes);
+                .bindingMode(bindingMode).queueMode(registration.getQueueMode()).objectLinks(linkObject)
+                .registrationDate(registration.getRegistrationDate()).lastUpdate(lastUpdate)
+                .additionalRegistrationAttributes(additionalAttributes);
 
         return builder.build();
 
@@ -114,7 +116,7 @@ public class RegistrationUpdate {
         return smsNumber;
     }
 
-    public BindingMode getBindingMode() {
+    public EnumSet<BindingMode> getBindingMode() {
         return bindingMode;
     }
 

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/PresenceServiceTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/PresenceServiceTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
+import java.util.EnumSet;
 
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.Identity;
@@ -74,7 +75,7 @@ public class PresenceServiceTest {
         Registration.Builder builder = new Registration.Builder("ID", "urn:client",
                 Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354));
 
-        Registration reg = builder.bindingMode(BindingMode.UQ).build();
+        Registration reg = builder.bindingMode(EnumSet.of(BindingMode.U, BindingMode.Q)).build();
         presenceService.setAwake(reg);
         return reg;
     }

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/RegistrationSerializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/RegistrationSerializer.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.server.demo.servlet.json;
 
 import java.lang.reflect.Type;
 
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.server.queue.PresenceService;
 import org.eclipse.leshan.server.registration.Registration;
 
@@ -45,7 +46,7 @@ public class RegistrationSerializer implements JsonSerializer<Registration> {
         element.addProperty("smsNumber", src.getSmsNumber());
         element.addProperty("lwM2mVersion", src.getLwM2mVersion());
         element.addProperty("lifetime", src.getLifeTimeInSec());
-        element.addProperty("bindingMode", src.getBindingMode().toString());
+        element.addProperty("bindingMode", BindingMode.toString(src.getBindingMode()));
         element.add("rootPath", context.serialize(src.getRootPath()));
         element.add("objectLinks", context.serialize(src.getSortedObjectLinks()));
         element.add("secure", context.serialize(src.getIdentity().isSecure()));

--- a/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
+++ b/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
@@ -43,7 +43,9 @@ public class RegistrationSerDes {
             o.add("sms", r.getSmsNumber());
         }
         o.add("ver", r.getLwM2mVersion());
-        o.add("bnd", r.getBindingMode().name());
+        o.add("bnd", BindingMode.toString(r.getBindingMode()));
+        if (r.getQueueMode() != null)
+            o.add("qm", r.getQueueMode());
         o.add("ep", r.getEndpoint());
         o.add("regId", r.getId());
 
@@ -84,7 +86,9 @@ public class RegistrationSerDes {
     public static Registration deserialize(JsonObject jObj) {
         Registration.Builder b = new Registration.Builder(jObj.getString("regId", null), jObj.getString("ep", null),
                 IdentitySerDes.deserialize(jObj.get("identity").asObject()));
-        b.bindingMode(BindingMode.valueOf(jObj.getString("bnd", null)));
+        b.bindingMode(BindingMode.parse(jObj.getString("bnd", null)));
+        if (jObj.get("qm") != null)
+            b.queueMode(jObj.getBoolean("qm", false));
         b.lastUpdate(new Date(jObj.getLong("lastUp", 0)));
         b.lifeTimeInSec(jObj.getLong("lt", 0));
         b.lwM2mVersion(jObj.getString("ver", Version.getDefault().toString()));


### PR DESCRIPTION
There is several changes in LWM2M 1.1 about binding mode : 
- new mode was added (T,N)
- QueueMode is not part of binding mode anymore but has it own parameter.

This PR aims to support new format, trying to keep compatible with LWM2M 1.0.

[Here](https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/490#issuecomment-706995813) some discussion about LWM2M changes about Binding Mode.

(I will maybe add  test about that to this PR)