### PR TITLE
Add callback mechanism into LwM2mClientObserver for when the unexpected error occurred

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -325,8 +325,7 @@ public class LeshanClient implements LwM2mClient {
         return endpointsManager.getEndpoint(server).getAddress();
     }
 
-    private static class ShutdownOnUnexpectedErrorObserver extends
-        LwM2mClientObserverAdapter {
+    private static class ShutdownOnUnexpectedErrorObserver extends LwM2mClientObserverAdapter {
         final LeshanClient client;
 
         public ShutdownOnUnexpectedErrorObserver(final LeshanClient client) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
@@ -526,6 +526,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
                     LOG.info("Bootstrap task interrupted. ");
                 } catch (RuntimeException e) {
                     LOG.error("Unexpected exception during bootstrap task", e);
+                    observer.onUnexpectedErrorOccurred(e);
                 }
             }
         }
@@ -564,6 +565,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
                     LOG.info("Registration task interrupted. ");
                 } catch (RuntimeException e) {
                     LOG.error("Unexpected exception during registration task", e);
+                    observer.onUnexpectedErrorOccurred(e);
                 }
             }
         }
@@ -612,6 +614,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
                     LOG.info("Registration update task interrupted.");
                 } catch (RuntimeException e) {
                     LOG.error("Unexpected exception during update registration task", e);
+                    observer.onUnexpectedErrorOccurred(e);
                 }
             }
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/DefaultRegistrationEngine.java
@@ -526,7 +526,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
                     LOG.info("Bootstrap task interrupted. ");
                 } catch (RuntimeException e) {
                     LOG.error("Unexpected exception during bootstrap task", e);
-                    observer.onUnexpectedErrorOccurred(e);
+                    observer.onUnexpectedError(e);
                 }
             }
         }
@@ -565,7 +565,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
                     LOG.info("Registration task interrupted. ");
                 } catch (RuntimeException e) {
                     LOG.error("Unexpected exception during registration task", e);
-                    observer.onUnexpectedErrorOccurred(e);
+                    observer.onUnexpectedError(e);
                 }
             }
         }
@@ -614,7 +614,7 @@ public class DefaultRegistrationEngine implements RegistrationEngine {
                     LOG.info("Registration update task interrupted.");
                 } catch (RuntimeException e) {
                     LOG.error("Unexpected exception during update registration task", e);
-                    observer.onUnexpectedErrorOccurred(e);
+                    observer.onUnexpectedError(e);
                 }
             }
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserver.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserver.java
@@ -69,4 +69,8 @@ public interface LwM2mClientObserver {
             String errorMessage, Exception cause);
 
     void onDeregistrationTimeout(ServerIdentity server, DeregisterRequest request);
