### PR TITLE
Certificate usage config

### DIFF
--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
@@ -104,6 +104,7 @@
                     shortId : 123,
                     security : {
                         bootstrapServer : false,
+                        certificateUsage: lwserver.certificateUsage,
                         clientOldOffTime : 1,
                         publicKeyOrId : lwserver.id,
                         secretKey : lwserver.key,
@@ -120,6 +121,7 @@
                  bs:[{
                     security : {
                         bootstrapServer : true,
+                        certificateUsage: bsserver.certificateUsage,
                         clientOldOffTime : 1,
                         publicKeyOrId : bsserver.id,
                         secretKey : bsserver.key,

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap.tag
@@ -58,6 +58,9 @@
                         <p>
                             <strong>{ security.uri }</strong><br/>
                             security mode : {security.securityMode}<br/>
+                            <span if={security.certificateUsage}>
+                            certificate usage : {security.certificateUsage}<br/>
+                            </span>
                             <span if={security.securityMode === 'PSK'}>
                                 Identity : <code code style=display:block;white-space:pre-wrap>{wrap(toAscii(security.publicKeyOrId))}</code>
                                 Key : <code code style=display:block;white-space:pre-wrap>{wrap(toHex(security.secretKey))}</code>
@@ -70,6 +73,9 @@
                         <p>
                             <strong>{security.uri}</strong><br/>
                             security mode : {security.securityMode}<br/>
+                            <span if={security.certificateUsage}>
+                            certificate usage : {security.certificateUsage}<br/>
+                            </span>
                             <span if={security.securityMode === 'PSK'}>
                                 Identity : <code code style=display:block;white-space:pre-wrap>{wrap(toAscii(security.publicKeyOrId))}</code>
                                 key : <code code style=display:block;white-space:pre-wrap>{wrap(toHex(security.secretKey))}</code>

--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/securityconfig-input.tag
@@ -35,11 +35,24 @@
         <x509-input ref="x509" onchange={onchange} disable={disable} servercertificate={servercertificate}></x509-input>
     </div>
 
+    <div class="form-group">
+        <label for="certificateUsage" class="col-sm-4 control-label">Certificate usage</label>
+        <div class="col-sm-8">
+            <select class="form-control" id="certificateUsage" ref="certificateUsage">
+                <option value="CA_CONSTRAINT"                      >CA constraint</option>
+                <option value="SERVICE_CERTIFICATE_CONSTRAINT"     >service certificate constraint</option>
+                <option value="TRUST_ANCHOR_ASSERTION"             >trust anchor assertion</option>
+                <option value="DOMAIN_ISSUER_CERTIFICATE" selected >domain-issued certificate</option>
+            </select>
+        </div>
+    </div>
+
     <script>
         // Tag definition
         var tag = this;
         // Tag Params
         tag.secmode = opts.secmode || {no_sec:true};
+        tag.certificateUsage = opts.certificateUsage || "";
         tag.disable = opts.disable || {};
         tag.serverpubkey = opts.serverpubkey || "";
         tag.servercertificate = opts.servercertificate || "";
@@ -98,6 +111,9 @@
                 config.key = fromHex(x509.key);
                 config.serverKey = fromHex(x509.servCert);
             }
+
+            // set Certificate Usage
+            config.certificateUsage = tag.refs.certificateUsage.value;
 
             return config;
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -110,6 +110,15 @@ public class Security extends BaseInstanceEnabler {
     }
 
     /**
+     * Returns a new security instance (X509) for a bootstrap server.
+     */
+    public static Security x509Bootstrap(String serverUri, byte[] clientCertificate, byte[] clientPrivateKey,
+            byte[] serverPublicKey, ULong certificateUsage) {
+        return new Security(serverUri, true, SecurityMode.X509.code, clientCertificate.clone(), serverPublicKey.clone(),
+                clientPrivateKey.clone(), 0, certificateUsage);
+    }
+
+    /**
      * Returns a new security instance (NoSec) for a device management server.
      */
     public static Security noSec(String serverUri, int shortServerId) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -23,8 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.util.datatype.ULong;
 
 /**
  * A client configuration to apply to a device during a bootstrap session.
@@ -223,14 +225,26 @@ public class BootstrapConfig implements Serializable {
          */
         public Integer bootstrapServerAccountTimeout = 0;
 
+        /**
+         * The Certificate Usage Resource specifies the semantic of the certificate or raw public key stored in the
+         * Server Public Key Resource, which is used to match the certificate presented in the TLS/DTLS handshake.
+         * <ul>
+         * <li>0: CA constraint
+         * <li>1: service certificate constraint
+         * <li>2: trust anchor assertion
+         * <li>3: domain-issued certificate (default if missing)
+         * </ul>
+         */
+        public CertificateUsage certificateUsage;
+
         @Override
         public String toString() {
             // Note : secretKey and smsBindingKeySecret are explicitly excluded from the display for security purposes
             return String.format(
-                    "ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s]",
+                    "ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s, certificateUsage=%s]",
                     uri, bootstrapServer, securityMode, Arrays.toString(publicKeyOrId),
                     Arrays.toString(serverPublicKey), smsSecurityMode, Arrays.toString(smsBindingKeyParam),
-                    serverSmsNumber, serverId, clientOldOffTime, bootstrapServerAccountTimeout);
+                    serverSmsNumber, serverId, clientOldOffTime, bootstrapServerAccountTimeout, certificateUsage);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
@@ -66,6 +66,8 @@ public class BootstrapUtil {
             resources.add(LwM2mSingleResource.newIntegerResource(11, securityConfig.clientOldOffTime));
         if (securityConfig.bootstrapServerAccountTimeout != null)
             resources.add(LwM2mSingleResource.newIntegerResource(12, securityConfig.bootstrapServerAccountTimeout));
+        if (securityConfig.certificateUsage != null)
+            resources.add(LwM2mSingleResource.newUnsignedIntegerResource(15, securityConfig.certificateUsage.code));
 
         return new LwM2mObjectInstance(instanceId, resources);
     }


### PR DESCRIPTION
Adds support to configure certificate usage from server side during bootstrapping.

Also adds support to leshan-client-demo for using custom certificate usage for initial connection.