### PR TITLE
Add `shutdownTrigger` for registration engine

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -58,6 +58,11 @@ import org.slf4j.LoggerFactory;
 public class LeshanClient implements LwM2mClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(LeshanClient.class);
+    private static final Runnable NOP_SHUTDOWN_TRIGGER = new Runnable() {
+        @Override
+        public void run() {
+        }
+    };
 
     private final CoapAPI coapApi;
     private final CoapServer coapServer;
@@ -85,7 +90,7 @@ public class LeshanClient implements LwM2mClient {
             Map<String, String> additionalAttributes, Map<String, String> bsAdditionalAttributes,
             LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder, ScheduledExecutorService sharedExecutor) {
         this(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder, null, endpointFactory,
-                engineFactory, additionalAttributes, bsAdditionalAttributes, encoder, decoder, sharedExecutor);
+                engineFactory, additionalAttributes, bsAdditionalAttributes, encoder, decoder, sharedExecutor, NOP_SHUTDOWN_TRIGGER);
     }
 
     /** @since 2.0 */
@@ -93,7 +98,7 @@ public class LeshanClient implements LwM2mClient {
             List<? extends LwM2mObjectEnabler> objectEnablers, NetworkConfig coapConfig, Builder dtlsConfigBuilder, List<Certificate> trustStore,
             EndpointFactory endpointFactory, RegistrationEngineFactory engineFactory,
             Map<String, String> additionalAttributes, Map<String, String> bsAdditionalAttributes,
-            LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder, ScheduledExecutorService sharedExecutor) {
+            LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder, ScheduledExecutorService sharedExecutor, Runnable shutdownTrigger) {
 
         Validate.notNull(endpoint);
         Validate.notEmpty(objectEnablers);
@@ -105,7 +110,7 @@ public class LeshanClient implements LwM2mClient {
         endpointsManager = createEndpointsManager(localAddress, coapConfig, dtlsConfigBuilder, trustStore, endpointFactory);
         requestSender = createRequestSender(endpointsManager, sharedExecutor);
         engine = engineFactory.createRegistratioEngine(endpoint, objectTree, endpointsManager, requestSender,
-                bootstrapHandler, observers, additionalAttributes, bsAdditionalAttributes, sharedExecutor);
+                bootstrapHandler, observers, additionalAttributes, bsAdditionalAttributes, sharedExecutor, shutdownTrigger);
 
         coapServer = createCoapServer(coapConfig, sharedExecutor);
         coapServer.add(createBootstrapResource(engine, bootstrapHandler));

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -77,6 +77,12 @@ public class LeshanClientBuilder {
     /** @since 1.1 */
     protected Map<String, String> bsAdditionalAttributes;
 
+    private Runnable shutdownTrigger = new Runnable() {
+        @Override
+        public void run() {
+        }
+    };
+
     /**
      * Creates a new instance for setting the configuration options for a {@link LeshanClient} instance.
      * 
@@ -218,6 +224,16 @@ public class LeshanClientBuilder {
     }
 
     /**
+     * Set the shutdown trigger that called on unexpected exception has been occurred.
+     *
+     * The default value is NOP procedure.
+     */
+    public LeshanClientBuilder setShutdownTrigger(Runnable shutdownTrigger) {
+        this.shutdownTrigger = shutdownTrigger;
+        return this;
+    }
+
+    /**
      * Set a shared executor. This executor will be used everywhere it is possible. This is generally used when you want
      * to limit the number of thread to use or if you want to simulate a lot of clients sharing the same thread pool.
      * <p>
@@ -324,7 +340,8 @@ public class LeshanClientBuilder {
         }
 
         return createLeshanClient(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder,
-                this.trustStore, endpointFactory, engineFactory, additionalAttributes, encoder, decoder, executor);
+                this.trustStore, endpointFactory, engineFactory, additionalAttributes, encoder, decoder, executor,
+                shutdownTrigger);
     }
 
     /**
@@ -355,9 +372,9 @@ public class LeshanClientBuilder {
             List<? extends LwM2mObjectEnabler> objectEnablers, NetworkConfig coapConfig, Builder dtlsConfigBuilder,
             List<Certificate> trustStore, EndpointFactory endpointFactory, RegistrationEngineFactory engineFactory,
             Map<String, String> additionalAttributes, LwM2mNodeEncoder encoder, LwM2mNodeDecoder decoder,
-            ScheduledExecutorService sharedExecutor) {
+            ScheduledExecutorService sharedExecutor, Runnable shutdownTrigger) {
         return new LeshanClient(endpoint, localAddress, objectEnablers, coapConfig, dtlsConfigBuilder, trustStore,
                 endpointFactory, engineFactory, additionalAttributes, bsAdditionalAttributes, encoder, decoder,
-                executor);
+                executor, shutdownTrigger);
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngineFactory.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngineFactory.java
@@ -47,11 +47,12 @@ public class DefaultRegistrationEngineFactory implements RegistrationEngineFacto
     public RegistrationEngine createRegistratioEngine(String endpoint, LwM2mObjectTree objectTree,
             EndpointsManager endpointsManager, LwM2mRequestSender requestSender, BootstrapHandler bootstrapState,
             LwM2mClientObserver observer, Map<String, String> additionalAttributes,
-            Map<String, String> bsAdditionalAttributes, ScheduledExecutorService sharedExecutor) {
+            Map<String, String> bsAdditionalAttributes, ScheduledExecutorService sharedExecutor,
+            Runnable shutdownTrigger) {
         return new DefaultRegistrationEngine(endpoint, objectTree, endpointsManager, requestSender, bootstrapState,
                 observer, additionalAttributes, bsAdditionalAttributes, sharedExecutor, requestTimeoutInMs,
                 deregistrationTimeoutInMs, bootstrapSessionTimeoutInSec, retryWaitingTimeInMs, communicationPeriodInMs,
-                reconnectOnUpdate, resumeOnConnect, queueMode);
+                reconnectOnUpdate, resumeOnConnect, queueMode, shutdownTrigger);
     }
 
     /**

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/RegistrationEngineFactory.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/RegistrationEngineFactory.java
@@ -32,5 +32,6 @@ public interface RegistrationEngineFactory {
     RegistrationEngine createRegistratioEngine(String endpoint, LwM2mObjectTree objectTree,
             EndpointsManager endpointsManager, LwM2mRequestSender requestSender, BootstrapHandler bootstrapState,
             LwM2mClientObserver observer, Map<String, String> additionalAttributes,
-            Map<String, String> bsAdditionalAttributes, ScheduledExecutorService sharedExecutor);
+            Map<String, String> bsAdditionalAttributes, ScheduledExecutorService sharedExecutor,
+            Runnable shutdownTrigger);
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
@@ -31,9 +31,11 @@ public class MyDevice extends BaseInstanceEnabler {
     private static final List<Integer> supportedResources = Arrays.asList(0, 1, 2, 3, 9, 10, 11, 13, 14, 15, 16, 17, 18,
             19, 20, 21);
 
+    private final Timer timer;
+
     public MyDevice() {
         // notify new date each 5 second
-        Timer timer = new Timer("Device-Current Time");
+        timer = new Timer("Device-Current Time");
         timer.schedule(new TimerTask() {
             @Override
             public void run() {
@@ -209,5 +211,9 @@ public class MyDevice extends BaseInstanceEnabler {
     @Override
     public List<Integer> getAvailableResourceIds(ObjectModel model) {
         return supportedResources;
+    }
+
+    public void cancel() {
+        timer.cancel();
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
@@ -113,4 +113,8 @@ public class RandomTemperatureSensor extends BaseInstanceEnabler {
     public List<Integer> getAvailableResourceIds(ObjectModel model) {
         return supportedResources;
     }
+
+    public void shutdown() {
+        scheduler.shutdown();
+    }
 }


### PR DESCRIPTION
Hello,

If the procedure inside of `ClientInitiatedBootstrapTask`, `UpdateRegistrationTask`, and/or `RegistrationTask` raises an unexpected exception, that exception caught by a `catch` clause and it logs that, but that task never works after caught and unfortunately the process still alive.
For example, if `registerWithRetry()` that is in `RegistrationTask#run()` raises a `RuntimeException`, that task never scheduled anymore.
This behavior makes a little bit hard to implement a robust LwM2M client. I think it would be better to exit when it falls an unexpected situation, as like as "let it crash".
So this patch introduces the `shutdownTrigger` mechanism to shut down the client when an unexpected exception occurred. `shutdownTrigger` is an implementation of `Runnable`, so the user can hand over the user-defined shutdown procedure to the registration engine.