### PR TITLE
Add support of "ct=" attribute at Server side

### DIFF
--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
@@ -87,7 +87,8 @@ public class RegistrationUpdate {
         builder.lwM2mVersion(registration.getLwM2mVersion()).lifeTimeInSec(lifeTimeInSec).smsNumber(smsNumber)
                 .bindingMode(bindingMode).queueMode(registration.getQueueMode()).objectLinks(linkObject)
                 .registrationDate(registration.getRegistrationDate()).lastUpdate(lastUpdate)
-                .additionalRegistrationAttributes(additionalAttributes).rootPath(registration.getRootPath());
+                .additionalRegistrationAttributes(additionalAttributes).rootPath(registration.getRootPath())
+                .supportedContentFormats(registration.getSupportedContentFormats());
 
         return builder.build();
 

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
@@ -18,10 +18,13 @@ package org.eclipse.leshan.server.registration;
 import static org.junit.Assert.*;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.leshan.core.Link;
 import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.server.registration.Registration.Builder;
 import org.junit.Test;
@@ -43,8 +46,8 @@ public class RegistrationTest {
     }
 
     @Test
-    public void test_object_links_with_default_rootpath() {
-        Registration reg = given_a_registration_with_object_link_like("</>;rt=\"oma.lwm2m\", </1/0>,</3/0>");
+    public void test_object_links_with_ct_but_with_rt() {
+        Registration reg = given_a_registration_with_object_link_like("</>;ct=0 42 11543,</1/0>,</3/0>");
 
         // check root path
         assertEquals("/", reg.getRootPath());
@@ -54,6 +57,33 @@ public class RegistrationTest {
         assertEquals(2, supportedObject.size());
         assertEquals(ObjectModel.DEFAULT_VERSION, supportedObject.get(1));
         assertEquals(ObjectModel.DEFAULT_VERSION, supportedObject.get(3));
+
+        // Check Supported Content format
+        Set<ContentFormat> supportedContentFormats = reg.getSupportedContentFormats();
+        assertEquals(4, supportedContentFormats.size()); // 3 + 1 mandatory TLV content format for LWM2M v1.0
+        assertTrue(supportedContentFormats.containsAll(
+                Arrays.asList(ContentFormat.TLV, ContentFormat.TEXT, ContentFormat.OPAQUE, ContentFormat.JSON)));
+    }
+
+    @Test
+    public void test_object_links_with_default_rootpath() {
+        Registration reg = given_a_registration_with_object_link_like(
+                "</>;rt=\"oma.lwm2m\";ct=0 42 11543,</1/0>,</3/0>");
+
+        // check root path
+        assertEquals("/", reg.getRootPath());
+
+        // Ensure supported objects are correct
+        Map<Integer, String> supportedObject = reg.getSupportedObject();
+        assertEquals(2, supportedObject.size());
+        assertEquals(ObjectModel.DEFAULT_VERSION, supportedObject.get(1));
+        assertEquals(ObjectModel.DEFAULT_VERSION, supportedObject.get(3));
+
+        // Check Supported Content format
+        Set<ContentFormat> supportedContentFormats = reg.getSupportedContentFormats();
+        assertEquals(4, supportedContentFormats.size()); // 3 + 1 mandatory TLV content format for LWM2M v1.0
+        assertTrue(supportedContentFormats.containsAll(
+                Arrays.asList(ContentFormat.TLV, ContentFormat.TEXT, ContentFormat.OPAQUE, ContentFormat.JSON)));
     }
 
     @Test

--- a/leshan-server-redis/src/test/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDesTest.java
+++ b/leshan-server-redis/src/test/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDesTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.leshan.core.Link;
+import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.server.registration.Registration;
 import org.junit.Test;
@@ -40,7 +41,8 @@ public class RegistrationSerDesTest {
         objs[1] = new Link("/0/2");
 
         Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",
-                Identity.unsecure(Inet4Address.getLoopbackAddress(), 1)).objectLinks(objs).rootPath("/");
+                Identity.unsecure(Inet4Address.getLoopbackAddress(), 1)).objectLinks(objs).rootPath("/")
+                        .supportedContentFormats(ContentFormat.TLV, ContentFormat.TEXT);
 
         builder.registrationDate(new Date(100L));
         builder.lastUpdate(new Date(101L));


### PR DESCRIPTION
Add support to `ct=` attribute at **Server** side.
"ct" attribute allow to let know to the server content formats supported by the client. 

> If the LwM2M Client supports optional data formats, it MAY inform the LwM2M Server by including the content type in the root path link using the ct= link attribute. (note that the content type value 110 is the value assigned in the CoAP Content-Format Registry for the SenML JSON format used by LwM2M).
>
> </>;ct=110, </1/0>,</1/1>,</2/0>,</2/1>,</2/2>,</2/3>,</2/4>,</3/0>,</4/0>,</5>
 
 (source [core§6.2.1](http://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_1_1-20190617-A.html#6-2-1-0-621-Register-Operation))

Since LWM2M 1.1, there is no more one mandatory content format  to rule them all (TLV) and so this kind of negotiation is more needed. 
(see https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/514)