### PR TITLE
Support null value for short server id for bootstrap instance of  Security object

### DIFF
--- a/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
+++ b/leshan-bsserver-demo/src/main/resources/webapp/tag/bootstrap-modal.tag
@@ -124,7 +124,6 @@
                         publicKeyOrId : bsserver.id,
                         secretKey : bsserver.key,
                         securityMode : bsserver.secmode,
-                        serverId : 111,
                         serverPublicKey : bsserver.serverKey,
                         serverSmsNumber : "",
                         smsBindingKeyParam : [  ],

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -79,7 +79,7 @@ public class Security extends BaseInstanceEnabler {
      * Returns a new security instance (NoSec) for a bootstrap server.
      */
     public static Security noSecBootstap(String serverUri) {
-        return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0], 0,
+        return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0], null,
                 CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
     }
 
@@ -88,7 +88,7 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security pskBootstrap(String serverUri, byte[] pskIdentity, byte[] privateKey) {
         return new Security(serverUri, true, SecurityMode.PSK.code, pskIdentity.clone(), new byte[0],
-                privateKey.clone(), 0, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                privateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
     }
 
     /**
@@ -97,7 +97,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security rpkBootstrap(String serverUri, byte[] clientPublicKey, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, true, SecurityMode.RPK.code, clientPublicKey.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), 0, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                clientPrivateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
     }
 
     /**
@@ -106,7 +106,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security x509Bootstrap(String serverUri, byte[] clientCertificate, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, true, SecurityMode.X509.code, clientCertificate.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), 0, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                clientPrivateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
     }
 
     /**
@@ -241,8 +241,10 @@ public class Security extends BaseInstanceEnabler {
             return ReadResponse.success(resourceid, secretKey);
 
         case SEC_SERVER_ID: // short server id
-            return ReadResponse.success(resourceid, shortServerId);
-
+            if (shortServerId != null)
+                return ReadResponse.success(resourceid, shortServerId);
+            else
+                return ReadResponse.notFound();
         case SEC_CERTIFICATE_USAGE: // certificate usage
             return ReadResponse.success(resourceid, certificateUsage);
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
@@ -356,7 +356,6 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
 
                 // security for BS server
                 ServerSecurity bsSecurity = new ServerSecurity();
-                bsSecurity.serverId = 1111;
                 bsSecurity.bootstrapServer = true;
                 bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                         + bootstrapServer.getUnsecuredAddress().getPort();
@@ -413,7 +412,6 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
 
                 // security for BS server
                 ServerSecurity bsSecurity = new ServerSecurity();
-                bsSecurity.serverId = 1111;
                 bsSecurity.bootstrapServer = true;
                 bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                         + bootstrapServer.getUnsecuredAddress().getPort();
@@ -464,7 +462,6 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
 
                 // security for BS server
                 ServerSecurity bsSecurity = new ServerSecurity();
-                bsSecurity.serverId = 1111;
                 bsSecurity.bootstrapServer = true;
                 bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                         + bootstrapServer.getUnsecuredAddress().getPort();
@@ -501,7 +498,6 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
 
                 // security for BS server
                 ServerSecurity bsSecurity = new ServerSecurity();
-                bsSecurity.serverId = 1111;
                 bsSecurity.bootstrapServer = true;
                 bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                         + bootstrapServer.getUnsecuredAddress().getPort();

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/ConfigurationChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/ConfigurationChecker.java
@@ -185,7 +185,7 @@ public class ConfigurationChecker {
 
     protected static BootstrapConfig.ServerSecurity getSecurityEntry(BootstrapConfig config, int shortId) {
         for (Map.Entry<Integer, BootstrapConfig.ServerSecurity> es : config.security.entrySet()) {
-            if (es.getValue().serverId == shortId) {
+            if (!es.getValue().bootstrapServer && es.getValue().serverId == shortId) {
                 return es.getValue();
             }
         }


### PR DESCRIPTION
This aims to fix #987 