### PR TITLE
Remove lazy loading for getSupportedObjects in Registration.

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
@@ -368,4 +368,29 @@ public class LwM2mPath {
         return true;
     }
 
+    /**
+     * Parse a string containing a full LWM2M path containing rootpath (rt="oma.lwm2m").
+     * <p>
+     * E.g. : fullpath="/myrootpath/1/0 and rootpath="/myrootpat/" will return <code>new LwM2mPath(1,0)</code>
+     * 
+     * @param fullpath the path to parse.
+     * @param lwm2mRootpath the expected rootpath. <code>null</code> is considered as "/"
+     * @return A valid {@link LwM2mPath} or null it does not start by lwm2mRootPath
+     * 
+     * @exception NumberFormatException if path contains not Numeric value
+     * @exception LwM2mNodeException if path is invalid (e.g. too big number in path)
+     * @exception IllegalArgumentException if path length is invalid
+     */
+    public static LwM2mPath parse(String fullpath, String lwm2mRootpath)
+            throws NumberFormatException, LwM2mNodeException, IllegalArgumentException {
+        if (lwm2mRootpath == null) {
+            return new LwM2mPath(fullpath);
+        }
+
+        if (!fullpath.startsWith(lwm2mRootpath))
+            return null;
+        String path = fullpath.substring(lwm2mRootpath.length());
+
+        return new LwM2mPath(path);
+    }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
@@ -88,7 +88,8 @@ public class RegistrationUpdate {
                 .bindingMode(bindingMode).queueMode(registration.getQueueMode()).objectLinks(linkObject)
                 .registrationDate(registration.getRegistrationDate()).lastUpdate(lastUpdate)
                 .additionalRegistrationAttributes(additionalAttributes).rootPath(registration.getRootPath())
-                .supportedContentFormats(registration.getSupportedContentFormats());
+                .supportedContentFormats(registration.getSupportedContentFormats())
+                .supportedObjects(registration.getSupportedObject());
 
         return builder.build();
 

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
@@ -157,18 +157,10 @@ public class RegistrationTest {
         assertEquals("1.1", supportedObject.get(3));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void test_object_links_with_text_in_lwm2m_path() {
-        Registration reg = given_a_registration_with_object_link_like(
+        given_a_registration_with_object_link_like(
                 "<text>,</1/text/0/in/path>,empty,</2/O/test/in/path>,</3/0>;ver=\"1.1\",</4/0/0/>");
-
-        // check root path
-        assertEquals("/", reg.getRootPath());
-
-        // Ensure supported objects are correct
-        Map<Integer, String> supportedObject = reg.getSupportedObject();
-        assertEquals(1, supportedObject.size());
-        assertEquals("1.1", supportedObject.get(3));
     }
 
     private Registration given_a_registration_with_object_link_like(String objectLinks) {

--- a/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
+++ b/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.eclipse.leshan.core.Link;
@@ -30,6 +31,7 @@ import org.eclipse.leshan.server.registration.Registration;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonObject.Member;
 import com.eclipsesource.json.JsonValue;
 
 /**
@@ -83,6 +85,13 @@ public class RegistrationSerDes {
             ct.add(contentFormat.getCode());
         }
         o.add("ct", ct);
+
+        // handle supported object
+        JsonObject so = Json.object();
+        for (Entry<Integer, String> supportedObject : r.getSupportedObject().entrySet()) {
+            so.add(supportedObject.getKey().toString(), supportedObject.getValue());
+        }
+        o.add("suppObjs", so);
         return o;
     }
 
@@ -156,6 +165,19 @@ public class RegistrationSerDes {
             }
             b.supportedContentFormats(supportedContentFormat);
         }
+        // parse supported object
+        JsonValue so = jObj.get("suppObjs");
+        if (so == null) {
+            // Backward compatibility : if suppObjs doesn't exist we extract supported object from object link
+            b.extractDataFromObjectLink(true);
+        } else {
+            Map<Integer, String> supportedObject = new HashMap<>();
+            for (Member member : so.asObject()) {
+                supportedObject.put(Integer.parseInt(member.getName()), member.getValue().asString());
+            }
+            b.supportedObjects(supportedObject);
+        }
+
         return b.build();
     }
 


### PR DESCRIPTION
By the past `getSupportedObjects` was added in "Lazy loading" way.

But there is now more and more data to extract from LinkObject : 
 - root path
 - supported objects
 - supported content format
 - (To be done : available instances)
 
 It sounds better parse ObjectLink and extract data only when needed, then use classic serialize/deserialize for those data. (and so for supported objects too) 