### PR TITLE
Support client bootstrapping to receive OSCORE security information

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
@@ -97,11 +97,17 @@ public class BootstrapConfigSecurityStore implements BootstrapSecurityStore {
         // TODO this should be done via OSCORE store ?
         // Extract OSCORE security info
         if (bsConfig != null && bsConfig.oscore != null && !bsConfig.oscore.isEmpty()) {
-            LOG.trace("Extracting OSCORE security info for endpoint {}", endpoint);
+            LOG.trace("Looking for OSCORE security info for endpoint {}", endpoint);
 
             // First find the context for this endpoint
-            for (Map.Entry<Integer, BootstrapConfig.OscoreObject> oscoreEntry : bsConfig.oscore.entrySet()) {
-                OscoreObject value = oscoreEntry.getValue();
+            for (Map.Entry<Integer, BootstrapConfig.ServerSecurity> bsEntry : bsConfig.security.entrySet()) {
+                // Only find contexts for BS-Client connections
+                Integer bsOscoreSecurityMode = bsEntry.getValue().oscoreSecurityMode;
+                if (!bsEntry.getValue().bootstrapServer || bsOscoreSecurityMode == null) {
+                    continue;
+                }
+
+                OscoreObject value = bsConfig.oscore.get(bsOscoreSecurityMode);
 
                 HashMapCtxDB db = OscoreHandler.getContextDB();
                 byte[] rid = Hex.decodeHex(value.oscoreRecipientId.toCharArray());

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap.demo;
 
@@ -22,9 +23,14 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.leshan.core.SecurityMode;
+import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.SecurityUtil;
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
+import org.eclipse.leshan.server.bootstrap.BootstrapConfig.OscoreObject;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfigStore;
 import org.eclipse.leshan.server.bootstrap.EditableBootstrapConfigStore;
@@ -87,6 +93,26 @@ public class BootstrapConfigSecurityStore implements BootstrapSecurityStore {
     public Iterator<SecurityInfo> getAllByEndpoint(String endpoint) {
 
         BootstrapConfig bsConfig = bootstrapConfigStore.get(endpoint, null, null);
+
+        // TODO this should be done via OSCORE store ?
+        // Extract OSCORE security info
+        if (bsConfig != null && bsConfig.oscore != null && !bsConfig.oscore.isEmpty()) {
+            LOG.trace("Extracting OSCORE security info for endpoint {}", endpoint);
+
+            // First find the context for this endpoint
+            for (Map.Entry<Integer, BootstrapConfig.OscoreObject> oscoreEntry : bsConfig.oscore.entrySet()) {
+                OscoreObject value = oscoreEntry.getValue();
+
+                HashMapCtxDB db = OscoreHandler.getContextDB();
+                byte[] rid = Hex.decodeHex(value.oscoreRecipientId.toCharArray());
+                OSCoreCtx ctx = db.getContext(rid);
+
+                // Create the security info (will re-add the context to the db)
+                SecurityInfo securityInfo = SecurityInfo.newOSCoreInfo(endpoint, ctx);
+
+                return Arrays.asList(securityInfo).iterator();
+            }
+        }
 
         if (bsConfig == null || bsConfig.security == null)
             return null;

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
@@ -100,10 +100,10 @@ public class BootstrapConfigSecurityStore implements BootstrapSecurityStore {
             LOG.trace("Looking for OSCORE security info for endpoint {}", endpoint);
 
             // First find the context for this endpoint
-            for (Map.Entry<Integer, BootstrapConfig.ServerSecurity> bsEntry : bsConfig.security.entrySet()) {
+            for (ServerSecurity bsEntryValue : bsConfig.security.values()) {
                 // Only find contexts for BS-Client connections
-                Integer bsOscoreSecurityMode = bsEntry.getValue().oscoreSecurityMode;
-                if (!bsEntry.getValue().bootstrapServer || bsOscoreSecurityMode == null) {
+                Integer bsOscoreSecurityMode = bsEntryValue.oscoreSecurityMode;
+                if (!bsEntryValue.bootstrapServer || bsOscoreSecurityMode == null) {
                     continue;
                 }
 

--- a/leshan-bsserver-demo/src/main/resources/webapp/index.html
+++ b/leshan-bsserver-demo/src/main/resources/webapp/index.html
@@ -13,6 +13,7 @@
         <script src="tag/psk-input.tag" type="riot/tag"></script>
         <script src="tag/rpk-input.tag" type="riot/tag"></script>
         <script src="tag/x509-input.tag" type="riot/tag"></script>
+        <script src="tag/oscore-input.tag" type="riot/tag"></script>
         <script src="tag/bootstrap-modal.tag" type="riot/tag"></script>
         
         <script src="js/bsconfigstore.js"></script>

--- a/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
+++ b/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
@@ -6,6 +6,13 @@ var configFromRestToUI = function(config){
         var security = config.security[i];
         if (security.bootstrapServer){
             newConfig.bs.push({security:security});
+
+            // add oscore object (if any) to bs
+            var oscoreObjectInstanceId = security.oscoreSecurityMode;
+            var oscore = config.oscore[oscoreObjectInstanceId];
+            if(oscore){
+                newConfig.bs.push({oscore:oscore});
+            }
         }else{
             newConfig.dm = [];
             // search for DM information;
@@ -33,10 +40,11 @@ var configsFromRestToUI = function(configs){
 
 //convert config from UI to rest API format:
 var configFromUIToRest = function(config){
-    var newConfig = {servers:{}, security:{}};
+    var newConfig = {servers:{}, security:{}, oscore:{}};
     for (var i = 0; i < config.bs.length; i++) {
         var bs = config.bs[i];
         newConfig.security[i] = bs.security;
+        newConfig.oscore[i] = bs.oscore;
     }
     for (var j = 0; j < config.dm.length; j++) {
         var dm = config.dm[j];

--- a/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
+++ b/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
@@ -26,6 +26,13 @@ var configFromRestToUI = function(config){
             if (!newConfig.dm){
                 newConfig.dm.push({security:security});
             }
+            
+            // add oscore object (if any) to dm
+            var oscoreObjectInstanceId = security.oscoreSecurityMode;
+            var oscore = config.oscore[oscoreObjectInstanceId];
+            if(oscore){
+                newConfig.dm.push({oscore:oscore});
+            }
         }
     }
     return newConfig;
@@ -50,6 +57,8 @@ var configFromUIToRest = function(config){
         var dm = config.dm[j];
         newConfig.security[i+j] = dm.security;
         delete dm.security;
+        newConfig.oscore[i+j] = dm.oscore;
+        delete dm.oscore;
         newConfig.servers[j] = dm;
     }
     newConfig.toDelete = ["/0", "/1"]

--- a/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
+++ b/leshan-bsserver-demo/src/main/resources/webapp/js/bsconfigstore.js
@@ -48,20 +48,26 @@ var configsFromRestToUI = function(configs){
 //convert config from UI to rest API format:
 var configFromUIToRest = function(config){
     var newConfig = {servers:{}, security:{}, oscore:{}};
+    var writingOscore = false;
     for (var i = 0; i < config.bs.length; i++) {
         var bs = config.bs[i];
         newConfig.security[i] = bs.security;
         newConfig.oscore[i] = bs.oscore;
+        writingOscore |= (bs.oscore != null);
     }
     for (var j = 0; j < config.dm.length; j++) {
         var dm = config.dm[j];
         newConfig.security[i+j] = dm.security;
         delete dm.security;
         newConfig.oscore[i+j] = dm.oscore;
+        writingOscore |= (dm.oscore != null);
         delete dm.oscore;
         newConfig.servers[j] = dm;
     }
     newConfig.toDelete = ["/0", "/1"]
+    if(writingOscore) {
+        newConfig.toDelete.push("/21");
+    }
     return newConfig;
 };
 

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
@@ -36,7 +36,7 @@
                                                     serverpubkey= {serversecurity.rpk.hexDer}
                                                     servercertificate= {serversecurity.certificate.hexDer}
                                                     disable = { {uri:true, serverpubkey:true, servercertificate:true}}
-                                                    secmode = { {no_sec:true, psk:true,rpk:true, x509:true}}
+                                                    secmode = { {no_sec:true, psk:true,rpk:true, x509:true, oscore:true}}
                                                     ></securityconfig-input>
                         </div>
 
@@ -93,6 +93,22 @@
         function submit(){
             var lwserver = tag.refs.lwserver.get_value()
             var bsserver = tag.refs.bsserver.get_value()
+            
+            if(bsserver.secmode === "OSCORE") {
+                var bsserverOscore = bsserver.oscore;
+                var oscore =
+                {
+                    oscoreMasterSecret : bsserverOscore.masterSecret,
+                    oscoreSenderId : bsserverOscore.senderId,
+                    oscoreRecipientId : bsserverOscore.recipientId,
+                    oscoreAeadAlgorithm : bsserverOscore.aeadAlgorithm,
+                    oscoreHmacAlgorithm : bsserverOscore.hkdfAlgorithm,
+                    oscoreMasterSalt : bsserverOscore.masterSalt,
+                    oscoreIdContext : bsserverOscore.idContext
+                }
+                var bsOscoreSecurityMode = 0; // link to bs oscore object
+                bsserver.secmode = "NO_SEC"; // act as no_sec from here
+            }
 
             // add config to the store
             bsConfigStore.add(endpoint.value, {
@@ -131,7 +147,9 @@
                         smsBindingKeySecret : [  ],
                         smsSecurityMode : "NO_SEC",
                         uri : bsserver.uri,
-                      }
+                        oscoreSecurityMode : bsOscoreSecurityMode
+                      },
+                      oscore
                 }]
             });
             $('#bootstrap-modal').modal('hide');

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
@@ -104,7 +104,6 @@
                     oscoreAeadAlgorithm : bsserverOscore.aeadAlgorithm,
                     oscoreHmacAlgorithm : bsserverOscore.hkdfAlgorithm,
                     oscoreMasterSalt : bsserverOscore.masterSalt,
-                    oscoreIdContext : bsserverOscore.idContext
                 }
                 var bsOscoreSecurityMode = 0; // link to bs oscore object
                 bsserver.secmode = "NO_SEC"; // act as no_sec from here

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
@@ -26,7 +26,7 @@
                             <securityconfig-input   ref="lwserver" onchange={update} show={activetab.lwserver}
                                                     securi={ "coaps://" + location.hostname + ":5684" }
                                                     unsecuri= { "coap://" + location.hostname + ":5683" }
-                                                    secmode = { {no_sec:true, psk:true, rpk:true, x509:true} }
+                                                    secmode = { {no_sec:true, psk:true, rpk:true, x509:true, oscore:true} }
                                                     ></securityconfig-input>
                         </div>
                         <div>
@@ -96,7 +96,7 @@
             
             if(bsserver.secmode === "OSCORE") {
                 var bsserverOscore = bsserver.oscore;
-                var oscore =
+                var bsOscore =
                 {
                     oscoreMasterSecret : bsserverOscore.masterSecret,
                     oscoreSenderId : bsserverOscore.senderId,
@@ -107,6 +107,21 @@
                 }
                 var bsOscoreSecurityMode = 0; // link to bs oscore object
                 bsserver.secmode = "NO_SEC"; // act as no_sec from here
+            }
+
+            if(lwserver.secmode === "OSCORE") {
+                var lwserverOscore = lwserver.oscore;
+                var dmOscore =
+                {
+                    oscoreMasterSecret : lwserverOscore.masterSecret,
+                    oscoreSenderId : lwserverOscore.senderId,
+                    oscoreRecipientId : lwserverOscore.recipientId,
+                    oscoreAeadAlgorithm : lwserverOscore.aeadAlgorithm,
+                    oscoreHmacAlgorithm : lwserverOscore.hkdfAlgorithm,
+                    oscoreMasterSalt : lwserverOscore.masterSalt,
+                }
+                var dmOscoreSecurityMode = 1; // link to dm oscore object
+                lwserver.secmode = "NO_SEC"; // act as no_sec from here
             }
 
             // add config to the store
@@ -129,8 +144,10 @@
                         smsBindingKeyParam : [  ],
                         smsBindingKeySecret : [  ],
                         smsSecurityMode : "NO_SEC",
-                        uri : lwserver.uri
-                      }
+                        uri : lwserver.uri,
+                        oscoreSecurityMode : dmOscoreSecurityMode
+                      },
+                      oscore : dmOscore
                 }],
                  bs:[{
                     security : {
@@ -148,7 +165,7 @@
                         uri : bsserver.uri,
                         oscoreSecurityMode : bsOscoreSecurityMode
                       },
-                      oscore
+                      oscore : bsOscore
                 }]
             });
             $('#bootstrap-modal').modal('hide');

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
@@ -66,7 +66,7 @@
                     </div>
                 </td>
                 <td>
-                    <div each={ config.dm }>
+                    <div each={ config.dm } if={ security }>
                         <p>
                             <strong>{security.uri}</strong><br/>
                             security mode : {security.securityMode}<br/>

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
@@ -54,7 +54,7 @@
             <tr each={ config, endpoint in configs }>
                 <td>{ endpoint }</td>
                 <td>
-                    <div each={ config.bs }>
+                    <div each={ config.bs } if={ security }>
                         <p>
                             <strong>{ security.uri }</strong><br/>
                             security mode : {security.securityMode}<br/>

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/oscore-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/oscore-input.tag
@@ -20,17 +20,7 @@
             <p class="help-block" if={masterSalt.toolong}>The master salt is too long</p>
         </div>
     </div>
-    
-    <div class={ form-group:true, has-error: idContext.error }>
-        <label for="idContext" class="col-sm-4 control-label">ID Context</label>
-        <div class="col-sm-8">
-            <textarea class="form-control" style="resize:none" rows="1" id="idContext" ref="idContext" oninput={validate_idContext} onblur={validate_idContext} disabled={true}></textarea>
-            <p class="text-right text-muted small" style="margin:0">Not supported</p>
-            <p class="help-block" if={idContext.nothexa}>Hexadecimal format is expected</p>
-            <p class="help-block" if={idContext.toolong}>The ID context is too long</p>
-        </div>
-    </div>
-    
+
     <div class={ form-group:true, has-error: senderId.error }>
         <label for="senderId" class="col-sm-4 control-label">Sender ID</label>
         <div class="col-sm-8">
@@ -78,7 +68,6 @@
         // Tag internal state
         tag.masterSecret={};
         tag.masterSalt={};
-        tag.idContext={};
         tag.senderId={};
         tag.recipientId={};
         tag.aeadAlgorithm={};
@@ -87,7 +76,6 @@
         tag.defaultHkdfAlgorithm = "HKDF_HMAC_SHA_256";
         tag.validate_masterSecret = validate_masterSecret;
         tag.validate_masterSalt = validate_masterSalt;
-        tag.validate_idContext = validate_idContext;
         tag.validate_senderId = validate_senderId;
         tag.validate_recipientId = validate_recipientId;
         tag.validate_aeadAlgorithm = validate_aeadAlgorithm;
@@ -125,22 +113,6 @@
             }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
                 tag.masterSalt.error = true;
                 tag.masterSalt.nothexa = true;
-            }
-            tag.onchange();
-        }
-        
-        function validate_idContext(e){
-            var str = tag.refs.idContext.value;
-            tag.idContext.error = false;
-            tag.idContext.toolong = false;
-            tag.idContext.nothexa = false;
-            var isEmpty = !str || 0 === str.length;
-            if (str.length > 32){
-                tag.idContext.error = true;
-                tag.idContext.toolong = true;
-            }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
-                tag.idContext.error = true;
-                tag.idContext.nothexa = true;
             }
             tag.onchange();
         }
@@ -202,7 +174,6 @@
         function has_error(){
             return  typeof tag.masterSecret.error === "undefined" || tag.masterSecret.error
             || tag.masterSalt.error
-            || tag.idContext.error
             || tag.senderId.error
             || tag.recipientId.error
             || tag.aeadAlgorithm.error
@@ -248,7 +219,6 @@
         function get_value(){
             return { masterSecret:tag.refs.masterSecret.value,
                 masterSalt:tag.refs.masterSalt.value,
-                idContext:tag.refs.idContext.value,
                 senderId:tag.refs.senderId.value,
                 recipientId:tag.refs.recipientId.value,
                 aeadAlgorithm:parse_aeadAlgorithm(tag.refs.aeadAlgorithm.value),

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/oscore-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/oscore-input.tag
@@ -1,0 +1,259 @@
+<oscore-input>
+    <!-- OSCORE inputs -->
+    <div class={ form-group:true, has-error: masterSecret.error }>
+        <label for="masterSecret" class="col-sm-4 control-label">Master Secret</label>
+        <div class="col-sm-8">
+            <textarea class="form-control" style="resize:none" rows="2" id="masterSecret" ref="masterSecret" oninput={validate_masterSecret} onblur={validate_masterSecret}></textarea>
+            <p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+            <p class="help-block" if={masterSecret.required}>The master secret is required</p>
+            <p class="help-block" if={masterSecret.nothexa}>Hexadecimal format is expected</p>
+            <p class="help-block" if={masterSecret.toolong}>The master secret is too long</p>
+        </div>
+    </div>
+    
+    <div class={ form-group:true, has-error: masterSalt.error }>
+        <label for="masterSalt" class="col-sm-4 control-label">Master Salt</label>
+        <div class="col-sm-8">
+            <textarea class="form-control" style="resize:none" rows="2" id="masterSalt" ref="masterSalt" oninput={validate_masterSalt} onblur={validate_masterSalt}></textarea>
+            <p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+            <p class="help-block" if={masterSalt.nothexa}>Hexadecimal format is expected</p>
+            <p class="help-block" if={masterSalt.toolong}>The master salt is too long</p>
+        </div>
+    </div>
+    
+    <div class={ form-group:true, has-error: idContext.error }>
+        <label for="idContext" class="col-sm-4 control-label">ID Context</label>
+        <div class="col-sm-8">
+            <textarea class="form-control" style="resize:none" rows="1" id="idContext" ref="idContext" oninput={validate_idContext} onblur={validate_idContext} disabled={true}></textarea>
+            <p class="text-right text-muted small" style="margin:0">Not supported</p>
+            <p class="help-block" if={idContext.nothexa}>Hexadecimal format is expected</p>
+            <p class="help-block" if={idContext.toolong}>The ID context is too long</p>
+        </div>
+    </div>
+    
+    <div class={ form-group:true, has-error: senderId.error }>
+        <label for="senderId" class="col-sm-4 control-label">Sender ID</label>
+        <div class="col-sm-8">
+            <textarea class="form-control" style="resize:none" rows="1" id="senderId" ref="senderId" oninput={validate_senderId} onblur={validate_senderId}></textarea>
+            <p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+            <p class="help-block" if={senderId.nothexa}>Hexadecimal format is expected</p>
+            <p class="help-block" if={senderId.toolong}>The sender ID is too long</p>
+        </div>
+    </div>
+
+    <div class={ form-group:true, has-error: recipientId.error }>
+        <label for="recipientId" class="col-sm-4 control-label">Recipient ID</label>
+        <div class="col-sm-8">
+            <textarea class="form-control" style="resize:none" rows="1" id="recipientId" ref="recipientId" oninput={validate_recipientId} onblur={validate_recipientId}></textarea>
+            <p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+            <p class="help-block" if={recipientId.nothexa}>Hexadecimal format is expected</p>
+            <p class="help-block" if={recipientId.toolong}>The recipient ID is too long</p>
+        </div>
+    </div>
+    
+    <div class={ form-group:true, has-error: aeadAlgorithm.error }>
+        <label for="aeadAlgorithm" class="col-sm-4 control-label">AEAD Algorithm</label>
+        <div class="col-sm-8">
+            <textarea class="form-control" style="resize:none" rows="1" id="aeadAlgorithm" ref="aeadAlgorithm" oninput={validate_aeadAlgorithm} onblur={validate_aeadAlgorithm} placeholder={defaultAeadAlgorithm}></textarea>
+            <p class="help-block" if={aeadAlgorithm.toolong}>The AEAD algorithm is too long</p>
+        </div>
+    </div>
+    
+    <div class={ form-group:true, has-error: hkdfAlgorithm.error }>
+        <label for="hkdfAlgorithm" class="col-sm-4 control-label">HKDF Algorithm</label>
+        <div class="col-sm-8">
+            <textarea class="form-control" style="resize:none" rows="1" id="hkdfAlgorithm" ref="hkdfAlgorithm" oninput={validate_hkdfAlgorithm} onblur={validate_hkdfAlgorithm} placeholder={defaultHkdfAlgorithm}></textarea>
+            <p class="help-block" if={hkdfAlgorithm.toolong}>The HKDF algorithm is too long</p>
+        </div>
+    </div>
+
+    <script>
+        // Tag definition
+        var tag = this;
+        // Tag Params
+        tag.onchange = opts.onchange;
+        // Tag API
+        tag.has_error = has_error;
+        tag.get_value = get_value
+        // Tag internal state
+        tag.masterSecret={};
+        tag.masterSalt={};
+        tag.idContext={};
+        tag.senderId={};
+        tag.recipientId={};
+        tag.aeadAlgorithm={};
+        tag.defaultAeadAlgorithm = "AES_CCM_16_64_128";
+        tag.hkdfAlgorithm={};
+        tag.defaultHkdfAlgorithm = "HKDF_HMAC_SHA_256";
+        tag.validate_masterSecret = validate_masterSecret;
+        tag.validate_masterSalt = validate_masterSalt;
+        tag.validate_idContext = validate_idContext;
+        tag.validate_senderId = validate_senderId;
+        tag.validate_recipientId = validate_recipientId;
+        tag.validate_aeadAlgorithm = validate_aeadAlgorithm;
+        tag.validate_hkdfAlgorithm = validate_hkdfAlgorithm;
+
+        // Tag functions
+        function validate_masterSecret(e){
+            var str = tag.refs.masterSecret.value;
+            tag.masterSecret.error = false;
+            tag.masterSecret.required = false;
+            tag.masterSecret.toolong = false;
+            tag.masterSecret.nothexa = false;
+            if (!str || 0 === str.length){
+                tag.masterSecret.error = true;
+                tag.masterSecret.required = true;
+            }else if (str.length > 64){
+                tag.masterSecret.error = true;
+                tag.masterSecret.toolong = true;
+            }else if (! /^[0-9a-fA-F]+$/i.test(str)){
+                tag.masterSecret.error = true;
+                tag.masterSecret.nothexa = true;
+            }
+            tag.onchange();
+        }
+        
+        function validate_masterSalt(e){
+            var str = tag.refs.masterSalt.value;
+            tag.masterSalt.error = false;
+            tag.masterSalt.toolong = false;
+            tag.masterSalt.nothexa = false;
+            var isEmpty = !str || 0 === str.length;
+            if (str.length > 64){
+                tag.masterSalt.error = true;
+                tag.masterSalt.toolong = true;
+            }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
+                tag.masterSalt.error = true;
+                tag.masterSalt.nothexa = true;
+            }
+            tag.onchange();
+        }
+        
+        function validate_idContext(e){
+            var str = tag.refs.idContext.value;
+            tag.idContext.error = false;
+            tag.idContext.toolong = false;
+            tag.idContext.nothexa = false;
+            var isEmpty = !str || 0 === str.length;
+            if (str.length > 32){
+                tag.idContext.error = true;
+                tag.idContext.toolong = true;
+            }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
+                tag.idContext.error = true;
+                tag.idContext.nothexa = true;
+            }
+            tag.onchange();
+        }
+        
+        function validate_senderId(e){
+            var str = tag.refs.senderId.value;
+            tag.senderId.error = false;
+            tag.senderId.toolong = false;
+            tag.senderId.nothexa = false;
+            var isEmpty = !str || 0 === str.length;
+            if (str.length > 16){
+                tag.senderId.error = true;
+                tag.senderId.toolong = true;
+            }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
+                tag.senderId.error = true;
+                tag.senderId.nothexa = true;
+            }
+            tag.onchange();
+        }
+        
+        function validate_recipientId(e){
+            var str = tag.refs.recipientId.value;
+            tag.recipientId.error = false;
+            tag.recipientId.toolong = false;
+            tag.recipientId.nothexa = false;
+            var isEmpty = !str || 0 === str.length;
+            if (str.length > 16){
+                tag.recipientId.error = true;
+                tag.recipientId.toolong = true;
+            }else if (!isEmpty && ! /^[0-9a-fA-F]+$/i.test(str)){
+                tag.recipientId.error = true;
+                tag.recipientId.nothexa = true;
+            }
+            tag.onchange();
+        }
+        
+        function validate_aeadAlgorithm(e){
+            var str = tag.refs.aeadAlgorithm.value;
+            tag.aeadAlgorithm.error = false;
+            tag.aeadAlgorithm.toolong = false;
+            if (str.length > 32){
+                tag.aeadAlgorithm.error = true;
+                tag.aeadAlgorithm.toolong = true;
+            }
+            tag.onchange();
+        }
+        
+        function validate_hkdfAlgorithm(e){
+            var str = tag.refs.hkdfAlgorithm.value;
+            tag.hkdfAlgorithm.error = false;
+            tag.hkdfAlgorithm.toolong = false;
+            if (str.length > 32){
+                tag.hkdfAlgorithm.error = true;
+                tag.hkdfAlgorithm.toolong = true;
+            }
+            tag.onchange();
+        }
+
+        function has_error(){
+            return  typeof tag.masterSecret.error === "undefined" || tag.masterSecret.error
+            || tag.masterSalt.error
+            || tag.idContext.error
+            || tag.senderId.error
+            || tag.recipientId.error
+            || tag.aeadAlgorithm.error
+            || tag.hkdfAlgorithm.error;
+        }
+
+        // Allows entering the AEAD algorithm as a string, and sets default if empty
+        function parse_aeadAlgorithm(alg){
+
+            if (!alg || 0 === alg.length){
+                alg = tag.defaultAeadAlgorithm;
+            }
+
+            switch(alg) {
+                case 'AES_CCM_16_64_128':
+                    return 10;
+                case 'AES_CCM_64_64_128':
+                    return 12;
+                case 'AES_CCM_16_128_128':
+                    return 30;
+                case 'AES_CCM_64_128_128':
+                    return 32;
+                default:
+                    return alg;
+            }
+        }
+
+        // Allows entering the HKDF algorithm as a string, and sets default if empty
+        function parse_hkdfAlgorithm(alg){
+
+            if (!alg || 0 === alg.length){
+                alg = tag.defaultHkdfAlgorithm;
+            }
+
+            switch(alg) {
+                case 'HKDF_HMAC_SHA_256':
+                    return -10;
+                default:
+                    return alg;
+            }
+        }
+
+        function get_value(){
+            return { masterSecret:tag.refs.masterSecret.value,
+                masterSalt:tag.refs.masterSalt.value,
+                idContext:tag.refs.idContext.value,
+                senderId:tag.refs.senderId.value,
+                recipientId:tag.refs.recipientId.value,
+                aeadAlgorithm:parse_aeadAlgorithm(tag.refs.aeadAlgorithm.value),
+                hkdfAlgorithm:parse_hkdfAlgorithm(tag.refs.hkdfAlgorithm.value) };
+        }
+    </script>
+</oscore-input>
+

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
@@ -16,6 +16,7 @@
                 <option value="psk"    show={secmode.psk}    >Pre-Shared Key</option>
                 <option value="rpk"    show={secmode.rpk}    >Raw Public Key</option>
                 <option value="x509"   show={secmode.x509}   >X.509 Certificate</option>
+                <option value="oscore" show={secmode.oscore} >OSCORE</option>
             </select>
         </div>
     </div>
@@ -33,6 +34,11 @@
     <!-- X509 -->
     <div if={  refs.secMode.value == "x509" } >
         <x509-input ref="x509" onchange={onchange} disable={disable} servercertificate={servercertificate}></x509-input>
+    </div>
+    
+    <!-- OSCORE -->
+    <div if={  refs.secMode.value == "oscore" } >
+        <oscore-input ref="oscore" onchange={onchange} disable={disable}></oscore-input>
     </div>
 
     <script>
@@ -54,7 +60,7 @@
 
         // Tag Functions
         function default_uri() {
-            if (!tag.refs.secMode || tag.refs.secMode.value == "no_sec")
+            if (!tag.refs.secMode || tag.refs.secMode.value == "no_sec" || tag.refs.secMode.value == "oscore")
                 return opts.unsecuri;
             else
                 return opts.securi;
@@ -63,7 +69,8 @@
         function has_error() {
             return tag.refs.secMode.value === "psk"  && tag.refs.psk.has_error()
                 || tag.refs.secMode.value === "rpk"  && tag.refs.rpk.has_error()
-                || tag.refs.secMode.value === "x509" && tag.refs.x509.has_error();
+                || tag.refs.secMode.value === "x509" && tag.refs.x509.has_error()
+                || tag.refs.secMode.value === "oscore" && tag.refs.oscore.has_error();
         }
 
         function get_value() {
@@ -97,6 +104,20 @@
                 config.id = fromHex(x509.cert);
                 config.key = fromHex(x509.key);
                 config.serverKey = fromHex(x509.servCert);
+            } else if(config.secmode === "OSCORE"){
+                var oscoreVals = tag.refs.oscore.get_value();
+                
+                // Relay to config object
+                config.oscore = {};
+                                
+                config.oscore.masterSecret = oscoreVals.masterSecret;
+                config.oscore.masterSalt = oscoreVals.masterSalt;
+                config.oscore.idContext = oscoreVals.idContext;
+                config.oscore.senderId = oscoreVals.senderId;
+                config.oscore.recipientId = oscoreVals.recipientId;
+                config.oscore.aeadAlgorithm = oscoreVals.aeadAlgorithm;
+                config.oscore.hkdfAlgorithm = oscoreVals.hkdfAlgorithm;
+
             }
 
             return config;

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
@@ -112,7 +112,6 @@
                                 
                 config.oscore.masterSecret = oscoreVals.masterSecret;
                 config.oscore.masterSalt = oscoreVals.masterSalt;
-                config.oscore.idContext = oscoreVals.idContext;
                 config.oscore.senderId = oscoreVals.senderId;
                 config.oscore.recipientId = oscoreVals.recipientId;
                 config.oscore.aeadAlgorithm = oscoreVals.aeadAlgorithm;

--- a/leshan-client-cf/pom.xml
+++ b/leshan-client-cf/pom.xml
@@ -46,6 +46,11 @@ Contributors:
             <groupId>org.eclipse.californium</groupId>
             <artifactId>scandium</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.californium</groupId>
+            <artifactId>cf-oscore</artifactId>
+            <version>${californium.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
@@ -192,8 +193,13 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
             }
 
             currentEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, db);
-            // TODO OSCORE: Should be visible in identity if OSCORE is used
-            serverIdentity = Identity.unsecure(serverInfo.getAddress());
+
+            // Build server identity for OSCORE
+            String sidString = Utils.toHexString(serverInfo.senderId).replace("[", "").replace("]", "").toLowerCase();
+            String ridString = Utils.toHexString(serverInfo.recipientId).replace("[", "").replace("]", "")
+                    .toLowerCase();
+            String oscoreIdentity = "sid=" + sidString + ",rid=" + ridString;
+            serverIdentity = Identity.oscoreOnly(serverInfo.getAddress(), oscoreIdentity);
         } else {
             currentEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, null);
             serverIdentity = Identity.unsecure(serverInfo.getAddress());

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -12,11 +12,14 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.client.californium;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -28,8 +31,13 @@ import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.cose.AlgorithmID;
+import org.eclipse.californium.cose.CoseException;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
@@ -45,6 +53,8 @@ import org.eclipse.leshan.core.californium.EndpointFactory;
 import org.eclipse.leshan.core.request.Identity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.upokecenter.cbor.CBORObject;
 
 /**
  * An {@link EndpointsManager} based on Californium(CoAP implementation) and Scandium (DTLS implementation) which
@@ -145,9 +155,46 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
             } else {
                 throw new RuntimeException("Unable to create connector : unsupported security mode");
             }
-            currentEndpoint = endpointFactory.createSecuredEndpoint(newBuilder.build(), coapConfig, null);
+            currentEndpoint = endpointFactory.createSecuredEndpoint(newBuilder.build(), coapConfig, null, null);
+        } else if (serverInfo.useOscore) {
+            // oscore only mode
+            LOG.info("Adding OSCORE context for " + serverInfo.getFullUri().toASCIIString());
+            // TODO OSCORE : use OscoreStore instead ?
+            HashMapCtxDB db = OscoreHandler.getContextDB();
+
+            AlgorithmID hkdfAlg = null;
+            try {
+                hkdfAlg = AlgorithmID.FromCBOR(CBORObject.FromObject(serverInfo.hkdfAlgorithm));
+            } catch (CoseException e) {
+                LOG.error("Failed to decode OSCORE HMAC algorithm");
+            }
+
+            AlgorithmID aeadAlg = null;
+            try {
+                aeadAlg = AlgorithmID.FromCBOR(CBORObject.FromObject(serverInfo.aeadAlgorithm));
+            } catch (CoseException e) {
+                LOG.error("Failed to decode OSCORE AEAD algorithm");
+            }
+
+            try {
+                OSCoreCtx ctx = new OSCoreCtx(serverInfo.masterSecret, true, aeadAlg, serverInfo.senderId,
+                        serverInfo.recipientId, hkdfAlg, 32, serverInfo.masterSalt, serverInfo.idContext);
+                db.addContext(serverInfo.getFullUri().toASCIIString(), ctx);
+
+                // Also add the context by the IP of the server since requests may use that
+                String serverIP = InetAddress.getByName(serverInfo.getFullUri().getHost()).getHostAddress();
+                db.addContext("coap://" + serverIP, ctx);
+
+            } catch (OSException | UnknownHostException e) {
+                LOG.error("Failed to generate OSCORE context information");
+                return null;
+            }
+
+            currentEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, db);
+            // TODO OSCORE: Should be visible in identity if OSCORE is used
+            serverIdentity = Identity.unsecure(serverInfo.getAddress());
         } else {
-            currentEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null);
+            currentEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, null);
             serverIdentity = Identity.unsecure(serverInfo.getAddress());
         }
 

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -177,8 +177,9 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
             }
 
             try {
+                byte[] idContext = null;
                 OSCoreCtx ctx = new OSCoreCtx(serverInfo.masterSecret, true, aeadAlg, serverInfo.senderId,
-                        serverInfo.recipientId, hkdfAlg, 32, serverInfo.masterSalt, serverInfo.idContext);
+                        serverInfo.recipientId, hkdfAlg, 32, serverInfo.masterSalt, idContext);
                 db.addContext(serverInfo.getFullUri().toASCIIString(), ctx);
 
                 // Also add the context by the IP of the server since requests may use that

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreHandler.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreHandler.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.client.californium;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+//TODO OSCORE : remove this class and static access.
+public class OscoreHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
@@ -12,14 +12,21 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
- *     Rikard Höglund (RISE SICS)
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *
  *******************************************************************************/
 package org.eclipse.leshan.client.object;
 
