### PR TITLE
Use CoAP ACK_TIMEOUT as default value for DTLS retransmission.

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java
@@ -308,6 +308,10 @@ public class LeshanClientBuilder {
         if (incompleteConfig.getStaleConnectionThreshold() == null)
             dtlsConfigBuilder.setStaleConnectionThreshold(coapConfig.getLong(Keys.MAX_PEER_INACTIVITY_PERIOD));
 
+        // define default timeout (see https://github.com/eclipse/leshan/issues/1002)
+        if (incompleteConfig.getRetransmissionTimeout() == null)
+            dtlsConfigBuilder.setRetransmissionTimeout(coapConfig.getInt(Keys.ACK_TIMEOUT));
+
         // Use only 1 thread to handle DTLS connection by default
         if (incompleteConfig.getConnectionThreadCount() == null) {
             dtlsConfigBuilder.setConnectionThreadCount(1);

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -468,6 +468,10 @@ public class LeshanServerBuilder {
             if (incompleteConfig.getStaleConnectionThreshold() == null)
                 dtlsConfigBuilder.setStaleConnectionThreshold(coapConfig.getLong(Keys.MAX_PEER_INACTIVITY_PERIOD));
 
+            // define default timeout (see https://github.com/eclipse/leshan/issues/1002)
+            if (incompleteConfig.getRetransmissionTimeout() == null)
+                dtlsConfigBuilder.setRetransmissionTimeout(coapConfig.getInt(Keys.ACK_TIMEOUT));
+
             // check conflict for private key
             if (privateKey != null) {
                 if (incompleteConfig.getPrivateKey() != null && !incompleteConfig.getPrivateKey().equals(privateKey)) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
@@ -463,6 +463,10 @@ public class LeshanBootstrapServerBuilder {
             if (incompleteConfig.getStaleConnectionThreshold() == null)
                 dtlsConfigBuilder.setStaleConnectionThreshold(coapConfig.getLong(Keys.MAX_PEER_INACTIVITY_PERIOD));
 
+            // define default timeout (see https://github.com/eclipse/leshan/issues/1002)
+            if (incompleteConfig.getRetransmissionTimeout() == null)
+                dtlsConfigBuilder.setRetransmissionTimeout(coapConfig.getInt(Keys.ACK_TIMEOUT));
+
             if (privateKey != null) {
                 // check conflict for private key
                 if (incompleteConfig.getPrivateKey() != null && !incompleteConfig.getPrivateKey().equals(privateKey)) {


### PR DESCRIPTION
Triggered by #1002 

(not planned to be merged for now)