### PR TITLE
Support for OSCORE Appendix B.2 context re-derivation procedure

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -37,6 +37,7 @@ import org.eclipse.californium.cose.CoseException;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.util.CertPathUtil;
+import org.eclipse.californium.oscore.ContextRederivation.PHASE;
 import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.californium.oscore.OSException;
@@ -241,6 +242,12 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
 
                 // Also add the context by the IP of the server since requests may use that
                 String serverIP = InetAddress.getByName(serverInfo.getFullUri().getHost()).getHostAddress();
+                // Support Appendix B.2 functionality
+                ctx.setContextRederivationEnabled(true);
+                // Set to initiate Appendix B.2 procedure on first sent request
+                // To either server or bs server
+                ctx.setContextRederivationPhase(PHASE.CLIENT_INITIATE);
+
                 db.addContext("coap://" + serverIP, ctx);
 
             } catch (OSException | UnknownHostException e) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
@@ -154,6 +154,9 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
 
                 OSCoreCtx ctx = new OSCoreCtx(masterSecret, false, aeadAlg, senderId, recipientId, hkdfAlg,
                         replayWindow, masterSalt, idContext);
+                // Support Appendix B.2 functionality
+                ctx.setContextRederivationEnabled(true);
+
                 db.addContext(ctx);
 
             } catch (OSException | CoseException e) {

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/SecurityDeserializer.java
@@ -164,6 +164,9 @@ public class SecurityDeserializer implements JsonDeserializer<SecurityInfo> {
                 try {
                     ctx = new OSCoreCtx(masterSecret, true, aeadAlgorithm, recipientId, senderId, hkdfAlgorithm, 32,
                             masterSalt, idContext);
+
+                    // Support Appendix B.2 functionality
+                    ctx.setContextRederivationEnabled(true);
                 } catch (OSException e) {
                     throw new JsonParseException("Failed to generate OSCORE context", e);
                 }


### PR DESCRIPTION
This pull request adds support for running the Appendix B.2 procedure from the OSCORE RFC, which securely re-generates OSCORE Security Context information. The LWM2M client can now run this procedure towards the LWM2M server or LWM2M bootstrap server.
See https://tools.ietf.org/html/rfc8613#appendix-B.2

It is specified in the LWM2M 1.1 Transport Bindings document section 5.5.3 that Appendix B.2 of OSCORE should be used. Using the procedure in Appendix B.2 will derive a new OSCORE Security Context (with new Sender and Recipient keys). The benefit this has is that if a LWM2M client reboots and starts using the same Security Context that it was originally configured with, it will not be using the same Sender Key while starting over from sequence number 0 (thus having nonce and key reuse). But rather it will first run Appendix B.2 to generate a new Context (Sender and Recipient keys) with the LWM2M Server or LWM2M Bootstrap server.

So every time the client connects the first time using OSCORE to a LWM2M Server or LWM2M Bootstrap server, Appendix B.2 will be run. Furthermore, currently if the client is restarted but the server is not, the server will complain about replayed messages. But since Appendix B.2 refreshes the security contexts this problem will no longer exist.