+import static org.eclipse.leshan.core.LwM2mId.*;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
@@ -33,77 +40,136 @@ public class Oscore extends BaseInstanceEnabler {
 
     private static final Logger LOG = LoggerFactory.getLogger(Security.class);
 
-    private byte[] masterSecret;
+    private final static List<Integer> supportedResources = Arrays.asList(OSCORE_Master_Secret, OSCORE_Sender_ID,
+            OSCORE_Recipient_ID, OSCORE_AEAD_Algorithm, OSCORE_HMAC_Algorithm, OSCORE_Master_Salt);
+
+    private String masterSecret;
     private String senderId;
     private String recipientId;
     private int aeadAlgorithm;
-    private int hmacAlgorithm;
+    private int hkdfAlgorithm;
+    private String masterSalt;
+    // TODO OSCORE : never used and not part of OSCORE object
+    private String idContext;
 
     public Oscore() {
 
     }
 
-    public Oscore(byte[] masterSecret, String senderId, String recipientId, int aeadAlgorithm, int hmacAlgorithm) {
-        super();
-        this.masterSecret = masterSecret.clone();
+    /**
+     * Default constructor.
+     */
+    public Oscore(int instanceId, String masterSecret, String senderId, String recipientId, int aeadAlgorithm,
+            int hkdfAlgorithm, String masterSalt) {
+        super(instanceId);
+        this.masterSecret = masterSecret;
         this.senderId = senderId;
         this.recipientId = recipientId;
         this.aeadAlgorithm = aeadAlgorithm;
-        this.hmacAlgorithm = hmacAlgorithm;
+        this.hkdfAlgorithm = hkdfAlgorithm;
+        this.masterSalt = masterSalt;
+        this.idContext = "";
+    }
+
+    /**
+     * Constructor providing some default values.
+     *
+     * aeadAlgorithm = 10; //AES_CCM_16_64_128m hmacAlgorithm = -10; //HKDF_HMAC_SHA_256, masterSalt = "";
+     *
+     */
+    public Oscore(int instanceId, String masterSecret, String senderId, String recipientId) {
+        this(instanceId, masterSecret, senderId, recipientId, 10, -10, "");
     }
 
     @Override
     public WriteResponse write(ServerIdentity identity, int resourceId, LwM2mResource value) {
         LOG.debug("Write on resource {}: {}", resourceId, value);
-        // extend
-        return WriteResponse.notFound();
+
+        // restricted to BS server?
+
+        switch (resourceId) {
+
+        case OSCORE_Master_Secret:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            masterSecret = (String) value.getValue();
+            return WriteResponse.success();
+
+        case OSCORE_Sender_ID:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            senderId = (String) value.getValue();
+            return WriteResponse.success();
+
+        case OSCORE_Recipient_ID:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            recipientId = (String) value.getValue();
+            return WriteResponse.success();
+
+        case OSCORE_AEAD_Algorithm:
+            if (value.getType() != Type.INTEGER) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            aeadAlgorithm = ((Long) value.getValue()).intValue();
+            return WriteResponse.success();
+
+        case OSCORE_HMAC_Algorithm:
+            if (value.getType() != Type.INTEGER) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            hkdfAlgorithm = ((Long) value.getValue()).intValue();
+            return WriteResponse.success();
+
+        case OSCORE_Master_Salt:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            masterSalt = (String) value.getValue();
+            return WriteResponse.success();
+
+        default:
+            return super.write(identity, resourceId, value);
+        }
+
     }
 
     @Override
     public ReadResponse read(ServerIdentity identity, int resourceid) {
         LOG.debug("Read on resource {}", resourceid);
-        // extend
-        return ReadResponse.notFound();
+        // only accessible for internal read?
+
+        switch (resourceid) {
+
+        case OSCORE_Master_Secret:
+            return ReadResponse.success(resourceid, masterSecret);
+
+        case OSCORE_Sender_ID:
+            return ReadResponse.success(resourceid, senderId);
+
+        case OSCORE_Recipient_ID:
+            return ReadResponse.success(resourceid, recipientId);
+
+        case OSCORE_AEAD_Algorithm:
+            return ReadResponse.success(resourceid, aeadAlgorithm);
+
+        case OSCORE_HMAC_Algorithm:
+            return ReadResponse.success(resourceid, hkdfAlgorithm);
+
+        case OSCORE_Master_Salt:
+            return ReadResponse.success(resourceid, masterSalt);
+
+        default:
+            return super.read(identity, resourceid);
+        }
     }
 
-    public byte[] getMasterSecret() {
-        return masterSecret;
-    }
-
-    public void setMasterSecret(byte[] masterSecret) {
-        this.masterSecret = masterSecret;
-    }
-
-    public String getSenderId() {
-        return senderId;
-    }
-
-    public void setSenderId(String senderId) {
-        this.senderId = senderId;
-    }
-
-    public String getRecipientId() {
-        return recipientId;
-    }
-
-    public void setRecipientId(String recipientId) {
-        this.recipientId = recipientId;
-    }
-
-    public int getAeadAlgorithm() {
-        return aeadAlgorithm;
-    }
-
-    public void setAeadAlgorithm(int aeadAlgorithm) {
-        this.aeadAlgorithm = aeadAlgorithm;
-    }
-
-    public int getHmacAlgorithm() {
-        return hmacAlgorithm;
-    }
-
-    public void setHmacAlgorithm(int hmacAlgorithm) {
-        this.hmacAlgorithm = hmacAlgorithm;
+    @Override
+    public List<Integer> getAvailableResourceIds(ObjectModel model) {
+        return supportedResources;
     }
 
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS)
+ *
+ *******************************************************************************/
+package org.eclipse.leshan.client.object;
+
+import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
+import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
+import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.response.ReadResponse;
+import org.eclipse.leshan.core.response.WriteResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple {@link LwM2mInstanceEnabler} for the OSCORE Security (21) object.
+ */
+public class Oscore extends BaseInstanceEnabler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Security.class);
+
+    private byte[] masterSecret;
+    private String senderId;
+    private String recipientId;
+    private int aeadAlgorithm;
+    private int hmacAlgorithm;
+
+    public Oscore() {
+
+    }
+
+    public Oscore(byte[] masterSecret, String senderId, String recipientId, int aeadAlgorithm, int hmacAlgorithm) {
+        super();
+        this.masterSecret = masterSecret.clone();
+        this.senderId = senderId;
+        this.recipientId = recipientId;
+        this.aeadAlgorithm = aeadAlgorithm;
+        this.hmacAlgorithm = hmacAlgorithm;
+    }
+
+    @Override
+    public WriteResponse write(ServerIdentity identity, int resourceId, LwM2mResource value) {
+        LOG.debug("Write on resource {}: {}", resourceId, value);
+        // extend
+        return WriteResponse.notFound();
+    }
+
+    @Override
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
+        LOG.debug("Read on resource {}", resourceid);
+        // extend
+        return ReadResponse.notFound();
+    }
+
+    public byte[] getMasterSecret() {
+        return masterSecret;
+    }
+
+    public void setMasterSecret(byte[] masterSecret) {
+        this.masterSecret = masterSecret;
+    }
+
+    public String getSenderId() {
+        return senderId;
+    }
+
+    public void setSenderId(String senderId) {
+        this.senderId = senderId;
+    }
+
+    public String getRecipientId() {
+        return recipientId;
+    }
+
+    public void setRecipientId(String recipientId) {
+        this.recipientId = recipientId;
+    }
+
+    public int getAeadAlgorithm() {
+        return aeadAlgorithm;
+    }
+
+    public void setAeadAlgorithm(int aeadAlgorithm) {
+        this.aeadAlgorithm = aeadAlgorithm;
+    }
+
+    public int getHmacAlgorithm() {
+        return hmacAlgorithm;
+    }
+
+    public void setHmacAlgorithm(int hmacAlgorithm) {
+        this.hmacAlgorithm = hmacAlgorithm;
+    }
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
@@ -49,8 +49,6 @@ public class Oscore extends BaseInstanceEnabler {
     private int aeadAlgorithm;
     private int hkdfAlgorithm;
     private String masterSalt;
-    // TODO OSCORE : never used and not part of OSCORE object
-    private String idContext;
 
     public Oscore() {
 
@@ -68,7 +66,6 @@ public class Oscore extends BaseInstanceEnabler {
         this.aeadAlgorithm = aeadAlgorithm;
         this.hkdfAlgorithm = hkdfAlgorithm;
         this.masterSalt = masterSalt;
-        this.idContext = "";
     }
 
     /**

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.client.object;
 
@@ -27,6 +28,7 @@ import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
@@ -41,7 +43,8 @@ public class Security extends BaseInstanceEnabler {
     private static final Logger LOG = LoggerFactory.getLogger(Security.class);
 
     private final static List<Integer> supportedResources = Arrays.asList(SEC_SERVER_URI, SEC_BOOTSTRAP,
-            SEC_SECURITY_MODE, SEC_PUBKEY_IDENTITY, SEC_SERVER_PUBKEY, SEC_SECRET_KEY, SEC_SERVER_ID);
+            SEC_SECURITY_MODE, SEC_PUBKEY_IDENTITY, SEC_SERVER_PUBKEY, SEC_SECRET_KEY, SEC_SERVER_ID,
+            SEC_OSCORE_SECURITY_MODE);
 
     private String serverUri; /* coaps://host:port */
     private boolean bootstrapServer;
@@ -52,13 +55,14 @@ public class Security extends BaseInstanceEnabler {
     private byte[] secretKey;
 
     private Integer shortServerId;
+    private ObjectLink oscoreSecurityMode;
 
     public Security() {
         // should only be used at bootstrap time
     }
 
     public Security(String serverUri, boolean bootstrapServer, int securityMode, byte[] publicKeyOrIdentity,
-            byte[] serverPublicKey, byte[] secretKey, Integer shortServerId) {
+            byte[] serverPublicKey, byte[] secretKey, Integer shortServerId, ObjectLink oscoreSecurityMode) {
         this.serverUri = serverUri;
         this.bootstrapServer = bootstrapServer;
         this.securityMode = securityMode;
@@ -66,13 +70,15 @@ public class Security extends BaseInstanceEnabler {
         this.serverPublicKey = serverPublicKey;
         this.secretKey = secretKey;
         this.shortServerId = shortServerId;
+        this.oscoreSecurityMode = oscoreSecurityMode;
     }
 
     /**
      * Returns a new security instance (NoSec) for a bootstrap server.
      */
     public static Security noSecBootstap(String serverUri) {
-        return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0], 0);
+        return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0], 0,
+                new ObjectLink());
     }
 
     /**
@@ -80,7 +86,7 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security pskBootstrap(String serverUri, byte[] pskIdentity, byte[] privateKey) {
         return new Security(serverUri, true, SecurityMode.PSK.code, pskIdentity.clone(), new byte[0],
-                privateKey.clone(), 0);
+                privateKey.clone(), 0, new ObjectLink());
     }
 
     /**
@@ -89,7 +95,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security rpkBootstrap(String serverUri, byte[] clientPublicKey, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, true, SecurityMode.RPK.code, clientPublicKey.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), 0);
+                clientPrivateKey.clone(), 0, new ObjectLink());
     }
 
     /**
@@ -98,7 +104,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security x509Bootstrap(String serverUri, byte[] clientCertificate, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, true, SecurityMode.X509.code, clientCertificate.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), 0);
+                clientPrivateKey.clone(), 0, new ObjectLink());
     }
 
     /**
@@ -106,7 +112,15 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security noSec(String serverUri, int shortServerId) {
         return new Security(serverUri, false, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0],
-                shortServerId);
+                shortServerId, new ObjectLink());
+    }
+
+    /**
+     * Returns a new security instance (OSCORE only) for a device management server.
+     */
+    public static Security oscoreOnly(String serverUri, int shortServerId, int oscoreObjectInstanceId) {
+        return new Security(serverUri, false, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0],
+                shortServerId, new ObjectLink(OSCORE, oscoreObjectInstanceId));
     }
 
     /**
@@ -114,7 +128,7 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security psk(String serverUri, int shortServerId, byte[] pskIdentity, byte[] privateKey) {
         return new Security(serverUri, false, SecurityMode.PSK.code, pskIdentity.clone(), new byte[0],
-                privateKey.clone(), shortServerId);
+                privateKey.clone(), shortServerId, new ObjectLink());
     }
 
     /**
@@ -123,7 +137,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security rpk(String serverUri, int shortServerId, byte[] clientPublicKey, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, false, SecurityMode.RPK.code, clientPublicKey.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), shortServerId);
+                clientPrivateKey.clone(), shortServerId, new ObjectLink());
     }
 
     /**
@@ -132,7 +146,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security x509(String serverUri, int shortServerId, byte[] clientCertificate, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, false, SecurityMode.X509.code, clientCertificate.clone(),
-                serverPublicKey.clone(), clientPrivateKey.clone(), shortServerId);
+                serverPublicKey.clone(), clientPrivateKey.clone(), shortServerId, new ObjectLink());
     }
 
     @Override
@@ -187,6 +201,13 @@ public class Security extends BaseInstanceEnabler {
             shortServerId = ((Long) value.getValue()).intValue();
             return WriteResponse.success();
 
+        case SEC_OSCORE_SECURITY_MODE: // oscore security mode
+            if (value.getType() != Type.OBJLNK) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            oscoreSecurityMode = (ObjectLink) value.getValue();
+            return WriteResponse.success();
+
         default:
             return super.write(identity, resourceId, value);
         }
@@ -218,6 +239,9 @@ public class Security extends BaseInstanceEnabler {
 
         case SEC_SERVER_ID: // short server id
             return ReadResponse.success(resourceid, shortServerId);
+
+        case SEC_OSCORE_SECURITY_MODE: // oscore security mode
+            return ReadResponse.success(resourceid, oscoreSecurityMode == null ? new ObjectLink() : oscoreSecurityMode);
 
         default:
             return super.read(identity, resourceid);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -74,6 +74,14 @@ public class Security extends BaseInstanceEnabler {
     }
 
     /**
+     * Returns a new security instance (OSCORE only) for a bootstrap server.
+     */
+    public static Security oscoreOnlyBootstrap(String serverUri, int shortServerId, int oscoreObjectInstanceId) {
+        return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0],
+                shortServerId, new ObjectLink(OSCORE, oscoreObjectInstanceId));
+    }
+
+    /**
      * Returns a new security instance (NoSec) for a bootstrap server.
      */
     public static Security noSecBootstap(String serverUri) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