+
+    // ============== Unexpected Error Handling =================
+
+    void onUnexpectedErrorOccurred(Throwable unexpectedError);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserver.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserver.java
@@ -72,5 +72,5 @@ public interface LwM2mClientObserver {
 
     // ============== Unexpected Error Handling =================
 
-    void onUnexpectedErrorOccurred(Throwable unexpectedError);
+    void onUnexpectedError(Throwable unexpectedError);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverAdapter.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverAdapter.java
@@ -95,4 +95,8 @@ public class LwM2mClientObserverAdapter implements LwM2mClientObserver {
     @Override
     public void onDeregistrationTimeout(ServerIdentity server, DeregisterRequest request) {
     }
+
+    @Override
+    public void onUnexpectedErrorOccurred(Throwable unexpectedError) {
+    }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverAdapter.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverAdapter.java
@@ -97,6 +97,6 @@ public class LwM2mClientObserverAdapter implements LwM2mClientObserver {
     }
 
     @Override
-    public void onUnexpectedErrorOccurred(Throwable unexpectedError) {
+    public void onUnexpectedError(Throwable unexpectedError) {
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverDispatcher.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverDispatcher.java
@@ -151,4 +151,10 @@ public class LwM2mClientObserverDispatcher implements LwM2mClientObserver {
         }
     }
 
+    @Override
+    public void onUnexpectedErrorOccurred(Throwable unexpectedError) {
+        for (LwM2mClientObserver observer : observers) {
+            observer.onUnexpectedErrorOccurred(unexpectedError);
+        }
+    }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverDispatcher.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverDispatcher.java
@@ -152,9 +152,9 @@ public class LwM2mClientObserverDispatcher implements LwM2mClientObserver {
     }
 
     @Override
-    public void onUnexpectedErrorOccurred(Throwable unexpectedError) {
+    public void onUnexpectedError(Throwable unexpectedError) {
         for (LwM2mClientObserver observer : observers) {
-            observer.onUnexpectedErrorOccurred(unexpectedError);
+            observer.onUnexpectedError(unexpectedError);
         }
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mInstanceEnabler.java
@@ -22,6 +22,9 @@ import java.util.List;
 
 import org.eclipse.leshan.client.LwM2mClient;
 import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.Destroyable;
+import org.eclipse.leshan.core.Startable;
+import org.eclipse.leshan.core.Stoppable;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mResource;
@@ -45,6 +48,12 @@ import org.eclipse.leshan.core.response.WriteResponse;
  * <p>
  * Implementations of this interface should adhere to the definition of the implemented LWM2M Object type regarding
  * acceptable resource IDs for the <code>read, write</code> and <code>execute</code> methods.
+ * An instance that implements this interface synchronizes with the lifecycle of the LeshanClient. This means when
+ * <p>
+ * {@code LeshanClient#destroy()} is called, {@code LwM2mInstanceEnabler#destroy()} is also called if it implements the
+ * {@link Destroyable} interface. And {@link Startable} ({@code #start()}) and {@link Stoppable} ({@code #stop()}) are
+ * also same as this. If you need to restart the instance, please implement {@link Startable} with {@link Stoppable}
+ * together.
  */
 public interface LwM2mInstanceEnabler {
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -28,7 +28,10 @@ import java.util.Map.Entry;
 import org.eclipse.leshan.client.LwM2mClient;
 import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.client.servers.ServersInfoExtractor;
+import org.eclipse.leshan.core.Destroyable;
 import org.eclipse.leshan.core.LwM2mId;
+import org.eclipse.leshan.core.Startable;
+import org.eclipse.leshan.core.Stoppable;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.LwM2mObject;
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
@@ -62,7 +65,7 @@ import org.eclipse.leshan.core.response.WriteResponse;
  * Implementing a {@link LwM2mInstanceEnabler} then creating an {@link ObjectEnabler} with {@link ObjectsInitializer} is
  * the easier way to implement LWM2M object in Leshan client.
  */
-public class ObjectEnabler extends BaseObjectEnabler {
+public class ObjectEnabler extends BaseObjectEnabler implements Destroyable, Startable, Stoppable{
 
     protected Map<Integer, LwM2mInstanceEnabler> instances;
     protected LwM2mInstanceEnablerFactory instanceFactory;
@@ -409,6 +412,35 @@ public class ObjectEnabler extends BaseObjectEnabler {
     public void setLwM2mClient(LwM2mClient client) {
         for (LwM2mInstanceEnabler instanceEnabler : instances.values()) {
             instanceEnabler.setLwM2mClient(client);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        for (LwM2mInstanceEnabler instanceEnabler : instances.values()) {
+            if (instanceEnabler instanceof Destroyable) {
+                ((Destroyable) instanceEnabler).destroy();
+            } else if (instanceEnabler instanceof Stoppable) {
+                ((Stoppable) instanceEnabler).stop();
+            }
+        }
+    }
+
+    @Override
+    public void start() {
+        for (LwM2mInstanceEnabler instanceEnabler : instances.values()) {
+            if (instanceEnabler instanceof Startable) {
+                ((Startable) instanceEnabler).start();
+            }
+        }
+    }
+
+    @Override
+    public void stop() {
+        for (LwM2mInstanceEnabler instanceEnabler : instances.values()) {
+            if (instanceEnabler instanceof Stoppable) {
+                ((Stoppable) instanceEnabler).stop();
+            }
         }
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -65,7 +65,7 @@ import org.eclipse.leshan.core.response.WriteResponse;
  * Implementing a {@link LwM2mInstanceEnabler} then creating an {@link ObjectEnabler} with {@link ObjectsInitializer} is
  * the easier way to implement LWM2M object in Leshan client.
  */
-public class ObjectEnabler extends BaseObjectEnabler implements Destroyable, Startable, Stoppable{
+public class ObjectEnabler extends BaseObjectEnabler implements Destroyable, Startable, Stoppable {
 
     protected Map<Integer, LwM2mInstanceEnabler> instances;
     protected LwM2mInstanceEnablerFactory instanceFactory;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -895,7 +895,7 @@ public class LeshanClientDemo {
         }
 
         @Override
-        public void onUnexpectedErrorOccurred(Throwable unexpectedError) {
+        public void onUnexpectedError(Throwable unexpectedError) {
             LOG.error("unexpected error occurred", unexpectedError);
             client.destroy(true);
             myDevice.destroy();

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -624,11 +624,9 @@ public class LeshanClientDemo {
                 initializer.setInstancesForObject(SERVER, new Server(123, lifetime));
             }
         }
-        final MyDevice myDevice = new MyDevice();
-        final RandomTemperatureSensor randomTemperatureSensor = new RandomTemperatureSensor();
-        initializer.setInstancesForObject(DEVICE, myDevice);
+        initializer.setInstancesForObject(DEVICE, new MyDevice());
         initializer.setInstancesForObject(LOCATION, locationInstance);
-        initializer.setInstancesForObject(OBJECT_ID_TEMPERATURE_SENSOR, randomTemperatureSensor);
+        initializer.setInstancesForObject(OBJECT_ID_TEMPERATURE_SENSOR, new RandomTemperatureSensor());
         List<LwM2mObjectEnabler> enablers = initializer.createAll();
 
         // Create CoAP Config
@@ -748,8 +746,7 @@ public class LeshanClientDemo {
         builder.setBootstrapAdditionalAttributes(bsAdditionalAttributes);
         final LeshanClient client = builder.build();
 
-        client.addObserver(
-            new ClientShutdownOnUnexpectedErrorObserver(client, myDevice, randomTemperatureSensor));
+        client.addObserver(new ClientShutdownOnUnexpectedErrorObserver(client));
 
         client.getObjectTree().addListener(new ObjectsListenerAdapter() {
             @Override
@@ -881,25 +878,15 @@ public class LeshanClientDemo {
 
     private static class ClientShutdownOnUnexpectedErrorObserver extends LwM2mClientObserverAdapter {
         final LeshanClient client;
-        final MyDevice myDevice;
-        final RandomTemperatureSensor randomTemperatureSensor;
 
-        public ClientShutdownOnUnexpectedErrorObserver(
-            final LeshanClient client,
-			final MyDevice myDevice,
-            final RandomTemperatureSensor randomTemperatureSensor
-        ) {
+        public ClientShutdownOnUnexpectedErrorObserver(final LeshanClient client) {
             this.client = client;
-            this.myDevice = myDevice;
-            this.randomTemperatureSensor = randomTemperatureSensor;
         }
 
         @Override
         public void onUnexpectedError(Throwable unexpectedError) {
             LOG.error("unexpected error occurred", unexpectedError);
             client.destroy(true);
-            myDevice.destroy();
-            randomTemperatureSensor.destroy();
         }
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -746,8 +746,6 @@ public class LeshanClientDemo {
         builder.setBootstrapAdditionalAttributes(bsAdditionalAttributes);
         final LeshanClient client = builder.build();
 
-        client.addObserver(new ClientShutdownOnUnexpectedErrorObserver(client));
-
         client.getObjectTree().addListener(new ObjectsListenerAdapter() {
             @Override
             public void objectRemoved(LwM2mObjectEnabler object) {
@@ -873,20 +871,6 @@ public class LeshanClientDemo {
                     LOG.info("Unknown command '{}'", command);
                 }
             }
-        }
-    }
-
-    private static class ClientShutdownOnUnexpectedErrorObserver extends LwM2mClientObserverAdapter {
-        final LeshanClient client;
-
-        public ClientShutdownOnUnexpectedErrorObserver(final LeshanClient client) {
-            this.client = client;
-        }
-
-        @Override
-        public void onUnexpectedError(Throwable unexpectedError) {
-            LOG.error("unexpected error occurred", unexpectedError);
-            client.destroy(true);
         }
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -59,7 +59,6 @@ import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Server;
-import org.eclipse.leshan.client.observer.LwM2mClientObserverAdapter;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
@@ -14,6 +14,7 @@ import java.util.TimerTask;
 
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.Destroyable;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mResource;
@@ -23,7 +24,7 @@ import org.eclipse.leshan.core.response.WriteResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MyDevice extends BaseInstanceEnabler {
+public class MyDevice extends BaseInstanceEnabler implements Destroyable {
 
     private static final Logger LOG = LoggerFactory.getLogger(MyDevice.class);
 
@@ -31,9 +32,11 @@ public class MyDevice extends BaseInstanceEnabler {
     private static final List<Integer> supportedResources = Arrays.asList(0, 1, 2, 3, 9, 10, 11, 13, 14, 15, 16, 17, 18,
             19, 20, 21);
 
+    private final Timer timer;
+
     public MyDevice() {
         // notify new date each 5 second
-        Timer timer = new Timer("Device-Current Time");
+        this.timer = new Timer("Device-Current Time");
         timer.schedule(new TimerTask() {
             @Override
             public void run() {
@@ -209,5 +212,10 @@ public class MyDevice extends BaseInstanceEnabler {
     @Override
     public List<Integer> getAvailableResourceIds(ObjectModel model) {
         return supportedResources;
+    }
+
+    @Override
+    public void destroy() {
+        timer.cancel();
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.Destroyable;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -18,7 +19,7 @@ import org.eclipse.leshan.core.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RandomTemperatureSensor extends BaseInstanceEnabler {
+public class RandomTemperatureSensor extends BaseInstanceEnabler implements Destroyable {
 
     private static final Logger LOG = LoggerFactory.getLogger(RandomTemperatureSensor.class);
 
@@ -112,5 +113,10 @@ public class RandomTemperatureSensor extends BaseInstanceEnabler {
     @Override
     public List<Integer> getAvailableResourceIds(ObjectModel model) {
         return supportedResources;
+    }
+
+    @Override
+    public void destroy() {
+        scheduler.shutdown();
     }
 }


### PR DESCRIPTION
Ref #933 

## Done

- Add `onUnexpectedErrorOccurred()` method to `LwM2mClientObserver` interface
- Call `LwM2mClientObserver#onUnexpectedErrorOccurred()` on `DefaultRegistrationEngine` when it raises `RuntimeException` at task loop.
- Support this error handling system on the client demo project