@@ -51,6 +52,16 @@ public class ServerInfo {
     public Certificate serverCertificate;
 
     public PrivateKey privateKey;
+
+    // OSCORE parameters
+    public boolean useOscore;
+    public byte[] masterSecret;
+    public byte[] senderId;
+    public byte[] recipientId;
+    public long aeadAlgorithm;
+    public long hkdfAlgorithm;
+    public byte[] masterSalt;
+    public byte[] idContext;
 
     public InetSocketAddress getAddress() {
         return getAddress(serverUri);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
@@ -61,7 +61,6 @@ public class ServerInfo {
     public long aeadAlgorithm;
     public long hkdfAlgorithm;
     public byte[] masterSalt;
-    public byte[] idContext;
 
     public InetSocketAddress getAddress() {
         return getAddress(serverUri);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -113,7 +113,6 @@ public class ServersInfoExtractor {
                             info.aeadAlgorithm = getAeadAlgorithm(oscoreInstance);
                             info.hkdfAlgorithm = getHkdfAlgorithm(oscoreInstance);
                             info.masterSalt = getMasterSalt(oscoreInstance);
-                            info.idContext = getIdContext(oscoreInstance);
                         } else if (info.secureMode == SecurityMode.PSK) {
                             info.pskId = getPskIdentity(security);
                             info.pskKey = getPskKey(security);
@@ -157,7 +156,6 @@ public class ServersInfoExtractor {
                         info.aeadAlgorithm = getAeadAlgorithm(oscoreInstance);
                         info.hkdfAlgorithm = getHkdfAlgorithm(oscoreInstance);
                         info.masterSalt = getMasterSalt(oscoreInstance);
-                        info.idContext = getIdContext(oscoreInstance);
                     } else if (info.secureMode == SecurityMode.PSK) {
                         info.pskId = getPskIdentity(security);
                         info.pskKey = getPskKey(security);
@@ -362,9 +360,5 @@ public class ServersInfoExtractor {
         } else {
             return Hex.decodeHex(value.toCharArray());
         }
-    }
-
-    public static byte[] getIdContext(LwM2mObjectInstance oscoreInstance) {
-        return null;
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -104,7 +104,9 @@ public class ServersInfoExtractor {
                         if (useOscore) {
                             // get corresponding oscore object
                             LwM2mObjectInstance oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
-                            LOG.trace("Bootstrap connection is using OSCORE.");
+                            if (oscoreInstance == null) {
+                                LOG.error("Failed to retrieve OSCORE object linked from BS security object");
+                            }
 
                             info.useOscore = true;
                             info.masterSecret = getMasterSecret(oscoreInstance);
@@ -147,8 +149,9 @@ public class ServersInfoExtractor {
                     if (useOscore) {
                         // get corresponding oscore object
                         LwM2mObjectInstance oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
-                        LOG.trace("Registration connection is using OSCORE.");
-
+                        if (oscoreInstance == null) {
+                            LOG.error("Failed to retrieve OSCORE object linked from DM security object");
+                        }
                         info.useOscore = true;
                         info.masterSecret = getMasterSecret(oscoreInstance);
                         info.senderId = getSenderId(oscoreInstance);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -92,22 +92,25 @@ public class ServersInfoExtractor {
                         info.serverUri = new URI((String) security.getResource(SEC_SERVER_URI).getValue());
                         info.secureMode = getSecurityMode(security);
 
-                        // find instance id of the associated oscore object (if any)
-                        ObjectLink oscoreObjLink = (ObjectLink) security.getResource(SEC_OSCORE_SECURITY_MODE).getValue();
-                        int oscoreObjectInstanceId = oscoreObjLink.getObjectInstanceId();
-
-                        if (!oscoreObjLink.isNullLink() && oscoreObjLink.getObjectId() != OSCORE) {
-                            LOG.warn("The security object's 'OSCORE Security Mode' links to an incorrect object type.");
+                        // find associated oscore instance (if any)
+                        LwM2mObjectInstance oscoreInstance = null;
+                        ObjectLink oscoreObjLink = (ObjectLink) security.getResource(SEC_OSCORE_SECURITY_MODE)
+                                .getValue();
+                        if (oscoreObjLink != null) {
+                            int oscoreObjectInstanceId = oscoreObjLink.getObjectInstanceId();
+                            if (!oscoreObjLink.isNullLink() && oscoreObjLink.getObjectId() != OSCORE) {
+                                LOG.warn(
+                                        "The security object's 'OSCORE Security Mode' links to an incorrect object type.");
+                            } else {
+                                oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
+                                if (oscoreInstance == null) {
+                                    // maybe we should use same log level for this one and the other just above
+                                    LOG.error("Failed to retrieve OSCORE object linked from BS security object");
+                                }
+                            }
                         }
 
-                        boolean useOscore = oscoreObjLink.getObjectId() == OSCORE;
-                        if (useOscore) {
-                            // get corresponding oscore object
-                            LwM2mObjectInstance oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
-                            if (oscoreInstance == null) {
-                                LOG.error("Failed to retrieve OSCORE object linked from BS security object");
-                            }
-
+                        if (oscoreInstance != null) {
                             info.useOscore = true;
                             info.masterSecret = getMasterSecret(oscoreInstance);
                             info.senderId = getSenderId(oscoreInstance);
@@ -137,21 +140,23 @@ public class ServersInfoExtractor {
                     info.serverId = (long) security.getResource(SEC_SERVER_ID).getValue();
                     info.secureMode = getSecurityMode(security);
 
-                    // find instance id of the associated oscore object (if any)
+                    // find associated oscore instance (if any)
+                    LwM2mObjectInstance oscoreInstance = null;
                     ObjectLink oscoreObjLink = (ObjectLink) security.getResource(SEC_OSCORE_SECURITY_MODE).getValue();
-                    int oscoreObjectInstanceId = oscoreObjLink.getObjectInstanceId();
-
-                    if (!oscoreObjLink.isNullLink() && oscoreObjLink.getObjectId() != OSCORE) {
-                        LOG.warn("The security object's 'OSCORE Security Mode' links to an incorrect object type.");
+                    if (oscoreObjLink != null) {
+                        int oscoreObjectInstanceId = oscoreObjLink.getObjectInstanceId();
+                        if (!oscoreObjLink.isNullLink() && oscoreObjLink.getObjectId() != OSCORE) {
+                            LOG.warn("The security object's 'OSCORE Security Mode' links to an incorrect object type.");
+                        } else {
+                            oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
+                            if (oscoreInstance == null) {
+                                // maybe we should use same log level for this one and the other just above
+                                LOG.error("Failed to retrieve OSCORE object linked from DM security object");
+                            }
+                        }
                     }
 
-                    boolean useOscore = oscoreObjLink.getObjectId() == OSCORE;
-                    if (useOscore) {
-                        // get corresponding oscore object
-                        LwM2mObjectInstance oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
-                        if (oscoreInstance == null) {
-                            LOG.error("Failed to retrieve OSCORE object linked from DM security object");
-                        }
+                    if (oscoreInstance != null) {
                         info.useOscore = true;
                         info.masterSecret = getMasterSecret(oscoreInstance);
                         info.senderId = getSenderId(oscoreInstance);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -96,16 +96,22 @@ public class ServersInfoExtractor {
                         LwM2mObjectInstance oscoreInstance = null;
                         ObjectLink oscoreObjLink = (ObjectLink) security.getResource(SEC_OSCORE_SECURITY_MODE)
                                 .getValue();
-                        if (oscoreObjLink != null) {
-                            int oscoreObjectInstanceId = oscoreObjLink.getObjectInstanceId();
-                            if (!oscoreObjLink.isNullLink() && oscoreObjLink.getObjectId() != OSCORE) {
+                        if (oscoreObjLink != null && !oscoreObjLink.isNullLink()) {
+                            if (oscoreObjLink.getObjectId() != OSCORE) {
                                 LOG.warn(
-                                        "The security object's 'OSCORE Security Mode' links to an incorrect object type.");
+                                        "Invalid Security info for bootstrap server : 'OSCORE Security Mode' does not link to OSCORE Object but to {} object.",
+                                        oscoreObjLink.getObjectId());
                             } else {
-                                oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
-                                if (oscoreInstance == null) {
-                                    // maybe we should use same log level for this one and the other just above
-                                    LOG.error("Failed to retrieve OSCORE object linked from BS security object");
+                                if (oscores == null) {
+                                    LOG.warn(
+                                            "Invalid Security info for bootstrap server : OSCORE object enabler is not available.");
+                                } else {
+                                    oscoreInstance = oscores.getInstance(oscoreObjLink.getObjectInstanceId());
+                                    if (oscoreInstance == null) {
+                                        LOG.warn(
+                                                "Invalid Security info for bootstrap server : OSCORE instance {} does not exist.",
+                                                oscoreObjLink.getObjectInstanceId());
+                                    }
                                 }
                             }
                         }
@@ -143,15 +149,22 @@ public class ServersInfoExtractor {
                     // find associated oscore instance (if any)
                     LwM2mObjectInstance oscoreInstance = null;
                     ObjectLink oscoreObjLink = (ObjectLink) security.getResource(SEC_OSCORE_SECURITY_MODE).getValue();
-                    if (oscoreObjLink != null) {
-                        int oscoreObjectInstanceId = oscoreObjLink.getObjectInstanceId();
-                        if (!oscoreObjLink.isNullLink() && oscoreObjLink.getObjectId() != OSCORE) {
-                            LOG.warn("The security object's 'OSCORE Security Mode' links to an incorrect object type.");
+                    if (oscoreObjLink != null && !oscoreObjLink.isNullLink()) {
+                        if (oscoreObjLink.getObjectId() != OSCORE) {
+                            LOG.warn(
+                                    "Invalid Security info for LWM2M server : 'OSCORE Security Mode' does not link to OSCORE Object but to {} object.",
+                                    oscoreObjLink.getObjectId());
                         } else {
-                            oscoreInstance = oscores.getInstance(oscoreObjectInstanceId);
-                            if (oscoreInstance == null) {
-                                // maybe we should use same log level for this one and the other just above
-                                LOG.error("Failed to retrieve OSCORE object linked from DM security object");
+                            if (oscores == null) {
+                                LOG.warn(
+                                        "Invalid Security info for LWM2M server : OSCORE object enabler is not available.");
+                            } else {
+                                oscoreInstance = oscores.getInstance(oscoreObjLink.getObjectInstanceId());
+                                if (oscoreInstance == null) {
+                                    LOG.warn(
+                                            "Invalid Security info for LWM2M server : OSCORE instance {} does not exist.",
+                                            oscoreObjLink.getObjectInstanceId());
+                                }
                             }
                         }
                     }

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
@@ -265,6 +265,7 @@ public class LinkFormatHelperTest {
         Link[] links = LinkFormatHelper.getBootstrapClientDescription(objectEnablers);
         String strLinks = Link.serialize(links);
 
+        // TODO : handle version correctly
         assertEquals(
                 "</>;lwm2m=1.0,</0/0>;ssid=111,</0/1>,</0/2>;ssid=222,</0/3>;ssid=333,</1>;ver=2.0,</1/0>;ssid=333,</2>;ver=2.0,</3/0>",
                 strLinks);

--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -13,6 +13,7 @@ and the Eclipse Distribution License is available at
 
 Contributors:
     Zebra Technologies - initial API and implementation
+    Rikard Höglund (RISE SICS) - Additions to support OSCORE
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -35,6 +35,11 @@ Contributors:
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.californium</groupId>
+            <artifactId>cf-oscore</artifactId>
+            <version>${californium.version}</version>
+        </dependency>
 
         <!-- runtime dependencies -->
         <dependency>

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -14,6 +14,7 @@
  *     Zebra Technologies - initial API and implementation
  *     Sierra Wireless, - initial API and implementation
  *     Bosch Software Innovations GmbH, - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 
 package org.eclipse.leshan.client.demo;
@@ -23,8 +24,6 @@ import static org.eclipse.leshan.core.LwM2mId.*;
 
 import java.io.File;
 import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -49,13 +48,9 @@ import org.apache.commons.cli.Option.Builder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.californium.core.network.config.NetworkConfig;
-import org.eclipse.californium.cose.AlgorithmID;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.util.SslContextUtil;
-import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
-import org.eclipse.californium.oscore.OSCoreCtx;
-import org.eclipse.californium.oscore.OSException;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.ClientHandshaker;
@@ -72,6 +67,7 @@ import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.californium.OscoreHandler;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
+import org.eclipse.leshan.client.object.Oscore;
 import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
@@ -575,45 +571,20 @@ public class LeshanClientDemo {
         // Get models folder
         String modelsFolderPath = cl.getOptionValue("m");
 
-        // Set up OSCORE Context when using OSCORE
+        // Set boolean controlling OSCORE usage
+        // TODO OSCORE : we should define a wording for OSCORE class : Oscore or OSCore or OSCORE
+        boolean useOSCore = false;
         if (cl.hasOption("oscore")) {
             System.out.println("Using OSCORE");
-
-            HashMapCtxDB db = OscoreHandler.getContextDB();
-            AlgorithmID alg = AlgorithmID.AES_CCM_16_64_128;
-            AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
-
-            byte[] master_secret = { 0x11, 0x22, 0x33, 0x44 };
-            byte[] sid = new byte[] { (byte) 0xAA };
-            byte[] rid = new byte[] { (byte) 0xBB };
-
-            // Add the OSCORE context associated to the URI of the server
-            OSCoreCtx ctx = null;
-            try {
-                ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, null, null);
-                db.addContext(serverURI, ctx);
-            } catch (OSException e) {
-                System.err.println("Failed to generate OSCORE Context");
-                e.printStackTrace();
-            }
-
-            // Also add the context by the IP of the server since requests may use that
-            String serverIP = null;
-            try {
-                serverIP = InetAddress.getByName(new URI(serverURI).getHost()).getHostAddress();
-                db.addContext("coap://" + serverIP, ctx);
-            } catch (UnknownHostException | URISyntaxException | OSException e) {
-                System.err.println("Failed to find Server IP");
-                e.printStackTrace();
-            }
-            OSCoreCoapStackFactory.useAsDefault(db);
+            // TODO OSCORE : this should be done in DefaultEndpointFactory
+            OSCoreCoapStackFactory.useAsDefault(OscoreHandler.getContextDB());
         }
         try {
             createAndStartClient(endpoint, localAddress, localPort, cl.hasOption("b"), additionalAttributes,
                     bsAdditionalAttributes, lifetime, communicationPeriod, serverURI, pskIdentity, pskKey,
                     clientPrivateKey, clientPublicKey, serverPublicKey, clientCertificate, serverCertificate,
                     trustStore, latitude, longitude, scaleFactor, cl.hasOption("ocf"), cl.hasOption("oc"),
-                    cl.hasOption("r"), cl.hasOption("f"), modelsFolderPath, ciphers);
+                    cl.hasOption("r"), cl.hasOption("f"), modelsFolderPath, ciphers, useOSCore);
         } catch (Exception e) {
             System.err.println("Unable to create and start client ...");
             e.printStackTrace();
@@ -628,7 +599,7 @@ public class LeshanClientDemo {
             X509Certificate clientCertificate, X509Certificate serverCertificate, List<Certificate> trustStore,
             Float latitude, Float longitude, float scaleFactor, boolean supportOldFormat,
             boolean supportDeprecatedCiphers, boolean reconnectOnUpdate, boolean forceFullhandshake,
-            String modelsFolderPath, List<CipherSuite> ciphers) throws Exception {
+            String modelsFolderPath, List<CipherSuite> ciphers, boolean useOSCore) throws Exception {
 
         locationInstance = new MyLocation(latitude, longitude, scaleFactor);
 
@@ -669,6 +640,12 @@ public class LeshanClientDemo {
             } else if (clientCertificate != null) {
                 initializer.setInstancesForObject(SECURITY, x509(serverURI, 123, clientCertificate.getEncoded(),
                         clientPrivateKey.getEncoded(), serverCertificate.getEncoded()));
+                initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
+            } else if (useOSCore) {
+                String clientName = Hex.encodeHexString(endpoint.getBytes());
+                Oscore oscoreObject = new Oscore(12345, "11223344", clientName, "BB"); // Partially hardcoded values
+                initializer.setInstancesForObject(SECURITY, oscoreOnly(serverURI, 123, oscoreObject.getId()));
+                initializer.setInstancesForObject(OSCORE, oscoreObject);
                 initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
             } else {
                 initializer.setInstancesForObject(SECURITY, noSec(serverURI, 123));

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -605,13 +605,13 @@ public class LeshanClientDemo {
         // Get models folder
         String modelsFolderPath = cl.getOptionValue("m");
 
+        // TODO OSCORE : OSCoreCoapStack should be create in Default endpoint factory
+        HashMapCtxDB db = OscoreHandler.getContextDB();
+        OSCoreCoapStackFactory.useAsDefault(db);
+
         // Set parameters controlling OSCORE usage
         OSCoreSettings oscoreSettings = null;
         if (cl.hasOption("msec")) {
-
-            HashMapCtxDB db = OscoreHandler.getContextDB();
-            // TODO OSCORE : OSCoreCoapStack should be create in Default endpoint factory
-            OSCoreCoapStackFactory.useAsDefault(db);
 
             // Parse OSCORE related command line parameters
 
@@ -744,6 +744,7 @@ public class LeshanClientDemo {
                 initializer.setInstancesForObject(SECURITY, noSecBootstap(serverURI));
                 initializer.setClassForObject(SERVER, Server.class);
             }
+            initializer.setClassForObject(OSCORE, Oscore.class);
         } else {
             if (pskIdentity != null) {
                 initializer.setInstancesForObject(SECURITY, psk(serverURI, 123, pskIdentity, pskKey));

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -247,8 +247,6 @@ public class LeshanClientDemo {
                 "The OSCORE pre-shared key used between the Client and LwM2M Server/Bootstrap Server.");
         options.addOption("msalt", true,
                 "The OSCORE master salt used between the Client and LwM2M Server or Bootstrap Server.\nDefault: Empty");
-        options.addOption("idctx", true,
-                "The OSCORE ID Context used between the Client and LwM2M Server or Bootstrap Server.\nDefault: Empty");
         options.addOption("sid", true,
                 "The OSCORE Sender ID used by the client to the LwM2M Server or Bootstrap Server.");
         options.addOption("rid", true,
@@ -630,13 +628,6 @@ public class LeshanClientDemo {
                 mastersaltStr = "";
             }
 
-            String idcontextStr = cl.getOptionValue("idctx");
-            if (idcontextStr != null) {
-                System.err.println("The OSCORE ID Context parameter is not yet supported");
-                formatter.printHelp(USAGE, options);
-                return;
-            }
-
             String senderidStr = cl.getOptionValue("sid");
             if (senderidStr == null) {
                 System.err.println("The OSCORE Sender ID must be indicated");
@@ -692,7 +683,7 @@ public class LeshanClientDemo {
             }
 
             // Save the configured OSCORE parameters
-            oscoreSettings = new OSCoreSettings(mastersecretStr, mastersaltStr, idcontextStr, senderidStr,
+            oscoreSettings = new OSCoreSettings(mastersecretStr, mastersaltStr, senderidStr,
                     recipientidStr, aeadInt, hkdfInt);
         }
 
@@ -1051,7 +1042,7 @@ public class LeshanClientDemo {
         public int aeadAlgorithm;
         public int hkdfAlgorithm;
 
-        public OSCoreSettings(String masterSecret, String masterSalt, String idContext, String senderId,
+        public OSCoreSettings(String masterSecret, String masterSalt, String senderId,
                 String recipientId, int aeadAlgorithm, int hkdfAlgorithm) {
             this.masterSecret = masterSecret;
             this.masterSalt = masterSalt;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -48,8 +48,11 @@ import org.apache.commons.cli.Option.Builder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.cose.AlgorithmID;
+import org.eclipse.californium.cose.CoseException;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.util.SslContextUtil;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
@@ -85,6 +88,8 @@ import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.SecurityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.upokecenter.cbor.CBORObject;
 
 public class LeshanClientDemo {
 
@@ -181,6 +186,14 @@ public class LeshanClientDemo {
         X509Chapter.append("\n | See https://github.com/eclipse/leshan/wiki/Credential-files-format   |");
         X509Chapter.append("\n ------------------------------------------------------------------------");
 
+        final StringBuilder OSCOREChapter = new StringBuilder();
+        OSCOREChapter.append("\n .");
+        OSCOREChapter.append("\n .");
+        OSCOREChapter.append("\n ===============================[OSCORE]=================================");
+        OSCOREChapter.append("\n | By default Leshan demo use non secure connection.                    |");
+        OSCOREChapter.append("\n | To use OSCORE, -msec -sid -rid options should be used together       |");
+        OSCOREChapter.append("\n ------------------------------------------------------------------------");
+
         options.addOption("h", "help", false, "Display help information.");
         options.addOption("n", true, String.format(
                 "Set the endpoint name of the Client.\nDefault: the local hostname or '%s' if any.", DEFAULT_ENDPOINT));
@@ -228,8 +241,22 @@ public class LeshanClientDemo {
         options.addOption("ccert", true,
                 "The path to your client certificate file.\n The certificate Common Name (CN) should generaly be equal to the client endpoint name (see -n option).\nThe certificate should be in X509v3 format (DER encoding).");
         options.addOption("scert", true,
-                "The path to your server certificate file.\n The certificate should be in X509v3 format (DER encoding).");
-        options.addOption("oscore", false, "Use OSCORE for communication between client and server.");
+                "The path to your server certificate file.\n The certificate should be in X509v3 format (DER encoding)."
+                        + OSCOREChapter);
+        options.addOption("msec", true,
+                "The OSCORE pre-shared key used between the Client and LwM2M Server/Bootstrap Server.");
+        options.addOption("msalt", true,
+                "The OSCORE master salt used between the Client and LwM2M Server or Bootstrap Server.\nDefault: Empty");
+        options.addOption("idctx", true,
+                "The OSCORE ID Context used between the Client and LwM2M Server or Bootstrap Server.\nDefault: Empty");
+        options.addOption("sid", true,
+                "The OSCORE Sender ID used by the client to the LwM2M Server or Bootstrap Server.");
+        options.addOption("rid", true,
+                "The OSCORE Recipient ID used by the client to the LwM2M Server or Bootstrap Server.");
+        options.addOption("aead", true,
+                "The OSCORE AEAD algorithm used between the Client and LwM2M Server or Bootstrap Server.\nDefault: AES_CCM_16_64_128");
+        options.addOption("hkdf", true,
+                "The OSCORE HKDF algorithm used between the Client and LwM2M Server or Bootstrap Server.\nDefault: HKDF_HMAC_SHA_256");
 
         final StringBuilder trustStoreChapter = new StringBuilder();
         trustStoreChapter.append("\n .");
@@ -312,6 +339,15 @@ public class LeshanClientDemo {
             if (!x509config && !rpkConfig) {
                 System.err.println(
                         "cprik should be used with ccert and scert for X509 config OR cpubk and spubk for RPK config");
+                formatter.printHelp(USAGE, options);
+                return;
+            }
+        }
+
+        // Abort if all OSCORE config is not complete
+        if (cl.hasOption("msec")) {
+            if (!cl.hasOption("sid") || !cl.hasOption("rid")) {
+                System.err.println("msec, sid and rid should be used together to connect using OSCORE");
                 formatter.printHelp(USAGE, options);
                 return;
             }
@@ -571,20 +607,101 @@ public class LeshanClientDemo {
         // Get models folder
         String modelsFolderPath = cl.getOptionValue("m");
 
-        // Set boolean controlling OSCORE usage
-        // TODO OSCORE : we should define a wording for OSCORE class : Oscore or OSCore or OSCORE
-        boolean useOSCore = false;
-        if (cl.hasOption("oscore")) {
-            System.out.println("Using OSCORE");
-            // TODO OSCORE : this should be done in DefaultEndpointFactory
-            OSCoreCoapStackFactory.useAsDefault(OscoreHandler.getContextDB());
+        // Set parameters controlling OSCORE usage
+        OSCoreSettings oscoreSettings = null;
+        if (cl.hasOption("msec")) {
+
+            HashMapCtxDB db = OscoreHandler.getContextDB();
+            // TODO OSCORE : OSCoreCoapStack should be create in Default endpoint factory
+            OSCoreCoapStackFactory.useAsDefault(db);
+
+            // Parse OSCORE related command line parameters
+
+            String mastersecretStr = cl.getOptionValue("msec");
+            if (mastersecretStr == null) {
+                System.err.println("The OSCORE master secret must be indicated");
+                formatter.printHelp(USAGE, options);
+                return;
+            }
+
+            // Set salt to empty string if not indicated
+            String mastersaltStr = cl.getOptionValue("msalt");
+            if (mastersaltStr == null) {
+                mastersaltStr = "";
+            }
+
+            String idcontextStr = cl.getOptionValue("idctx");
+            if (idcontextStr != null) {
+                System.err.println("The OSCORE ID Context parameter is not yet supported");
+                formatter.printHelp(USAGE, options);
+                return;
+            }
+
+            String senderidStr = cl.getOptionValue("sid");
+            if (senderidStr == null) {
+                System.err.println("The OSCORE Sender ID must be indicated");
+                formatter.printHelp(USAGE, options);
+                return;
+            }
+
+            String recipientidStr = cl.getOptionValue("rid");
+            if (recipientidStr == null) {
+                System.err.println("The OSCORE Recipient ID must be indicated");
+                formatter.printHelp(USAGE, options);
+                return;
+            }
+
+            // Parse AEAD Algorithm (set to default if not indicated)
+            String aeadStr = cl.getOptionValue("aead");
+            String defaultAeadAlgorithm = "AES_CCM_16_64_128";
+            if (aeadStr == null) {
+                aeadStr = defaultAeadAlgorithm;
+            }
+
+            int aeadInt;
+            try {
+                if (aeadStr.matches("-?\\d+")) { // Indicated as integer
+                    aeadInt = AlgorithmID.FromCBOR(CBORObject.FromObject(Integer.parseInt(aeadStr))).AsCBOR().AsInt32();
+                } else { // Indicated as string
+                    aeadInt = AlgorithmID.valueOf(aeadStr).AsCBOR().AsInt32();
+                }
+            } catch (IllegalArgumentException | CoseException e) {
+                System.err.println("The AEAD algorithm is not supported (" + defaultAeadAlgorithm + " recommended)");
+                formatter.printHelp(USAGE, options);
+                return;
+            }
+
+            // Parse HKDF Algorithm (set to default if not indicated)
+            String hkdfStr = cl.getOptionValue("hkdf");
+            String defaultHkdfAlgorithm = "HKDF_HMAC_SHA_256";
+            if (hkdfStr == null) {
+                hkdfStr = defaultHkdfAlgorithm;
+            }
+
+            int hkdfInt;
+            try {
+                if (hkdfStr.matches("-?\\d+")) { // Indicated as integer
+                    hkdfInt = AlgorithmID.FromCBOR(CBORObject.FromObject(Integer.parseInt(hkdfStr))).AsCBOR().AsInt32();
+                } else { // Indicated as string
+                    hkdfInt = AlgorithmID.valueOf(hkdfStr).AsCBOR().AsInt32();
+                }
+            } catch (IllegalArgumentException | CoseException e) {
+                System.err.println("The HKDF algorithm is not supported (" + defaultHkdfAlgorithm + " recommended)");
+                formatter.printHelp(USAGE, options);
+                return;
+            }
+
+            // Save the configured OSCORE parameters
+            oscoreSettings = new OSCoreSettings(mastersecretStr, mastersaltStr, idcontextStr, senderidStr,
+                    recipientidStr, aeadInt, hkdfInt);
         }
+
         try {
             createAndStartClient(endpoint, localAddress, localPort, cl.hasOption("b"), additionalAttributes,
                     bsAdditionalAttributes, lifetime, communicationPeriod, serverURI, pskIdentity, pskKey,
                     clientPrivateKey, clientPublicKey, serverPublicKey, clientCertificate, serverCertificate,
                     trustStore, latitude, longitude, scaleFactor, cl.hasOption("ocf"), cl.hasOption("oc"),
-                    cl.hasOption("r"), cl.hasOption("f"), modelsFolderPath, ciphers, useOSCore);
+                    cl.hasOption("r"), cl.hasOption("f"), modelsFolderPath, ciphers, oscoreSettings);
         } catch (Exception e) {
             System.err.println("Unable to create and start client ...");
             e.printStackTrace();
@@ -599,7 +716,7 @@ public class LeshanClientDemo {
             X509Certificate clientCertificate, X509Certificate serverCertificate, List<Certificate> trustStore,
             Float latitude, Float longitude, float scaleFactor, boolean supportOldFormat,
             boolean supportDeprecatedCiphers, boolean reconnectOnUpdate, boolean forceFullhandshake,
-            String modelsFolderPath, List<CipherSuite> ciphers, boolean useOSCore) throws Exception {
+            String modelsFolderPath, List<CipherSuite> ciphers, OSCoreSettings oscoreSettings) throws Exception {
 
         locationInstance = new MyLocation(latitude, longitude, scaleFactor);
 
@@ -641,9 +758,10 @@ public class LeshanClientDemo {
                 initializer.setInstancesForObject(SECURITY, x509(serverURI, 123, clientCertificate.getEncoded(),
                         clientPrivateKey.getEncoded(), serverCertificate.getEncoded()));
                 initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
-            } else if (useOSCore) {
-                String clientName = Hex.encodeHexString(endpoint.getBytes());
-                Oscore oscoreObject = new Oscore(12345, "11223344", clientName, "BB"); // Partially hardcoded values
+            } else if (oscoreSettings != null) {
+                Oscore oscoreObject = new Oscore(12345, oscoreSettings.masterSecret, oscoreSettings.senderId,
+                        oscoreSettings.recipientId, oscoreSettings.aeadAlgorithm, oscoreSettings.hkdfAlgorithm,
+                        oscoreSettings.masterSalt);
                 initializer.setInstancesForObject(SECURITY, oscoreOnly(serverURI, 123, oscoreObject.getId()));
                 initializer.setInstancesForObject(OSCORE, oscoreObject);
                 initializer.setInstancesForObject(SERVER, new Server(123, lifetime, BindingMode.U, false));
@@ -821,6 +939,21 @@ public class LeshanClientDemo {
                     Hex.encodeHexString(clientPrivateKey.getEncoded()));
         }
 
+        // Display OSCORE settings
+        if (oscoreSettings != null) {
+            try {
+                LOG.info(
+                        "Client uses OSCORE : \n Master Secret (Hex): {} \n Master Salt (Hex): {} \n Sender ID (Hex): {} \n Recipient ID (Hex) {} \n AEAD Algorithm: {} ({}) \n HKDF Algorithm: {} ({})",
+                        oscoreSettings.masterSecret, oscoreSettings.masterSalt, oscoreSettings.senderId,
+                        oscoreSettings.recipientId, oscoreSettings.aeadAlgorithm,
+                        AlgorithmID.FromCBOR(CBORObject.FromObject(oscoreSettings.aeadAlgorithm)),
+                        oscoreSettings.hkdfAlgorithm,
+                        AlgorithmID.FromCBOR(CBORObject.FromObject(oscoreSettings.hkdfAlgorithm)));
+            } catch (CoseException e) {
+                throw new IllegalStateException("Invalid agorithm used for OSCORE.");
+            }
+        }
+
         // Print commands help
         StringBuilder commandsHelp = new StringBuilder("Commands available :");
         commandsHelp.append(System.lineSeparator());
@@ -899,6 +1032,26 @@ public class LeshanClientDemo {
                     LOG.info("Unknown command '{}'", command);
                 }
             }
+        }
+    }
+
+    // Class for holding OSCORE related information
+    private static class OSCoreSettings {
+        public String masterSecret;
+        public String masterSalt;
+        public String senderId;
+        public String recipientId;
+        public int aeadAlgorithm;
+        public int hkdfAlgorithm;
+
+        public OSCoreSettings(String masterSecret, String masterSalt, String idContext, String senderId,
+                String recipientId, int aeadAlgorithm, int hkdfAlgorithm) {
+            this.masterSecret = masterSecret;
+            this.masterSalt = masterSalt;
+            this.senderId = senderId;
+            this.recipientId = recipientId;
+            this.aeadAlgorithm = aeadAlgorithm;
+            this.hkdfAlgorithm = hkdfAlgorithm;
         }
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -742,6 +742,13 @@ public class LeshanClientDemo {
                 initializer.setInstancesForObject(SECURITY, x509Bootstrap(serverURI, clientCertificate.getEncoded(),
                         clientPrivateKey.getEncoded(), serverCertificate.getEncoded()));
                 initializer.setClassForObject(SERVER, Server.class);
+            } else if (oscoreSettings != null) {
+                Oscore oscoreObject = new Oscore(12345, oscoreSettings.masterSecret, oscoreSettings.senderId,
+                        oscoreSettings.recipientId, oscoreSettings.aeadAlgorithm, oscoreSettings.hkdfAlgorithm,
+                        oscoreSettings.masterSalt);
+                initializer.setInstancesForObject(SECURITY, oscoreOnlyBootstrap(serverURI, 123, oscoreObject.getId()));
+                initializer.setInstancesForObject(OSCORE, oscoreObject);
+                initializer.setClassForObject(SERVER, Server.class);
             } else {
                 initializer.setInstancesForObject(SECURITY, noSecBootstap(serverURI));
                 initializer.setClassForObject(SERVER, Server.class);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -23,13 +23,21 @@ import static org.eclipse.leshan.core.LwM2mId.*;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,8 +49,13 @@ import org.apache.commons.cli.Option.Builder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.cose.AlgorithmID;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.util.SslContextUtil;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.ClientHandshaker;
@@ -57,6 +70,7 @@ import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
+import org.eclipse.leshan.client.californium.OscoreHandler;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
@@ -219,15 +233,18 @@ public class LeshanClientDemo {
                 "The path to your client certificate file.\n The certificate Common Name (CN) should generaly be equal to the client endpoint name (see -n option).\nThe certificate should be in X509v3 format (DER encoding).");
         options.addOption("scert", true,
                 "The path to your server certificate file.\n The certificate should be in X509v3 format (DER encoding).");
+        options.addOption("oscore", false, "Use OSCORE for communication between client and server.");
 
         final StringBuilder trustStoreChapter = new StringBuilder();
         trustStoreChapter.append("\n .");
-        trustStoreChapter.append("\n URI format: file://<path-to-trust-store-file>#<hex-strore-password>#<alias-pattern>");
+        trustStoreChapter
+                .append("\n URI format: file://<path-to-trust-store-file>#<hex-strore-password>#<alias-pattern>");
         trustStoreChapter.append("\n .");
         trustStoreChapter.append("\n Where:");
         trustStoreChapter.append("\n - path-to-trust-store-file is path to pkcs12 trust store file");
         trustStoreChapter.append("\n - hex-store-password is HEX formatted password for store");
-        trustStoreChapter.append("\n - alias-pattern can be used to filter trusted certificates and can also be empty to get all");
+        trustStoreChapter.append(
+                "\n - alias-pattern can be used to filter trusted certificates and can also be empty to get all");
         trustStoreChapter.append("\n .");
         trustStoreChapter.append("\n Default: All certificates are trusted which is only OK for a demo.");
 
@@ -491,7 +508,8 @@ public class LeshanClientDemo {
 
                 // check input exists
                 if (!input.exists()) {
-                    System.err.println("Failed to load trust store - file or directory does not exist : " + input.toString());
+                    System.err.println(
+                            "Failed to load trust store - file or directory does not exist : " + input.toString());
                     formatter.printHelp(USAGE, options);
                     return;
                 }
@@ -557,6 +575,39 @@ public class LeshanClientDemo {
         // Get models folder
         String modelsFolderPath = cl.getOptionValue("m");
 
+        // Set up OSCORE Context when using OSCORE
+        if (cl.hasOption("oscore")) {
+            System.out.println("Using OSCORE");
+
+            HashMapCtxDB db = OscoreHandler.getContextDB();
+            AlgorithmID alg = AlgorithmID.AES_CCM_16_64_128;
+            AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
+
+            byte[] master_secret = { 0x11, 0x22, 0x33, 0x44 };
+            byte[] sid = new byte[] { (byte) 0xAA };
+            byte[] rid = new byte[] { (byte) 0xBB };
+
+            // Add the OSCORE context associated to the URI of the server
+            OSCoreCtx ctx = null;
+            try {
+                ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, null, null);
+                db.addContext(serverURI, ctx);
+            } catch (OSException e) {
+                System.err.println("Failed to generate OSCORE Context");
+                e.printStackTrace();
+            }
+
+            // Also add the context by the IP of the server since requests may use that
+            String serverIP = null;
+            try {
+                serverIP = InetAddress.getByName(new URI(serverURI).getHost()).getHostAddress();
+                db.addContext("coap://" + serverIP, ctx);
+            } catch (UnknownHostException | URISyntaxException | OSException e) {
+                System.err.println("Failed to find Server IP");
+                e.printStackTrace();
+            }
+            OSCoreCoapStackFactory.useAsDefault(db);
+        }
         try {
             createAndStartClient(endpoint, localAddress, localPort, cl.hasOption("b"), additionalAttributes,
                     bsAdditionalAttributes, lifetime, communicationPeriod, serverURI, pskIdentity, pskKey,

--- a/leshan-core-cf/pom.xml
+++ b/leshan-core-cf/pom.xml
@@ -13,6 +13,7 @@ and the Eclipse Distribution License is available at
 
 Contributors:
     Sierra Wireless - initial API and implementation
+    Rikard Höglund (RISE SICS) - Additions to support OSCORE
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -39,6 +40,11 @@ Contributors:
         <dependency>
             <groupId>org.eclipse.californium</groupId>
             <artifactId>scandium</artifactId>
+        </dependency>
+        <dependency>
+                <groupId>org.eclipse.californium</groupId>
+                <artifactId>cf-oscore</artifactId>
+                <version>${californium.version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
@@ -27,6 +27,7 @@ import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
 import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 
@@ -101,7 +102,8 @@ public class DefaultEndpointFactory implements EndpointFactory {
 
     @Override
     public CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, NetworkConfig coapConfig,
-            ObservationStore store) {
+            ObservationStore store, HashMapCtxDB db) {
+        // TODO OSCORE : db should maybe be replaced by OscoreEStore
         return createUnsecuredEndpointBuilder(address, coapConfig, store).build();
     }
 
@@ -148,7 +150,8 @@ public class DefaultEndpointFactory implements EndpointFactory {
 
     @Override
     public CoapEndpoint createSecuredEndpoint(DtlsConnectorConfig dtlsConfig, NetworkConfig coapConfig,
-            ObservationStore store) {
+            ObservationStore store, HashMapCtxDB db) {
+        // TODO OSCORE : db should maybe be replaced by OscoreEStore
         return createSecuredEndpointBuilder(dtlsConfig, coapConfig, store).build();
     }
 

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointFactory.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointFactory.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.core.californium;
 
@@ -20,6 +21,7 @@ import java.net.InetSocketAddress;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 
 /**
@@ -29,8 +31,9 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
  */
 public interface EndpointFactory {
 
-    CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, NetworkConfig coapConfig, ObservationStore store);
+    CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, NetworkConfig coapConfig, ObservationStore store,
+            HashMapCtxDB db);
 
-    CoapEndpoint createSecuredEndpoint(DtlsConnectorConfig dtlsConfig, NetworkConfig coapConfig,
-            ObservationStore store);
+    CoapEndpoint createSecuredEndpoint(DtlsConnectorConfig dtlsConfig, NetworkConfig coapConfig, ObservationStore store,
+            HashMapCtxDB db);
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2mId.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2mId.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.core;
 
@@ -31,6 +32,7 @@ public interface LwM2mId {
     public static final int LOCATION = 6;
     public static final int CONNECTIVITY_STATISTICS = 7;
     public static final int SOFTWARE_MANAGEMENT = 9;
+    public static final int OSCORE = 21;
 
     /* SECURITY RESOURCES */
 
@@ -41,6 +43,16 @@ public interface LwM2mId {
     public static final int SEC_SERVER_PUBKEY = 4;
     public static final int SEC_SECRET_KEY = 5;
     public static final int SEC_SERVER_ID = 10;
+    public static final int SEC_OSCORE_SECURITY_MODE = 17;
+
+    /* OSCORE RESOURCES */
+
+    public static final int OSCORE_Master_Secret = 0;
+    public static final int OSCORE_Sender_ID = 1;
+    public static final int OSCORE_Recipient_ID = 2;
+    public static final int OSCORE_AEAD_Algorithm = 3;
+    public static final int OSCORE_HMAC_Algorithm = 4;
+    public static final int OSCORE_Master_Salt = 5;
 
     /* SERVER RESOURCES */
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapIntegrationTestHelper.java
@@ -44,6 +44,7 @@ import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.SecurityMode;
+import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapDiscoverResponse;
@@ -188,7 +189,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
         // Create Security Object (with bootstrap server only)
         String bsUrl = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                 + bootstrapServer.getUnsecuredAddress().getPort();
-        return new Security(bsUrl, true, 3, new byte[0], new byte[0], new byte[0], 0);
+        return new Security(bsUrl, true, 3, new byte[0], new byte[0], new byte[0], 0, new ObjectLink());
     }
 
     @Override

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecureIntegrationTestHelper.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Zebra Technologies - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests;
@@ -45,6 +46,7 @@ import javax.security.auth.x500.X500Principal;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
@@ -223,7 +225,7 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
 
             @Override
             public CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, NetworkConfig coapConfig,
-                    ObservationStore store) {
+                    ObservationStore store, HashMapCtxDB db) {
                 CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
                 builder.setInetSocketAddress(address);
                 builder.setNetworkConfig(coapConfig);
@@ -232,7 +234,7 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
 
             @Override
             public CoapEndpoint createSecuredEndpoint(DtlsConnectorConfig dtlsConfig, NetworkConfig coapConfig,
-                    ObservationStore store) {
+                    ObservationStore store, HashMapCtxDB db) {
                 CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
                 Builder dtlsConfigBuilder = new Builder(dtlsConfig);
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -547,12 +547,13 @@ public class LeshanServerBuilder {
         // create endpoints
         CoapEndpoint unsecuredEndpoint = null;
         if (!noUnsecuredEndpoint) {
-            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, registrationStore);
+            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, registrationStore,
+                    null);
         }
 
         CoapEndpoint securedEndpoint = null;
         if (!noSecuredEndpoint && dtlsConfig != null) {
-            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, registrationStore);
+            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, registrationStore, null);
         }
 
         if (securedEndpoint == null && unsecuredEndpoint == null) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/BootstrapResource.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.bootstrap;
 
@@ -24,11 +25,15 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.californium.LwM2mCoapResource;
 import org.eclipse.leshan.core.request.BootstrapRequest;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +57,24 @@ public class BootstrapResource extends LwM2mCoapResource {
     public void handlePOST(CoapExchange exchange) {
         Request request = exchange.advanced().getRequest();
         LOG.trace("POST received : {}", request);
+
+        // TODO OSCORE : should we really need to do this ?
+        // Check if this incoming request is using OSCORE
+        if (exchange.advanced().getRequest().getOptions().getOscore() != null) {
+            LOG.trace("Client bootstrapped using OSCORE");
+
+            // Update the URI of the associated OSCORE Context with the client's URI
+            // So the server can send requests to the client
+            HashMapCtxDB db = OscoreHandler.getContextDB();
+            OSCoreCtx clientCtx = db.getContext(exchange.advanced().getCryptographicContextID());
+
+            try {
+                db.addContext(request.getScheme() + "://"
+                        + request.getSourceContext().getPeerAddress().getHostString().toString(), clientCtx);
+            } catch (OSException e) {
+                LOG.error("Failed to update OSCORE Context for registering client.", request, e);
+            }
+        }
 
         // The LW M2M spec (section 8.2) mandates the usage of Confirmable
         // messages

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
@@ -539,12 +539,12 @@ public class LeshanBootstrapServerBuilder {
 
         CoapEndpoint unsecuredEndpoint = null;
         if (!noUnsecuredEndpoint) {
-            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null);
+            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, null);
         }
 
         CoapEndpoint securedEndpoint = null;
         if (!noSecuredEndpoint && dtlsConfig != null) {
-            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, null);
+            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, null, null);
         }
 
         if (securedEndpoint == null && unsecuredEndpoint == null) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/LwM2mResponseBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/LwM2mResponseBuilder.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.request;
 
@@ -219,6 +220,21 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
             // handle success response:
             LwM2mNode content = decodeCoapResponse(request.getPath(), coapResponse, request, clientEndpoint);
             if (coapResponse.getOptions().hasObserve()) {
+
+                /*
+                 * Note: When using OSCORE and Observe the first coapRequest sent to register an observation can have
+                 * its Token missing here. Is this because OSCORE re-creates the request before sending? When looking in
+                 * Wireshark all messages have a Token as they should. The lines below fixes this by taking the Token
+                 * from the response that came to the request (since the request actually has a Token when going out the
+                 * response will have the same correct Token.
+                 * 
+                 * TODO OSCORE : This should probably not be done here.
+                 * should we fix this ? should we check if oscore is used ?
+                 */
+                if (coapRequest.getTokenBytes() == null) {
+                    coapRequest.setToken(coapResponse.getTokenBytes());
+                }
+
                 // observe request successful
                 Observation observation = ObserveUtil.createLwM2mObservation(coapRequest);
                 // add the observation to an ObserveResponse instance

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/RequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/RequestSender.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.request;
 
@@ -29,6 +30,9 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.californium.AsyncRequestObserver;
 import org.eclipse.leshan.core.californium.CoapAsyncRequestObserver;
 import org.eclipse.leshan.core.californium.CoapResponseCallback;
@@ -54,6 +58,7 @@ import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.core.util.NamedThreadFactory;
 import org.eclipse.leshan.core.util.Validate;
 import org.eclipse.leshan.server.Destroyable;
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.server.request.LowerLayerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +139,18 @@ public class RequestSender implements Destroyable {
         request.accept(coapClientRequestBuilder);
         final Request coapRequest = coapClientRequestBuilder.getRequest();
 
+        // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
+        // TODO OSCORE : this should be added in CoapRequestBuilder
+        HashMapCtxDB db = OscoreHandler.getContextDB();
+        try {
+            if (db.getContext(coapRequest.getURI()) != null) {
+                coapRequest.getOptions().setOscore(Bytes.EMPTY);
+            }
+        } catch (OSException e) {
+            System.err.println("Failed to retrieve OSCORE Context for request");
+            e.printStackTrace();
+        }
+
         // Send CoAP request synchronously
         SyncRequestObserver<T> syncMessageObserver = new SyncRequestObserver<T>(coapRequest, timeoutInMs) {
             @Override
@@ -210,6 +227,18 @@ public class RequestSender implements Destroyable {
         request.accept(coapClientRequestBuilder);
         final Request coapRequest = coapClientRequestBuilder.getRequest();
 
+        // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
+        // TODO OSCORE : this should be added in CoapRequestBuilder
+        HashMapCtxDB db = OscoreHandler.getContextDB();
+        try {
+            if (db.getContext(coapRequest.getURI()) != null) {
+                coapRequest.getOptions().setOscore(Bytes.EMPTY);
+            }
+        } catch (OSException e) {
+            System.err.println("Failed to retrieve OSCORE Context for request");
+            e.printStackTrace();
+        }
+
         // Add CoAP request callback
         MessageObserver obs = new AsyncRequestObserver<T>(coapRequest, responseCallback, errorCallback, timeoutInMs,
                 executor) {
@@ -263,6 +292,8 @@ public class RequestSender implements Destroyable {
         // Define destination
         EndpointContext context = EndpointContextUtil.extractContext(destination, allowConnectionInitiation);
         coapRequest.setDestinationContext(context);
+
+        // TODO OSCORE : should we add the OSCORE option automatically here too ?
 
         // Send CoAP request synchronously
         CoapSyncRequestObserver syncMessageObserver = new CoapSyncRequestObserver(coapRequest, timeoutInMs);
@@ -318,6 +349,8 @@ public class RequestSender implements Destroyable {
         // Define destination
         EndpointContext context = EndpointContextUtil.extractContext(destination, allowConnectionInitiation);
         coapRequest.setDestinationContext(context);
+
+        // TODO OSCORE : should we add the OSCORE option automatically here too ?
 
         // Add CoAP request callback
         MessageObserver obs = new CoapAsyncRequestObserver(coapRequest, responseCallback, errorCallback, timeoutInMs,

--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -33,6 +33,11 @@ Contributors:
             <groupId>org.eclipse.leshan</groupId>
             <artifactId>leshan-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.californium</groupId>
+            <artifactId>cf-oscore</artifactId>
+            <version>${californium.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreHandler.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.server;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+// TODO OSCORE : remove this class and static access.
+public class OscoreHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -65,7 +65,9 @@ public class BootstrapConfig implements Serializable {
      */
     public Map<Integer, ACLConfig> acls = new HashMap<>();
 
-    // TODO OSCORE : add some javadoc
+    /**
+     * Map indexed by OSCORE Object Instance Id. Key is the OSCORE Object Instance to write.
+     */
     public Map<Integer, OscoreObject> oscore = new HashMap<>();
 
     /** Server Configuration (object 1) as defined in LWM2M 1.0.x TS. */

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
@@ -63,6 +64,9 @@ public class BootstrapConfig implements Serializable {
      * Map indexed by ACL Instance Id. Key is the ACL Instance to write.
      */
     public Map<Integer, ACLConfig> acls = new HashMap<>();
+
+    // TODO OSCORE : add some javadoc
+    public Map<Integer, OscoreObject> oscore = new HashMap<>();
 
     /** Server Configuration (object 1) as defined in LWM2M 1.0.x TS. */
     public static class ServerConfig implements Serializable {
@@ -221,6 +225,7 @@ public class BootstrapConfig implements Serializable {
          * Bootstrap-Server Account lifetime is infinite.
          */
         public Integer bootstrapServerAccountTimeout = 0;
+        public Integer oscoreSecurityMode;
 
         @Override
         public String toString() {
@@ -280,8 +285,32 @@ public class BootstrapConfig implements Serializable {
         }
     }
 
+    /** oscore configuration (object 17) */
+    // TODO OSCORE : add some javadoc
+    public static class OscoreObject implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        public String oscoreMasterSecret = "";
+        public String oscoreSenderId = "";
+        public String oscoreRecipientId = "";
+        public Integer oscoreAeadAlgorithm = null;
+        public Integer oscoreHmacAlgorithm = null;
+        public String oscoreMasterSalt = "";
+
+        @Override
+        public String toString() {
+            // Note : oscoreMasterSecret and oscoreMasterSalt are explicitly excluded from the display for security
+            // purposes
+            return String.format(
+                    "OscoreObject [oscoreSenderId=%s, oscoreRecipientId=%s, oscoreAeadAlgorithm=%s, oscoreHmacAlgorithm=%s]",
+                    oscoreSenderId, oscoreRecipientId, oscoreAeadAlgorithm, oscoreHmacAlgorithm);
+        }
+    }
+
     @Override
     public String toString() {
+        // TODO OSCORE : should we add OSCORE to toString ? or is it to sensitive data.
+        // this question remain for other config.
         return String.format("BootstrapConfig [servers=%s, security=%s, acls=%s]", servers, security, acls);
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -227,6 +227,11 @@ public class BootstrapConfig implements Serializable {
          * Bootstrap-Server Account lifetime is infinite.
          */
         public Integer bootstrapServerAccountTimeout = 0;
+        /**
+         * The Object ID of the OSCORE Object Instance that holds the OSCORE configuration to be used by the LWM2M
+         * Client to the LWM2M Server associated with this Security object.
+         * 
+         */
         public Integer oscoreSecurityMode;
 
         @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/ConfigurationChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/ConfigurationChecker.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
@@ -46,6 +47,19 @@ public class ConfigurationChecker {
         // check security configurations
         for (Map.Entry<Integer, BootstrapConfig.ServerSecurity> e : config.security.entrySet()) {
             BootstrapConfig.ServerSecurity sec = e.getValue();
+
+            // Retrieve the OSCORE object for this bootstrap server security object
+            if (sec.bootstrapServer && sec.oscoreSecurityMode != null) {
+                BootstrapConfig.OscoreObject osc = config.oscore.get(sec.oscoreSecurityMode);
+                if (osc != null) {
+                    assertIf(StringUtils.isEmpty(osc.oscoreMasterSecret), "master secret must not be empty");
+                    assertIf(StringUtils.isEmpty(osc.oscoreSenderId) && StringUtils.isEmpty(osc.oscoreRecipientId),
+                            "either sender ID or recipient ID must be filled");
+                } else {
+                    throw new InvalidConfigurationException(
+                            "Bootstrap server is set to use OSCORE, its OSCORE object must not be empty");
+                }
+            }
 
             // checks security config
             switch (sec.securityMode) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
@@ -120,10 +120,13 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
     // TODO this should be done via a kind of OSCORE Store
     public void addOscoreContext(BootstrapConfig config) {
         HashMapCtxDB db = OscoreHandler.getContextDB();
-        LOG.trace("Adding OSCORE context information to the context database");
-        BootstrapConfig.OscoreObject osc = null;
-        for (Map.Entry<Integer, BootstrapConfig.OscoreObject> o : config.oscore.entrySet()) {
-            osc = o.getValue();
+        for (ServerSecurity security : config.security.values()) {
+            // Make sure to only add OSCORE context for the BS-Client connection
+            BootstrapConfig.OscoreObject osc = config.oscore.get(security.oscoreSecurityMode);
+            if (!security.bootstrapServer || osc == null) {
+                continue;
+            }
+            LOG.trace("Adding OSCORE context information to the context database");
             try {
 
                 // Parse hexadecimal context parameters

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
@@ -19,9 +20,20 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.californium.cose.AlgorithmID;
+import org.eclipse.californium.cose.CoseException;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.util.Hex;
+import org.eclipse.leshan.server.OscoreHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.upokecenter.cbor.CBORObject;
 
 /**
  * Simple bootstrap store implementation storing bootstrap configuration information in memory.
@@ -32,6 +44,8 @@ import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
  */
 @Deprecated
 public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InMemoryBootstrapConfigStore.class);
 
     protected final ConfigurationChecker configChecker = new ConfigurationChecker();
 
@@ -67,6 +81,7 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
         if (pskToAdd != null) {
             bootstrapByPskId.put(pskToAdd, config);
         }
+        addOscoreContext(config);
     }
 
     protected void checkConfig(String endpoint, BootstrapConfig config) throws InvalidConfigurationException {
@@ -99,6 +114,49 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
     @Override
     public Map<String, BootstrapConfig> getAll() {
         return Collections.unmodifiableMap(bootstrapByEndpoint);
+    }
+
+    // If an OSCORE configuration came, add it to the context db
+    // TODO this should be done via a kind of OSCORE Store
+    public void addOscoreContext(BootstrapConfig config) {
+        HashMapCtxDB db = OscoreHandler.getContextDB();
+        LOG.trace("Adding OSCORE context information to the context database");
+        BootstrapConfig.OscoreObject osc = null;
+        for (Map.Entry<Integer, BootstrapConfig.OscoreObject> o : config.oscore.entrySet()) {
+            osc = o.getValue();
+            try {
+
+                // Parse hexadecimal context parameters
+                byte[] masterSecret = Hex.decodeHex(osc.oscoreMasterSecret.toCharArray());
+                byte[] senderId = Hex.decodeHex(osc.oscoreSenderId.toCharArray());
+                byte[] recipientId = Hex.decodeHex(osc.oscoreRecipientId.toCharArray());
+
+                // Parse master salt which, should be conveyed as null if empty
+                byte[] masterSalt = Hex.decodeHex(osc.oscoreMasterSalt.toCharArray());
+                if (masterSalt.length == 0) {
+                    masterSalt = null;
+                }
+
+                // Parse AEAD Algorithm
+                AlgorithmID aeadAlg = AlgorithmID.FromCBOR(CBORObject.FromObject(osc.oscoreAeadAlgorithm));
+
+                // Parse HKDF Algorithm
+                AlgorithmID hkdfAlg = AlgorithmID.FromCBOR(CBORObject.FromObject(osc.oscoreHmacAlgorithm));
+
+                // ID Context is not supported
+                byte[] idContext = null;
+
+                // Replay window default value
+                int replayWindow = 32;
+
+                OSCoreCtx ctx = new OSCoreCtx(masterSecret, false, aeadAlg, senderId, recipientId, hkdfAlg,
+                        replayWindow, masterSalt, idContext);
+                db.addContext(ctx);
+
+            } catch (OSException | CoseException e) {
+                LOG.error("Failed to add OSCORE context to context database.", e);
+            }
+        }
     }
 
     protected static class PskByServer {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.security;
 
@@ -99,7 +100,7 @@ public class SecurityChecker {
                 return false;
             }
         } else {
-            if (securityInfo != null) {
+            if (securityInfo != null && securityInfo.useOSCore == false) {
                 LOG.debug("Client '{}' must connect using DTLS", endpoint);
                 return false;
             }
@@ -182,6 +183,11 @@ public class SecurityChecker {
                     expectedX509CommonName, receivedX509CommonName);
             return false;
         }
+        return true;
+    }
+
+    protected boolean checkOscoreIdentity(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
+        // TODO: Add comprehensive checks here
         return true;
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
@@ -100,7 +100,9 @@ public class SecurityChecker {
                 return false;
             }
         } else {
-            if (securityInfo != null && securityInfo.useOSCore == false) {
+            if (clientIdentity.isOSCORE()) {
+                return checkOscoreIdentity(endpoint, clientIdentity, securityInfo);
+            } else if (securityInfo != null) {
                 LOG.debug("Client '{}' must connect using DTLS", endpoint);
                 return false;
             }
@@ -187,7 +189,28 @@ public class SecurityChecker {
     }
 
     protected boolean checkOscoreIdentity(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
-        // TODO: Add comprehensive checks here
+        // Manage OSCORE authentication
+        // ----------------------------------------------------
+        if (!securityInfo.useOSCORE()) {
+            LOG.debug("Client '{}' is not supposed to use OSCORE to authenticate", endpoint);
+            return false;
+        }
+
+        if (!matchOscoreIdentity(endpoint, clientIdentity.getOscoreIdentity(), securityInfo.getOscoreIdentity())) {
+            return false;
+        }
+
+        LOG.trace("Authenticated client '{}' using OSCORE", endpoint);
+        return true;
+    }
+
+    protected boolean matchOscoreIdentity(String endpoint, String receivedOscoreIdentity,
+            String expectedOscoreIdentity) {
+        if (!receivedOscoreIdentity.equals(expectedOscoreIdentity)) {
+            LOG.debug("Invalid identity for client '{}': expected '{}' but was '{}'", endpoint, expectedOscoreIdentity,
+                    receivedOscoreIdentity);
+            return false;
+        }
         return true;
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
@@ -57,6 +57,14 @@ public class SecurityChecker {
                 } while (securityInfos.hasNext());
                 return false;
             }
+        } else if (clientIdentity.isOSCORE()) {
+            LOG.trace("Checking incoming clients OSCORE identity.");
+            do {
+                SecurityInfo securityInfo = securityInfos.next();
+                if (checkSecurityInfo(endpoint, clientIdentity, securityInfo)) {
+                    return true;
+                }
+            } while (securityInfos.hasNext());
         } else if (securityInfos != null && securityInfos.hasNext()) {
             LOG.debug("Client '{}' must connect using DTLS", endpoint);
             return false;
@@ -75,7 +83,6 @@ public class SecurityChecker {
      * @see SecurityInfo
      */
     public boolean checkSecurityInfo(String endpoint, Identity clientIdentity, SecurityInfo securityInfo) {
-
         // if this is a secure end-point, we must check that the registering client is using the right identity.
         if (clientIdentity.isSecure()) {
             if (securityInfo == null) {
@@ -101,6 +108,7 @@ public class SecurityChecker {
             }
         } else {
             if (clientIdentity.isOSCORE()) {
+                LOG.trace("Checking incoming client's OSCORE identity.");
                 return checkOscoreIdentity(endpoint, clientIdentity, securityInfo);
             } else if (securityInfo != null) {
                 LOG.debug("Client '{}' must connect using DTLS", endpoint);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityChecker.java
@@ -58,13 +58,19 @@ public class SecurityChecker {
                 return false;
             }
         } else if (clientIdentity.isOSCORE()) {
-            LOG.trace("Checking incoming clients OSCORE identity.");
-            do {
-                SecurityInfo securityInfo = securityInfos.next();
-                if (checkSecurityInfo(endpoint, clientIdentity, securityInfo)) {
-                    return true;
-                }
-            } while (securityInfos.hasNext());
+            if (securityInfos == null || !securityInfos.hasNext()) {
+                LOG.debug("Client '{}' without security info trying to connect using OSCORE", endpoint);
+                return false;
+            } else {
+                // check if one expected security info matches OSCORE client identity
+                LOG.trace("Checking incoming client's OSCORE identity.");
+                do {
+                    SecurityInfo securityInfo = securityInfos.next();
+                    if (checkSecurityInfo(endpoint, clientIdentity, securityInfo)) {
+                        return true;
+                    }
+                } while (securityInfos.hasNext());
+            }
         } else if (securityInfos != null && securityInfos.hasNext()) {
             LOG.debug("Client '{}' must connect using DTLS", endpoint);
             return false;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.Validate;
 import org.eclipse.leshan.server.OscoreHandler;
 
@@ -56,7 +57,7 @@ public class SecurityInfo implements Serializable {
     private final boolean useX509Cert;
 
     // TODO OSCORE : Save content properly information here. Must be serializable.
-    boolean useOSCore;
+    private final String oscoreIdentity;
 
     private SecurityInfo(String endpoint, String identity, byte[] preSharedKey, PublicKey rawPublicKey,
             boolean useX509Cert, OSCoreCtx oscoreCtx) {
@@ -66,7 +67,7 @@ public class SecurityInfo implements Serializable {
         this.preSharedKey = preSharedKey;
         this.rawPublicKey = rawPublicKey;
         this.useX509Cert = useX509Cert;
-        this.useOSCore = oscoreCtx != null;
+        this.oscoreIdentity = generateOscoreIdentity(oscoreCtx);
     }
 
     /**
@@ -113,17 +114,27 @@ public class SecurityInfo implements Serializable {
     /**
      * Construct a {@link SecurityInfo} when using OSCORE.
      */
-    public static SecurityInfo newOSCoreInfo(String endpoint, String identity, OSCoreCtx oscoreCtx) {
-        Validate.notEmpty(identity);
-        Validate.notNull(identity);
+    public static SecurityInfo newOSCoreInfo(String endpoint, OSCoreCtx oscoreCtx) {
         Validate.notNull(oscoreCtx);
 
         // Add the OSCORE Context to the context database
         HashMapCtxDB db = OscoreHandler.getContextDB();
         db.addContext(oscoreCtx);
 
-        // TODO OSCORE : identity is reserved for PSK
-        return new SecurityInfo(endpoint, identity, null, null, false, oscoreCtx);
+        return new SecurityInfo(endpoint, null, null, null, false, oscoreCtx);
+    }
+
+    /**
+     * Generates an OSCORE identity from an OSCORE context
+     */
+    private static String generateOscoreIdentity(OSCoreCtx oscoreCtx) {
+        if (oscoreCtx == null) {
+            return null;
+        }
+
+        String oscoreIdentity = "sid=" + Hex.encodeHexString(oscoreCtx.getSenderId()) + ",rid="
+                + Hex.encodeHexString(oscoreCtx.getRecipientId());
+        return oscoreIdentity;
     }
 
     /**
@@ -177,6 +188,20 @@ public class SecurityInfo implements Serializable {
         return useX509Cert;
     }
 
+    /**
+     * @return The OSCORE identity
+     */
+    public String getOscoreIdentity() {
+        return oscoreIdentity;
+    }
+
+    /**
+     * @return <code>true</code> if this client should use OSCORE.
+     */
+    public boolean useOSCORE() {
+        return oscoreIdentity != null;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -186,6 +211,7 @@ public class SecurityInfo implements Serializable {
         result = prime * result + Arrays.hashCode(preSharedKey);
         result = prime * result + ((rawPublicKey == null) ? 0 : rawPublicKey.hashCode());
         result = prime * result + (useX509Cert ? 1231 : 1237);
+        result = prime * result + ((oscoreIdentity == null) ? 0 : oscoreIdentity.hashCode());
         return result;
     }
 
@@ -217,14 +243,21 @@ public class SecurityInfo implements Serializable {
             return false;
         if (useX509Cert != other.useX509Cert)
             return false;
+        if (oscoreIdentity == null) {
+            if (other.oscoreIdentity != null)
+                return false;
+        } else if (!oscoreIdentity.equals(other.oscoreIdentity))
+            return false;
+
         return true;
     }
 
     @Override
     public String toString() {
         // Note : preSharedKey is explicitly excluded from display for security purposes
-        return String.format("SecurityInfo [endpoint=%s, identity=%s, rawPublicKey=%s, useX509Cert=%s]", endpoint,
-                identity, rawPublicKey, useX509Cert);
+        return String.format(
+                "SecurityInfo [endpoint=%s, identity=%s, rawPublicKey=%s, useX509Cert=%s, oscoreIdentity=%s]", endpoint,
+                identity, rawPublicKey, useX509Cert, oscoreIdentity);
     }
 
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.security;
 
@@ -19,7 +20,10 @@ import java.io.Serializable;
 import java.security.PublicKey;
 import java.util.Arrays;
 
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.OscoreHandler;
 
 /**
  * The security info for a client.
@@ -31,6 +35,7 @@ import org.eclipse.leshan.core.util.Validate;
  * <li>Pre-Shared Key: the given identity and a key are needed</li>
  * <li>Raw Public Key Certificate: the given public key is needed</li>
  * <li>X509 Certificate: any trusted X509 certificate is needed</li>
+ * <li>OSCORE: an OSCORE security context is needed</li>
  * </ul>
  */
 public class SecurityInfo implements Serializable {
@@ -50,14 +55,18 @@ public class SecurityInfo implements Serializable {
     // X.509
     private final boolean useX509Cert;
 
+    // TODO OSCORE : Save content properly information here. Must be serializable.
+    boolean useOSCore;
+
     private SecurityInfo(String endpoint, String identity, byte[] preSharedKey, PublicKey rawPublicKey,
-            boolean useX509Cert) {
+            boolean useX509Cert, OSCoreCtx oscoreCtx) {
         Validate.notEmpty(endpoint);
         this.endpoint = endpoint;
         this.identity = identity;
         this.preSharedKey = preSharedKey;
         this.rawPublicKey = rawPublicKey;
         this.useX509Cert = useX509Cert;
+        this.useOSCore = oscoreCtx != null;
     }
 
     /**
@@ -72,7 +81,7 @@ public class SecurityInfo implements Serializable {
     public static SecurityInfo newPreSharedKeyInfo(String endpoint, String identity, byte[] preSharedKey) {
         Validate.notEmpty(identity);
         Validate.notNull(preSharedKey);
-        return new SecurityInfo(endpoint, identity, preSharedKey, null, false);
+        return new SecurityInfo(endpoint, identity, preSharedKey, null, false, null);
     }
 
     /**
@@ -85,7 +94,7 @@ public class SecurityInfo implements Serializable {
      */
     public static SecurityInfo newRawPublicKeyInfo(String endpoint, PublicKey rawPublicKey) {
         Validate.notNull(rawPublicKey);
-        return new SecurityInfo(endpoint, null, null, rawPublicKey, false);
+        return new SecurityInfo(endpoint, null, null, rawPublicKey, false, null);
     }
 
     /**
@@ -98,7 +107,23 @@ public class SecurityInfo implements Serializable {
      * @return a X.509 Security Info.
      */
     public static SecurityInfo newX509CertInfo(String endpoint) {
-        return new SecurityInfo(endpoint, null, null, null, true);
+        return new SecurityInfo(endpoint, null, null, null, true, null);
+    }
+
+    /**
+     * Construct a {@link SecurityInfo} when using OSCORE.
+     */
+    public static SecurityInfo newOSCoreInfo(String endpoint, String identity, OSCoreCtx oscoreCtx) {
+        Validate.notEmpty(identity);
+        Validate.notNull(identity);
+        Validate.notNull(oscoreCtx);
+
+        // Add the OSCORE Context to the context database
+        HashMapCtxDB db = OscoreHandler.getContextDB();
+        db.addContext(oscoreCtx);
+
+        // TODO OSCORE : identity is reserved for PSK
+        return new SecurityInfo(endpoint, identity, null, null, false, oscoreCtx);
     }
 
     /**

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
@@ -131,14 +131,8 @@ public class SecurityDeserializer implements JsonDeserializer<SecurityInfo> {
                     }
                 }
 
+                // ID Context not supported
                 byte[] idContext = null;
-                if (oscore.get("idContext") != null) {
-                    idContext = Hex.decodeHex(oscore.get("idContext").getAsString().toCharArray());
-
-                    if (idContext.length == 0) {
-                        idContext = null;
-                    }
-                }
 
                 // Parse AEAD Algorithm
                 AlgorithmID aeadAlgorithm = null;

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
@@ -174,17 +174,7 @@ public class SecurityDeserializer implements JsonDeserializer<SecurityInfo> {
                     throw new JsonParseException("Failed to generate OSCORE context", e);
                 }
 
-                // Create an identity string from the OSCORE context information
-                StringBuilder b = new StringBuilder();
-                if (ctx.getIdContext() != null) {
-                    b.append(Hex.encodeHex(ctx.getIdContext()));
-                    b.append(":");
-                }
-                b.append(Hex.encodeHex(ctx.getRecipientId()));
-                String identity = b.toString();
-
-                // TODO OSCORE : identity is for PSK and should not be used for OSCORE
-                info = SecurityInfo.newOSCoreInfo(endpoint, identity, ctx);
+                info = SecurityInfo.newOSCoreInfo(endpoint, ctx);
             } else {
                 throw new JsonParseException("Invalid security info content");
             }

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.demo.servlet.json;
 
@@ -28,6 +29,9 @@ import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.KeySpec;
 
+import org.eclipse.californium.cose.AlgorithmID;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.SecurityUtil;
 import org.eclipse.leshan.server.security.SecurityInfo;
@@ -63,6 +67,7 @@ public class SecurityDeserializer implements JsonDeserializer<SecurityInfo> {
 
             JsonObject psk = (JsonObject) object.get("psk");
             JsonObject rpk = (JsonObject) object.get("rpk");
+            JsonObject oscore = (JsonObject) object.get("oscore");
             JsonPrimitive x509 = object.getAsJsonPrimitive("x509");
             if (psk != null) {
                 // PSK Deserialization
@@ -108,6 +113,78 @@ public class SecurityDeserializer implements JsonDeserializer<SecurityInfo> {
                 info = SecurityInfo.newRawPublicKeyInfo(endpoint, key);
             } else if (x509 != null && x509.getAsBoolean()) {
                 info = SecurityInfo.newX509CertInfo(endpoint);
+            } else if (oscore != null) {
+                // OSCORE Deserialization
+
+                // Parse hexadecimal context parameters
+                byte[] masterSecret = Hex.decodeHex(oscore.get("masterSecret").getAsString().toCharArray());
+                byte[] senderId = Hex.decodeHex(oscore.get("senderId").getAsString().toCharArray());
+                byte[] recipientId = Hex.decodeHex(oscore.get("recipientId").getAsString().toCharArray());
+
+                // Check parameters that are allowed to be empty
+                byte[] masterSalt = null;
+                if (oscore.get("masterSalt") != null) {
+                    masterSalt = Hex.decodeHex(oscore.get("masterSalt").getAsString().toCharArray());
+
+                    if (masterSalt.length == 0) {
+                        masterSalt = null;
+                    }
+                }
+
+                byte[] idContext = null;
+                if (oscore.get("idContext") != null) {
+                    idContext = Hex.decodeHex(oscore.get("idContext").getAsString().toCharArray());
+
+                    if (idContext.length == 0) {
+                        idContext = null;
+                    }
+                }
+
+                // Parse AEAD Algorithm
+                AlgorithmID aeadAlgorithm = null;
+                try {
+                    String aeadAlgorithmStr = oscore.get("aeadAlgorithm").getAsString();
+                    aeadAlgorithm = AlgorithmID.valueOf(aeadAlgorithmStr);
+                } catch (IllegalArgumentException e) {
+                    throw new JsonParseException("Invalid AEAD algorithm", e);
+                }
+                if (aeadAlgorithm != AlgorithmID.AES_CCM_16_64_128) {
+                    throw new JsonParseException("Unsupported AEAD algorithm");
+                }
+
+                // Parse HKDF Algorithm
+                AlgorithmID hkdfAlgorithm = null;
+                try {
+                    String hkdfAlgorithmStr = oscore.get("hkdfAlgorithm").getAsString();
+                    hkdfAlgorithm = AlgorithmID.valueOf(hkdfAlgorithmStr);
+                } catch (IllegalArgumentException e) {
+                    throw new JsonParseException("Invalid HKDF algorithm", e);
+                }
+                if (hkdfAlgorithm != AlgorithmID.HKDF_HMAC_SHA_256) {
+                    throw new JsonParseException("Unsupported HKDF algorithm");
+                }
+
+                OSCoreCtx ctx = null;
+                // Attempt to generate OSCORE Context from parsed parameters
+                // Note that the sender and recipient IDs are inverted here
+                try {
+                    ctx = new OSCoreCtx(masterSecret, true, aeadAlgorithm, recipientId, senderId, hkdfAlgorithm, 32,
+                            masterSalt, idContext);
+                } catch (OSException e) {
+                    throw new JsonParseException("Failed to generate OSCORE context", e);
+                }
+
+                // Create an identity string from the OSCORE context information
+                StringBuilder b = new StringBuilder();
+                if (ctx.getIdContext() != null) {
+                    b.append(Hex.encodeHex(ctx.getIdContext()));
+                    b.append(":");
+                }
+                b.append(Hex.encodeHex(ctx.getRecipientId()));
+                String identity = b.toString();
+
+                // TODO OSCORE : identity is for PSK and should not be used for OSCORE
+                info = SecurityInfo.newOSCoreInfo(endpoint, identity, ctx);
             } else {
                 throw new JsonParseException("Invalid security info content");
             }

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecuritySerializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecuritySerializer.java
@@ -38,11 +38,13 @@ public class SecuritySerializer implements JsonSerializer<SecurityInfo> {
         JsonObject element = new JsonObject();
 
         element.addProperty("endpoint", src.getEndpoint());
-
         if (src.getIdentity() != null) {
             JsonObject psk = new JsonObject();
             psk.addProperty("identity", src.getIdentity());
-            psk.addProperty("key", Hex.encodeHexString(src.getPreSharedKey()));
+            // TODO OSCORE : remove this if because oscore should not use identity.
+            if (src.getPreSharedKey() != null) {
+                psk.addProperty("key", Hex.encodeHexString(src.getPreSharedKey()));
+            }
             element.add("psk", psk);
         }
 
@@ -80,6 +82,8 @@ public class SecuritySerializer implements JsonSerializer<SecurityInfo> {
         if (src.useX509Cert()) {
             element.addProperty("x509", true);
         }
+
+        // TODO OSCORE : implement serialization for OSCORE.
 
         return element;
     }

--- a/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
@@ -102,7 +102,12 @@ angular.module('securityControllers', [])
                     var security = {endpoint: $scope.endpoint, psk : { identity : $scope.pskIdentity , key : $scope.pskValue}};
                 } else if($scope.securityMode == "rpk") {
                     var security = {endpoint: $scope.endpoint, rpk : { key : $scope.rpkValue }};
-                } else {
+                } else if($scope.securityMode == "oscore") {
+                    // Information for OSCORE
+                    var security = {endpoint: $scope.endpoint, oscore : { masterSecret : $scope.masterSecret, masterSalt : $scope.masterSalt,
+                        idContext : $scope.idContext, senderId : $scope.senderId, recipientId : $scope.recipientId,
+                        aeadAlgorithm : $scope.aeadAlgorithm || $scope.defaultAeadAlgorithm, hkdfAlgorithm : $scope.hkdfAlgorithm || $scope.defaultHkdfAlgorithm }};
+                    } else {
                     var security = {endpoint: $scope.endpoint, x509 : true};
                 }
                 if(security) {
@@ -129,6 +134,8 @@ angular.module('securityControllers', [])
             $scope.rpkXValue = '';
             $scope.rpkYValue = '';
             $scope.defaultParams = 'secp256r1';
+            $scope.defaultAeadAlgorithm = 'AES_CCM_16_64_128';
+            $scope.defaultHkdfAlgorithm = 'HKDF_HMAC_SHA_256';
        };
 }])
 

--- a/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
+++ b/leshan-server-demo/src/main/resources/webapp/js/security-controllers.js
@@ -105,8 +105,8 @@ angular.module('securityControllers', [])
                 } else if($scope.securityMode == "oscore") {
                     // Information for OSCORE
                     var security = {endpoint: $scope.endpoint, oscore : { masterSecret : $scope.masterSecret, masterSalt : $scope.masterSalt,
-                        idContext : $scope.idContext, senderId : $scope.senderId, recipientId : $scope.recipientId,
-                        aeadAlgorithm : $scope.aeadAlgorithm || $scope.defaultAeadAlgorithm, hkdfAlgorithm : $scope.hkdfAlgorithm || $scope.defaultHkdfAlgorithm }};
+                        senderId : $scope.senderId, recipientId : $scope.recipientId, aeadAlgorithm : $scope.aeadAlgorithm || $scope.defaultAeadAlgorithm,
+                        hkdfAlgorithm : $scope.hkdfAlgorithm || $scope.defaultHkdfAlgorithm }};
                     } else {
                     var security = {endpoint: $scope.endpoint, x509 : true};
                 }

--- a/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
@@ -63,7 +63,6 @@
 			<td ng-if="security.oscore">
 				Master Secret : <code>{{ security.oscore.masterSecret }}</code><br/>
 				Master Salt : <code>{{ security.oscore.masterSalt }}</code><br/>
-				ID Context : <code>{{ security.oscore.idContext }}</code><br/>
 				Sender ID : <code>{{ security.oscore.senderId }}</code><br/>
 				Recipient ID : <code>{{ security.oscore.recipientId }}</code><br/>
 				AEAD Algorithm : <code>{{ security.oscore.aeadAlgorithm }}</code><br/>
@@ -159,17 +158,6 @@
 							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
 							<p class="help-block" ng-if="form.masterSalt.$error.pattern">Hexadecimal format is expected</p>
 							<p class="help-block" ng-if="form.masterSalt.$error.maxlength">Master Salt is too long</p>
-						</div>
-					</div>
-
-					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
-						<label for="idContextValue" class="col-sm-4 control-label">ID Context</label>
-						<div class="col-sm-8">
-							<textarea class="form-control" style="resize:none" rows="1" id="idContextValue" name="idContext" 
-							ng-model="idContext" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="32" disabled={true}></textarea>
-							<p class="text-right text-muted small" style="margin:0">Not supported</p>
-							<p class="help-block" ng-if="form.idContext.$error.pattern">Hexadecimal format is expected</p>
-							<p class="help-block" ng-if="form.idContext.$error.maxlength">ID Context is too long</p>
 						</div>
 					</div>
 

--- a/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
@@ -58,6 +58,17 @@
 				Identity : <code style=display:block;white-space:pre-wrap>{{ wrap(security.psk.identity) }}</code>
 				Key : <code style=display:block;white-space:pre-wrap>{{ wrap(security.psk.key) }}</code>
 			</td>
+			<!-- OSCORE fields -->
+			<td ng-if="security.oscore">OSCORE</td>
+			<td ng-if="security.oscore">
+				Master Secret : <code>{{ security.oscore.masterSecret }}</code><br/>
+				Master Salt : <code>{{ security.oscore.masterSalt }}</code><br/>
+				ID Context : <code>{{ security.oscore.idContext }}</code><br/>
+				Sender ID : <code>{{ security.oscore.senderId }}</code><br/>
+				Recipient ID : <code>{{ security.oscore.recipientId }}</code><br/>
+				AEAD Algorithm : <code>{{ security.oscore.aeadAlgorithm }}</code><br/>
+				HKDF Algorithm : <code>{{ security.oscore.hkdfAlgorithm }}</code>
+			</td>
 			<td ng-if="security.rpk">Raw Public Key <br/><small class="text-muted" >(Elliptic Curve)</small></td>
 			<td ng-if="security.rpk">Public Key : <br/> <code style=display:block;white-space:pre-wrap>{{wrap(security.rpk.key)}}</code><br/> 
 			</td>
@@ -98,6 +109,8 @@
 								<option value="psk">Pre-Shared Key</option>
 								<option value="rpk">Raw Public Key</option>
 								<option value="x509">X.509 Certificate</option>
+								<!-- Drop-down option for OSCORE security context information -->
+								<option value="oscore">OSCORE</option>
 							</select>
 						</div>
 					</div>
@@ -122,6 +135,83 @@
 							<p class="help-block" ng-if="form.pskValue.$error.required">The pre-shared key is required</p>
 							<p class="help-block" ng-if="form.pskValue.$error.pattern">Hexadecimal format is expected</p>
 							<p class="help-block" ng-if="form.pskValue.$error.maxlength">The pre-shared key is too long</p>
+						</div>
+					</div>
+
+					<!-- OSCORE inputs -->
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="masterSecretValue" class="col-sm-4 control-label">Master Secret</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="2" id="masterSecretValue" name="masterSecret" 
+							ng-model="masterSecret" ng-required="securityMode=='oscore'" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="64" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.masterSecret.$error.required">Master Secret is required</p>
+							<p class="help-block" ng-if="form.masterSecret.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.masterSecret.$error.maxlength">Master Secret is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="masterSaltValue" class="col-sm-4 control-label">Master Salt</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="2" id="masterSaltValue" name="masterSalt" 
+							ng-model="masterSalt" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="64" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.masterSalt.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.masterSalt.$error.maxlength">Master Salt is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="idContextValue" class="col-sm-4 control-label">ID Context</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="idContextValue" name="idContext" 
+							ng-model="idContext" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="32" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.idContext.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.idContext.$error.maxlength">ID Context is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="senderIdValue" class="col-sm-4 control-label">Sender ID</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="senderIdValue" name="senderId" 
+							ng-model="senderId" ng-required="securityMode=='oscore'" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="16" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.senderId.$error.required">Sender ID is required</p>
+							<p class="help-block" ng-if="form.senderId.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.senderId.$error.maxlength">Sender ID is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="recipientIdValue" class="col-sm-4 control-label">Recipient ID</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="recipientIdValue" name="recipientId" 
+							ng-model="recipientId" ng-required="securityMode=='oscore'" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="16" ></textarea>
+							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							<p class="help-block" ng-if="form.recipientId.$error.required">Recipient ID is required</p>
+							<p class="help-block" ng-if="form.recipientId.$error.pattern">Hexadecimal format is expected</p>
+							<p class="help-block" ng-if="form.recipientId.$error.maxlength">Recipient ID is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="aeadAlgorithmValue" class="col-sm-4 control-label">AEAD Algorithm</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="aeadAlgorithmValue" name="aeadAlgorithm" 
+							ng-model="aeadAlgorithm" ng-maxlength="32" placeholder="{{defaultAeadAlgorithm}}" ></textarea>
+							<p class="help-block" ng-if="form.aeadAlgorithm.$error.maxlength">AEAD Algorithm is too long</p>
+						</div>
+					</div>
+
+					<div class="form-group" ng-class="{'hidden': securityMode!='oscore'}" show-errors>
+						<label for="hkdfAlgorithmValue" class="col-sm-4 control-label">HKDF Algorithm</label>
+						<div class="col-sm-8">
+							<textarea class="form-control" style="resize:none" rows="1" id="hkdfAlgorithmValue" name="hkdfAlgorithm" 
+							ng-model="hkdfAlgorithm" ng-maxlength="32" placeholder="{{defaultHkdfAlgorithm}}" ></textarea>
+							<p class="help-block" ng-if="form.hkdfAlgorithm.$error.maxlength">HKDF Algorithm is too long</p>
 						</div>
 					</div>
 

--- a/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
+++ b/leshan-server-demo/src/main/resources/webapp/partials/security-list.html
@@ -166,8 +166,8 @@
 						<label for="idContextValue" class="col-sm-4 control-label">ID Context</label>
 						<div class="col-sm-8">
 							<textarea class="form-control" style="resize:none" rows="1" id="idContextValue" name="idContext" 
-							ng-model="idContext" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="32" ></textarea>
-							<p class="text-right text-muted small" style="margin:0">Hexadecimal format</p>
+							ng-model="idContext" ng-pattern="/^[0-9a-fA-F]+$/" ng-maxlength="32" disabled={true}></textarea>
+							<p class="text-right text-muted small" style="margin:0">Not supported</p>
 							<p class="help-block" ng-if="form.idContext.$error.pattern">Hexadecimal format is expected</p>
 							<p class="help-block" ng-if="form.idContext.$error.maxlength">ID Context is too long</p>
 						</div>


### PR DESCRIPTION
This commit enables the client to receive OSCORE security context information from the bootstrap server during the bootstrapping process. The bootstrap server web UI was updated to accept settings for OSCORE under the LWM2M Server tab. Some changes were done in the client side code to support this functionality. Finally, an OSCORE server identity is now generated and set.