### PR TITLE
Add Auto ID for Bootstrap Server Security Object(0) instance

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -305,6 +305,11 @@ public class LeshanClient implements LwM2mClient {
     }
 
     @Override
+    public boolean triggerClientInitiatedBootstrap(boolean deregister) {
+        return engine.triggerClientInitiatedBootstrap(deregister);
+    }
+
+    @Override
     public SendResponse sendData(ServerIdentity server, ContentFormat format, List<String> paths, long timeoutInMs)
             throws InterruptedException {
         Validate.notNull(server);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LwM2mClient.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LwM2mClient.java
@@ -68,6 +68,15 @@ public interface LwM2mClient {
     void triggerRegistrationUpdate(ServerIdentity server);
 
     /**
+     * Trigger a client initiated bootstrap.
+     * 
+     * @param deregister True if client should deregister itself before to stop.
+     * 
+     * @return true if the bootstrap can be initiated.
+     */
+    boolean triggerClientInitiatedBootstrap(boolean deregister);
+
+    /**
      * Send Data synchronously to a LWM2M Server.
      * <p>
      * The "Send" operation is used by the LwM2M Client to send data to the LwM2M Server without explicit request by

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapConsistencyChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapConsistencyChecker.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.bootstrap;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+
+/**
+ * This class is responsible to check the consistency state of the client after at the end of a bootstrap session.
+ */
+public interface BootstrapConsistencyChecker {
+
+    /**
+     * check if current state of the client is consistent
+     * 
+     * @param objectEnablers all objects supported by the client.
+     * @return <code>null</code> if the current state is consistent or a list of issues
+     */
+    List<String> checkconfig(Map<Integer, LwM2mObjectEnabler> objectEnablers);
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BootstrapHandler.java
@@ -16,6 +16,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.bootstrap;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -40,11 +41,15 @@ public class BootstrapHandler {
 
     private boolean bootstrapping = false;
     private CountDownLatch bootstrappingLatch = new CountDownLatch(1);
+    // last session state (null means no error)
+    private volatile List<String> lastConsistencyError = null;
 
     private final Map<Integer, LwM2mObjectEnabler> objects;
+    private BootstrapConsistencyChecker checker;
 
-    public BootstrapHandler(Map<Integer, LwM2mObjectEnabler> objectEnablers) {
+    public BootstrapHandler(Map<Integer, LwM2mObjectEnabler> objectEnablers, BootstrapConsistencyChecker checker) {
         objects = objectEnablers;
+        this.checker = checker;
     }
 
     public synchronized SendableResponse<BootstrapFinishResponse> finished(ServerIdentity server,
@@ -54,7 +59,6 @@ public class BootstrapHandler {
             if (!server.isLwm2mBootstrapServer()) {
                 return new SendableResponse<>(BootstrapFinishResponse.badRequest("not from a bootstrap server"));
             }
-            // TODO delete bootstrap server (see 5.2.5.2 Bootstrap Delete)
 
             Runnable whenSent = new Runnable() {
                 @Override
@@ -63,7 +67,17 @@ public class BootstrapHandler {
                 }
             };
 
-            return new SendableResponse<>(BootstrapFinishResponse.success(), whenSent);
+            // check consistency state of the client
+            lastConsistencyError = checker.checkconfig(objects);
+            if (lastConsistencyError == null) {
+                return new SendableResponse<>(BootstrapFinishResponse.success(), whenSent);
+            } else {
+                // TODO rollback configuration.
+                // see https://github.com/eclipse/leshan/issues/968
+                return new SendableResponse<>(BootstrapFinishResponse.notAcceptable(lastConsistencyError.toString()),
+                        whenSent);
+            }
+
         } else {
             return new SendableResponse<>(BootstrapFinishResponse.badRequest("no pending bootstrap session"));
         }
@@ -91,6 +105,7 @@ public class BootstrapHandler {
         if (!bootstrapping) {
             bootstrappingLatch = new CountDownLatch(1);
             bootstrapping = true;
+            lastConsistencyError = null;
             return true;
         }
         return false;
@@ -100,8 +115,15 @@ public class BootstrapHandler {
         return bootstrapping;
     }
 
-    public boolean waitBoostrapFinished(long timeInSeconds) throws InterruptedException {
-        return bootstrappingLatch.await(timeInSeconds, TimeUnit.SECONDS);
+    public boolean waitBoostrapFinished(long timeInSeconds) throws InterruptedException, InvalidStateException {
+        boolean finished = bootstrappingLatch.await(timeInSeconds, TimeUnit.SECONDS);
+        if (finished) {
+            if (lastConsistencyError != null) {
+                throw new InvalidStateException(
+                        String.format("Invalid Bootstrap state : %s", lastConsistencyError.toString()));
+            }
+        }
+        return finished;
     }
 
     public synchronized void closeSession() {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/DefaultBootstrapConsistencyChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/DefaultBootstrapConsistencyChecker.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.bootstrap;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.client.servers.ServersInfoExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A default implementation of {@link BootstrapConsistencyChecker}
+ */
+public class DefaultBootstrapConsistencyChecker implements BootstrapConsistencyChecker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultBootstrapConsistencyChecker.class);
+
+    @Override
+    public List<String> checkconfig(Map<Integer, LwM2mObjectEnabler> objectEnablers) {
+        try {
+            ServersInfoExtractor.getInfo(objectEnablers, true);
+        } catch (RuntimeException e) {
+            LOG.debug(e.getMessage());
+            return Arrays.asList(e.getMessage());
+        }
+        return null;
+    }
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/InvalidStateException.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/InvalidStateException.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.bootstrap;
+
+/**
+ * Raised if LWM2M client is in an invalid or inconsistent state.
+ * 
+ */
+public class InvalidStateException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidStateException() {
+    }
+
+    public InvalidStateException(String m) {
+        super(m);
+    }
+
+    public InvalidStateException(String m, Object... args) {
+        super(String.format(m, args));
+    }
+
+    public InvalidStateException(Throwable e) {
+        super(e);
+    }
+
+    public InvalidStateException(String m, Throwable e) {
+        super(m, e);
+    }
+
+    public InvalidStateException(Throwable e, String m, Object... args) {
+        super(String.format(m, args), e);
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/RegistrationEngine.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/engine/RegistrationEngine.java
@@ -53,6 +53,15 @@ public interface RegistrationEngine {
     void triggerRegistrationUpdate(ServerIdentity server, RegistrationUpdate registrationUpdate);
 
     /**
+     * Trigger a client initiated bootstrap.
+     * 
+     * @param deregister True if client should deregister itself before to stop.
+     * 
+     * @return true if the bootstrap can be initiated.
+     */
+    boolean triggerClientInitiatedBootstrap(boolean deregister);
+
+    /**
      * Returns the current registration Id for this server.
      * 
      * @return the client registration Id or <code>null</code> if the client is not registered to this server.

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Server.java
@@ -201,6 +201,13 @@ public class Server extends BaseInstanceEnabler {
         if (resourceid == 8) {
             getLwM2mClient().triggerRegistrationUpdate(identity);
             return ExecuteResponse.success();
+        } else if (resourceid == 9) {
+            boolean success = getLwM2mClient().triggerClientInitiatedBootstrap(true);
+            if (success)
+                return ExecuteResponse.success();
+            else {
+                return ExecuteResponse.badRequest("probably no bootstrap server configured");
+            }
         } else {
             return super.execute(identity, resourceid, params);
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/ObjectEnabler.java
@@ -410,6 +410,7 @@ public class ObjectEnabler extends BaseObjectEnabler implements Destroyable, Sta
 
     @Override
     public void setLwM2mClient(LwM2mClient client) {
+        super.setLwM2mClient(client);
         for (LwM2mInstanceEnabler instanceEnabler : instances.values()) {
             instanceEnabler.setLwM2mClient(client);
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -208,6 +208,18 @@ public class ServersInfoExtractor {
         }
     }
 
+    public static String getServerURI(LwM2mObjectEnabler objectEnabler, int instanceId) {
+        ReadResponse response = null;
+        if (objectEnabler.getId() == SECURITY) {
+            response = objectEnabler.read(ServerIdentity.SYSTEM, new ReadRequest(SECURITY, instanceId, SEC_SERVER_URI));
+        }
+        if (response != null && response.isSuccess()) {
+            return (String) ((LwM2mResource) response.getContent()).getValue();
+        } else {
+            return null;
+        }
+    }
+
     public static SecurityMode getSecurityMode(LwM2mObjectInstance securityInstance) {
         return SecurityMode.fromCode((long) securityInstance.getResource(SEC_SECURITY_MODE).getValue());
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/util/LinkFormatHelper.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/util/LinkFormatHelper.java
@@ -170,21 +170,29 @@ public final class LinkFormatHelper {
         // add instance link
         for (Integer instanceId : objectEnabler.getAvailableInstanceIds()) {
             String instanceURL = getPath("/", Integer.toString(objectEnabler.getId()), Integer.toString(instanceId));
+            Map<String, String> objectAttributes = new HashMap<>();
 
             // get short id
-            Long shortServerId = null;
             if (objectEnabler.getId() == LwM2mId.SECURITY || objectEnabler.getId() == LwM2mId.SERVER) {
                 Boolean isBootstrapServer = objectEnabler.getId() == LwM2mId.SECURITY
                         && ServersInfoExtractor.isBootstrapServer(objectEnabler, instanceId);
                 if (isBootstrapServer != null && !isBootstrapServer) {
-                    shortServerId = ServersInfoExtractor.getServerId(objectEnabler, instanceId);
+                    Long shortServerId = ServersInfoExtractor.getServerId(objectEnabler, instanceId);
+                    if (shortServerId != null)
+                        objectAttributes.put("ssid", shortServerId.toString());
                 }
+
+            }
+
+            // get uri
+            if (objectEnabler.getId() == LwM2mId.SECURITY) {
+                String uri = ServersInfoExtractor.getServerURI(objectEnabler, instanceId);
+                if (uri != null)
+                    objectAttributes.put("uri", "\"" + uri + "\"");
             }
 
             // create link
-            if (shortServerId != null) {
-                Map<String, String> objectAttributes = new HashMap<>();
-                objectAttributes.put("ssid", shortServerId.toString());
+            if (!objectAttributes.isEmpty()) {
                 links.add(new Link(instanceURL, objectAttributes));
             } else {
                 links.add(new Link(instanceURL));

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
@@ -241,17 +241,21 @@ public class LinkFormatHelperTest {
     @Test
     public void encode_bootstrap_security_object() {
         Map<Integer, LwM2mInstanceEnabler> instancesMap = new HashMap<>();
-        instancesMap.put(0, Security.noSec("coap://localhost", 111));
-        instancesMap.put(1, Security.noSecBootstap("coap://localhost"));
-        instancesMap.put(2, Security.noSec("coap://localhost", 222));
-        instancesMap.put(3, Security.noSec("coap://localhost", 333));
+        instancesMap.put(0, Security.noSec("coap://localhost:11", 111));
+        instancesMap.put(1, Security.noSecBootstap("coap://localhost:1"));
+        instancesMap.put(2, Security.noSec("coap://localhost:22", 222));
+        instancesMap.put(3, Security.noSec("coap://localhost:33", 333));
         ObjectEnabler objectEnabler = new ObjectEnabler(0, getObjectModel(0), instancesMap, null,
                 ContentFormat.DEFAULT);
 
         Link[] links = LinkFormatHelper.getBootstrapObjectDescription(objectEnabler);
         String strLinks = Link.serialize(links);
 
-        assertEquals("</>;lwm2m=1.0,</0/0>;ssid=111,</0/1>,</0/2>;ssid=222,</0/3>;ssid=333", strLinks);
+        assertEquals("</>;lwm2m=1.0,</0/0>;ssid=111;uri=\"coap://localhost:11\"," //
+                + "</0/1>;uri=\"coap://localhost:1\"," //
+                + "</0/2>;ssid=222;uri=\"coap://localhost:22\"," //
+                + "</0/3>;ssid=333;uri=\"coap://localhost:33\"" //
+                , strLinks);
 
     }
 
@@ -261,10 +265,10 @@ public class LinkFormatHelperTest {
 
         // object 0
         Map<Integer, LwM2mInstanceEnabler> securityInstances = new HashMap<>();
-        securityInstances.put(0, Security.noSec("coap://localhost", 111));
-        securityInstances.put(1, Security.noSecBootstap("coap://localhost"));
-        securityInstances.put(2, Security.noSec("coap://localhost", 222));
-        securityInstances.put(3, Security.noSec("coap://localhost", 333));
+        securityInstances.put(0, Security.noSec("coap://localhost:11", 111));
+        securityInstances.put(1, Security.noSecBootstap("coap://localhost:1"));
+        securityInstances.put(2, Security.noSec("coap://localhost:22", 222));
+        securityInstances.put(3, Security.noSec("coap://localhost:33", 333));
         ObjectEnabler securityObjectEnabler = new ObjectEnabler(0, getObjectModel(0), securityInstances, null,
                 ContentFormat.DEFAULT);
         objectEnablers.add(securityObjectEnabler);
@@ -291,9 +295,11 @@ public class LinkFormatHelperTest {
         Link[] links = LinkFormatHelper.getBootstrapClientDescription(objectEnablers);
         String strLinks = Link.serialize(links);
 
-        assertEquals(
-                "</>;lwm2m=1.0,</0/0>;ssid=111,</0/1>,</0/2>;ssid=222,</0/3>;ssid=333,</1>;ver=2.0,</1/0>;ssid=333,</2>;ver=2.0,</3/0>",
-                strLinks);
+        assertEquals("</>;lwm2m=1.0,</0/0>;ssid=111;uri=\"coap://localhost:11\"," //
+                + "</0/1>;uri=\"coap://localhost:1\"," //
+                + "</0/2>;ssid=222;uri=\"coap://localhost:22\"," //
+                + "</0/3>;ssid=333;uri=\"coap://localhost:33\"," //
+                + "</1>;ver=2.0,</1/0>;ssid=333,</2>;ver=2.0,</3/0>", strLinks);
     }
 
     private ObjectModel getObjectModel(int id) {

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/MatchingType.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/MatchingType.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core;
+
+import org.eclipse.leshan.core.util.datatype.ULong;
+
+/**
+ * The Matching Type Resource specifies how the certificate or raw public key in in the Server Public Key is presented.
+ * Four values are currently defined:
+ * <ul>
+ * <li>0: Exact match. This is the default value and also corresponds to the functionality of LwM2M v1.0. Hence, if this
+ * resource is not present then the content of the Server Public Key Resource corresponds to this value.
+ * <li>1: SHA-256 hash [RFC6234]
+ * <li>2: SHA-384 hash [RFC6234]
+ * <li>3: SHA-512 hash [RFC6234]
+ * </ul>
+ */
+public enum MatchingType {
+    EXACT_MATCH(0), SHA256(1), SHA384(2), SHA512(3);
+
+    public final ULong code;
+
+    private MatchingType(int code) {
+        this.code = ULong.valueOf(code);
+    }
+
+    public static MatchingType fromCode(int code) {
+        return fromCode(ULong.valueOf(code));
+    }
+
+    public static MatchingType fromCode(ULong code) {
+        for (MatchingType sm : MatchingType.values()) {
+            if (sm.code.equals(code)) {
+                return sm;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Unsupported MatchingType code : %s", code));
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -187,7 +187,10 @@ public class BootstrapTest {
         helper.assertClientRegisterered();
         assertNotNull(helper.lastDiscoverAnswer);
         assertEquals(ResponseCode.CONTENT, helper.lastDiscoverAnswer.getCode());
-        assertEquals("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>,</1>;ver=1.1,</3>;ver=1.1,</3/0>",
+        assertEquals(
+                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>",
+                        helper.bootstrapServer.getUnsecuredAddress().getHostString(),
+                        helper.bootstrapServer.getUnsecuredAddress().getPort()),
                 Link.serialize(helper.lastDiscoverAnswer.getObjectLinks()));
     }
 
@@ -214,7 +217,10 @@ public class BootstrapTest {
         helper.assertClientRegisterered();
         assertNotNull(helper.lastDiscoverAnswer);
         assertEquals(ResponseCode.CONTENT, helper.lastDiscoverAnswer.getCode());
-        assertEquals("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>,</1>;ver=1.1,</3>;ver=1.1,</3/0>",
+        assertEquals(
+                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>",
+                        helper.bootstrapServer.getUnsecuredAddress().getHostString(),
+                        helper.bootstrapServer.getUnsecuredAddress().getPort()),
                 Link.serialize(helper.lastDiscoverAnswer.getObjectLinks()));
 
         // re-bootstrap
@@ -233,8 +239,11 @@ public class BootstrapTest {
         // check last discover response
         assertNotNull(helper.lastDiscoverAnswer);
         assertEquals(ResponseCode.CONTENT, helper.lastDiscoverAnswer.getCode());
-        assertEquals(
-                "</>;lwm2m=1.0,</0>;ver=1.1,</0/0>,</0/1>;ssid=2222,</1>;ver=1.1,</1/0>;ssid=2222,</3>;ver=1.1,</3/0>",
+        assertEquals(String.format(
+                "</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</0/1>;ssid=2222;uri=\"coap://%s:%d\",</1>;ver=1.1,</1/0>;ssid=2222,</3>;ver=1.1,</3/0>",
+                helper.bootstrapServer.getUnsecuredAddress().getHostString(),
+                helper.bootstrapServer.getUnsecuredAddress().getPort(),
+                helper.server.getUnsecuredAddress().getHostString(), helper.server.getUnsecuredAddress().getPort()),
                 Link.serialize(helper.lastDiscoverAnswer.getObjectLinks()));
 
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -43,6 +43,7 @@ import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.integration.tests.util.BootstrapIntegrationTestHelper;
 import org.eclipse.leshan.integration.tests.util.TestObjectsInitializer;
+import org.eclipse.leshan.server.bootstrap.BootstrapFailureCause;
 import org.eclipse.leshan.server.security.NonUniqueSecurityInfoException;
 import org.eclipse.leshan.server.security.SecurityInfo;
 import org.junit.After;
@@ -162,7 +163,8 @@ public class BootstrapTest {
         helper.assertClientRegisterered();
 
         // assert session contains additional attributes
-        assertEquals(additionalAttributes, helper.lastBootstrapSession.getBootstrapRequest().getAdditionalAttributes());
+        assertEquals(additionalAttributes,
+                helper.getLastBootstrapSession().getBootstrapRequest().getAdditionalAttributes());
     }
 
     @Test
@@ -297,6 +299,8 @@ public class BootstrapTest {
 
         // ensure bootstrap session failed because of invalid state
         helper.waitForInconsistentStateAtClientSide(1);
+        helper.waitForBootstrapFailureAtServerSide(1);
+        assertEquals(BootstrapFailureCause.FINISH_FAILED, helper.getLastCauseOfBootstrapFailure());
     }
 
     @Test
@@ -323,6 +327,7 @@ public class BootstrapTest {
 
         // ensure bootstrap session succeed
         helper.waitForBootstrapFinishedAtClientSide(1);
+        helper.waitForBootstrapSuccessAtServerSide(1);
         helper.waitForRegistrationAtServerSide(1);
         helper.assertClientRegisterered();
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -146,6 +146,33 @@ public class BootstrapTest {
     }
 
     @Test
+    public void bootstrap_contentformat_from_config() {
+        // Create DM Server without security & start it
+        helper.createServer();
+        helper.server.start();
+
+        // Create and start bootstrap server
+        helper.createBootstrapServer(null, helper.unsecuredBootstrap(ContentFormat.SENML_JSON));
+        helper.bootstrapServer.start();
+        BootstrapRequestChecker contentFormatChecker = BootstrapRequestChecker
+                .contentFormatChecker(ContentFormat.SENML_JSON);
+        helper.bootstrapServer.addListener(contentFormatChecker);
+
+        // Create Client and check it is not already registered
+        ContentFormat preferredFormat = ContentFormat.SENML_CBOR;
+        helper.createClient(preferredFormat);
+        helper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        helper.client.start();
+        helper.waitForRegistrationAtServerSide(1);
+        assertTrue("not expected content format used", contentFormatChecker.isValid());
+
+        // check the client is registered
+        helper.assertClientRegisterered();
+    }
+
+    @Test
     public void bootstrapWithAdditionalAttributes() {
         // Create DM Server without security & start it
         helper.createServer();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -300,6 +300,34 @@ public class BootstrapTest {
     }
 
     @Test
+    public void bootstrap_with_auto_id_for_security_object() {
+        // Create DM Server without security & start it
+        helper.createServer();
+        helper.server.start();
+
+        // Create and start bootstrap server
+        helper.createBootstrapServer(null, helper.unsecuredBootstrapWithAutoID());
+        helper.bootstrapServer.start();
+
+        // Create Client with bootstrap server config at /0/10
+        helper.createClient(helper.withoutSecurityAndInstanceId(10), null);
+        helper.assertClientNotRegisterered();
+
+        // Start BS.
+        // Server will delete /0 but Client will not delete /0/10 instance (because bs server is not deletable)
+        // Then a new BS server will be written at /0/0
+        //
+        // So bootstrap should failed because 2 bs server in Security Object is not a valid state.
+        // see https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/523
+        helper.client.start();
+
+        // ensure bootstrap session succeed
+        helper.waitForBootstrapFinishedAtClientSide(1);
+        helper.waitForRegistrationAtServerSide(1);
+        helper.assertClientRegisterered();
+    }
+
+    @Test
     public void bootstrapDeleteSecurity() {
         // Create DM Server without security & start it
         helper.createServer();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -274,6 +274,32 @@ public class BootstrapTest {
     }
 
     @Test
+    public void bootstrap_create_2_bsserver() {
+        // Create DM Server without security & start it
+        helper.createServer();
+        helper.server.start();
+
+        // Create and start bootstrap server
+        helper.createBootstrapServer(null, helper.unsecuredBootstrapStoreWithBsSecurityInstanceIdAt(0));
+        helper.bootstrapServer.start();
+
+        // Create Client with bootstrap server config at /0/10
+        helper.createClient(helper.withoutSecurityAndInstanceId(10), null);
+        helper.assertClientNotRegisterered();
+
+        // Start BS.
+        // Server will delete /0 but Client will not delete /0/10 instance (because bs server is not deletable)
+        // Then a new BS server will be written at /0/0
+        //
+        // So bootstrap should failed because 2 bs server in Security Object is not a valid state.
+        // see https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/523
+        helper.client.start();
+
+        // ensure bootstrap session failed because of invalid state
+        helper.waitForInconsistentStateAtClientSide(1);
+    }
+
+    @Test
     public void bootstrapDeleteSecurity() {
         // Create DM Server without security & start it
         helper.createServer();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -42,6 +42,7 @@ import org.eclipse.leshan.core.request.exception.RequestCanceledException;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.integration.tests.util.BootstrapIntegrationTestHelper;
+import org.eclipse.leshan.integration.tests.util.BootstrapRequestChecker;
 import org.eclipse.leshan.integration.tests.util.TestObjectsInitializer;
 import org.eclipse.leshan.server.bootstrap.BootstrapFailureCause;
 import org.eclipse.leshan.server.security.NonUniqueSecurityInfoException;
@@ -98,6 +99,8 @@ public class BootstrapTest {
         // Create and start bootstrap server
         helper.createBootstrapServer(null);
         helper.bootstrapServer.start();
+        BootstrapRequestChecker contentFormatChecker = BootstrapRequestChecker.contentFormatChecker(ContentFormat.TLV);
+        helper.bootstrapServer.addListener(contentFormatChecker);
 
         // Create Client and check it is not already registered
         ContentFormat noPreferredFormat = null; // if no preferred content format server should use TLV
@@ -108,6 +111,7 @@ public class BootstrapTest {
         // Start it and wait for registration
         helper.client.start();
         helper.waitForRegistrationAtServerSide(1);
+        assertTrue("not expected content format used", contentFormatChecker.isValid());
 
         // check the client is registered
         helper.assertClientRegisterered();
@@ -122,6 +126,9 @@ public class BootstrapTest {
         // Create and start bootstrap server
         helper.createBootstrapServer(null);
         helper.bootstrapServer.start();
+        BootstrapRequestChecker contentFormatChecker = BootstrapRequestChecker
+                .contentFormatChecker(ContentFormat.SENML_CBOR);
+        helper.bootstrapServer.addListener(contentFormatChecker);
 
         // Create Client and check it is not already registered
         ContentFormat preferredFormat = ContentFormat.SENML_CBOR;
@@ -132,6 +139,7 @@ public class BootstrapTest {
         // Start it and wait for registration
         helper.client.start();
         helper.waitForRegistrationAtServerSide(1);
+        assertTrue("not expected content format used", contentFormatChecker.isValid());
 
         // check the client is registered
         helper.assertClientRegisterered();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
@@ -360,18 +360,23 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
     }
 
     public BootstrapConfigStore unsecuredBootstrapStore() {
-        return unsecuredBootstrapStore(0, false);
+        return unsecuredBootstrapStore(0, false, null);
     }
 
     public BootstrapConfigStore unsecuredBootstrapStoreWithBsSecurityInstanceIdAt(Integer instanceId) {
-        return unsecuredBootstrapStore(instanceId, false);
+        return unsecuredBootstrapStore(instanceId, false, null);
     }
 
     public BootstrapConfigStore unsecuredBootstrapWithAutoID() {
-        return unsecuredBootstrapStore(0, true);
+        return unsecuredBootstrapStore(0, true, null);
     }
 
-    public BootstrapConfigStore unsecuredBootstrapStore(final Integer bsInstanceId, final boolean autoId) {
+    public BootstrapConfigStore unsecuredBootstrap(ContentFormat format) {
+        return unsecuredBootstrapStore(0, true, format);
+    }
+
+    public BootstrapConfigStore unsecuredBootstrapStore(final Integer bsInstanceId, final boolean autoId,
+            final ContentFormat format) {
         return new BootstrapConfigStore() {
 
             @Override
@@ -380,6 +385,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
                 BootstrapConfig bsConfig = new BootstrapConfig();
 
                 bsConfig.autoIdForSecurityObject = autoId;
+                bsConfig.contentFormat = format;
 
                 // security for BS server
                 ServerSecurity bsSecurity = new ServerSecurity();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
@@ -46,7 +46,7 @@ import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Device;
 import org.eclipse.leshan.client.object.Security;
-import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
+import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.SecurityMode;
@@ -258,7 +258,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
         initializer.setInstancesForObject(LwM2mId.SECURITY, security);
         initializer.setInstancesForObject(LwM2mId.DEVICE,
                 new Device("Eclipse Leshan", IntegrationTestHelper.MODEL_NUMBER, "12345"));
-        initializer.setClassForObject(LwM2mId.SERVER, DummyInstanceEnabler.class);
+        initializer.setClassForObject(LwM2mId.SERVER, Server.class);
         createClient(initializer, additionalAttributes, preferredContentFormat, supportedContentFormat);
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
@@ -203,10 +203,17 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
     }
 
     public Security withoutSecurity() {
+        return withoutSecurityAndInstanceId(null);
+    }
+
+    public Security withoutSecurityAndInstanceId(Integer id) {
         // Create Security Object (with bootstrap server only)
         String bsUrl = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                 + bootstrapServer.getUnsecuredAddress().getPort();
-        return Security.noSecBootstap(bsUrl);
+        Security sec = Security.noSecBootstap(bsUrl);
+        if (id != null)
+            sec.setId(id);
+        return sec;
     }
 
     @Override
@@ -348,6 +355,10 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
     }
 
     public BootstrapConfigStore unsecuredBootstrapStore() {
+        return unsecuredBootstrapStoreWithBsSecurityInstanceIdAt(0);
+    }
+
+    public BootstrapConfigStore unsecuredBootstrapStoreWithBsSecurityInstanceIdAt(final int instanceId) {
         return new BootstrapConfigStore() {
 
             @Override
@@ -361,7 +372,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
                 bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                         + bootstrapServer.getUnsecuredAddress().getPort();
                 bsSecurity.securityMode = SecurityMode.NO_SEC;
-                bsConfig.security.put(0, bsSecurity);
+                bsConfig.security.put(instanceId, bsSecurity);
 
                 // security for DM server
                 ServerSecurity dmSecurity = new ServerSecurity();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
@@ -189,7 +189,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
                     return tasks;
                 } else {
                     lastDiscoverAnswer = (BootstrapDiscoverResponse) previousResponses.get(0);
-                    return super.getTasks(session, previousResponses);
+                    return super.getTasks(session, null);
                 }
             }
         };
@@ -355,10 +355,18 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
     }
 
     public BootstrapConfigStore unsecuredBootstrapStore() {
-        return unsecuredBootstrapStoreWithBsSecurityInstanceIdAt(0);
+        return unsecuredBootstrapStore(0, false);
     }
 
-    public BootstrapConfigStore unsecuredBootstrapStoreWithBsSecurityInstanceIdAt(final int instanceId) {
+    public BootstrapConfigStore unsecuredBootstrapStoreWithBsSecurityInstanceIdAt(Integer instanceId) {
+        return unsecuredBootstrapStore(instanceId, false);
+    }
+
+    public BootstrapConfigStore unsecuredBootstrapWithAutoID() {
+        return unsecuredBootstrapStore(0, true);
+    }
+
+    public BootstrapConfigStore unsecuredBootstrapStore(final Integer bsInstanceId, final boolean autoId) {
         return new BootstrapConfigStore() {
 
             @Override
@@ -366,13 +374,15 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
 
                 BootstrapConfig bsConfig = new BootstrapConfig();
 
+                bsConfig.autoIdForSecurityObject = autoId;
+
                 // security for BS server
                 ServerSecurity bsSecurity = new ServerSecurity();
                 bsSecurity.bootstrapServer = true;
                 bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
                         + bootstrapServer.getUnsecuredAddress().getPort();
                 bsSecurity.securityMode = SecurityMode.NO_SEC;
-                bsConfig.security.put(instanceId, bsSecurity);
+                bsConfig.security.put(bsInstanceId, bsSecurity);
 
                 // security for DM server
                 ServerSecurity dmSecurity = new ServerSecurity();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapRequestChecker.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapRequestChecker.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util;
+
+import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
+import org.eclipse.leshan.core.request.BootstrapWriteRequest;
+import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.server.bootstrap.BootstrapSession;
+import org.eclipse.leshan.server.bootstrap.BootstrapSessionAdapter;
+
+public class BootstrapRequestChecker extends BootstrapSessionAdapter {
+
+    public interface RequestValidator {
+        boolean validate(BootstrapDownlinkRequest<? extends LwM2mResponse> request);
+    }
+
+    private RequestValidator validator;
+    private boolean valid = true;
+
+    public BootstrapRequestChecker(RequestValidator validator) {
+        this.validator = validator;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    @Override
+    public void sendRequest(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request) {
+        if (!validator.validate(request)) {
+            valid = false;
+        }
+
+    }
+
+    public static BootstrapRequestChecker contentFormatChecker(final ContentFormat expectedFormat) {
+        return new BootstrapRequestChecker(new RequestValidator() {
+            @Override
+            public boolean validate(BootstrapDownlinkRequest<? extends LwM2mResponse> request) {
+                if (request instanceof BootstrapWriteRequest) {
+                    return ((BootstrapWriteRequest) request).getContentFormat() == expectedFormat;
+                }
+                return true;
+            }
+        });
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/IntegrationTestHelper.java
@@ -281,6 +281,14 @@ public class IntegrationTestHelper {
         }
     }
 
+    public void waitForInconsistentStateAtClientSide(long timeInSeconds) {
+        try {
+            assertTrue(clientObserver.waitForInconsistenState(timeInSeconds, TimeUnit.SECONDS));
+        } catch (InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void ensureNoUpdate(long timeInSeconds) {
         try {
             registrationListener.waitForUpdate(timeInSeconds, TimeUnit.SECONDS);

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SynchronousBootstrapListener.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SynchronousBootstrapListener.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
+import org.eclipse.leshan.core.request.BootstrapRequest;
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.server.bootstrap.BootstrapFailureCause;
+import org.eclipse.leshan.server.bootstrap.BootstrapSession;
+import org.eclipse.leshan.server.bootstrap.BootstrapSessionListener;
+
+public class SynchronousBootstrapListener implements BootstrapSessionListener {
+
+    private CountDownLatch finishedLatch = new CountDownLatch(1);
+    private CountDownLatch failedLatch = new CountDownLatch(1);
+    private BootstrapSession lastSucessfulSession;
+    private BootstrapFailureCause lastCause;
+
+    @Override
+    public void sessionInitiated(BootstrapRequest request, Identity clientIdentity) {
+    }
+
+    @Override
+    public void unAuthorized(BootstrapRequest request, Identity clientIdentity) {
+    }
+
+    @Override
+    public void authorized(BootstrapSession session) {
+
+    }
+
+    @Override
+    public void noConfig(BootstrapSession session) {
+    }
+
+    @Override
+    public void sendRequest(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request) {
+    }
+
+    @Override
+    public void onResponseSuccess(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response) {
+    }
+
+    @Override
+    public void onResponseError(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response) {
+    }
+
+    @Override
+    public void onRequestFailure(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            Throwable cause) {
+    }
+
+    @Override
+    public void end(BootstrapSession session) {
+        lastSucessfulSession = session;
+        finishedLatch.countDown();
+    }
+
+    @Override
+    public void failed(BootstrapSession session, BootstrapFailureCause cause) {
+        lastCause = cause;
+        failedLatch.countDown();
+    }
+
+    /**
+     * Wait until next bootstrap success event.
+     * 
+     * @throws TimeoutException if wait timeouts
+     */
+    public void waitForSuccess(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+        try {
+            if (!finishedLatch.await(timeout, timeUnit))
+                throw new TimeoutException("wait for bs success timeout");
+        } finally {
+            finishedLatch = new CountDownLatch(1);
+        }
+    }
+
+    /**
+     * Wait until next bootstrap failure event.
+     * 
+     * @throws TimeoutException if wait timeouts
+     */
+    public void waitForFailure(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+        try {
+            if (!failedLatch.await(timeout, timeUnit))
+                throw new TimeoutException("wait for bs failure timeout");
+        } finally {
+            failedLatch = new CountDownLatch(1);
+        }
+    }
+
+    public BootstrapSession getLastSuccessfulSession() {
+        return lastSucessfulSession;
+    }
+
+    public BootstrapFailureCause getLastCauseOfFailure() {
+        return lastCause;
+    }
+}

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServer.java
@@ -31,6 +31,8 @@ import org.eclipse.leshan.core.node.codec.LwM2mNodeEncoder;
 import org.eclipse.leshan.core.util.Validate;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandlerFactory;
+import org.eclipse.leshan.server.bootstrap.BootstrapSessionDispatcher;
+import org.eclipse.leshan.server.bootstrap.BootstrapSessionListener;
 import org.eclipse.leshan.server.bootstrap.BootstrapSessionManager;
 import org.eclipse.leshan.server.bootstrap.LwM2mBootstrapRequestSender;
 import org.eclipse.leshan.server.californium.RootResource;
@@ -49,6 +51,7 @@ public class LeshanBootstrapServer {
     private final CoapServer coapServer;
     private final CoapEndpoint unsecuredEndpoint;
     private final CoapEndpoint securedEndpoint;
+    private final BootstrapSessionDispatcher dispatcher = new BootstrapSessionDispatcher();
 
     private LwM2mBootstrapRequestSender requestSender;
 
@@ -90,7 +93,8 @@ public class LeshanBootstrapServer {
         requestSender = createRequestSender(securedEndpoint, unsecuredEndpoint, encoder, decoder);
 
         // create bootstrap resource
-        CoapResource bsResource = createBootstrapResource(bsHandlerFactory.create(requestSender, bsSessionManager));
+        CoapResource bsResource = createBootstrapResource(
+                bsHandlerFactory.create(requestSender, bsSessionManager, dispatcher));
         coapServer.add(bsResource);
     }
 
@@ -175,6 +179,14 @@ public class LeshanBootstrapServer {
         } else {
             return null;
         }
+    }
+
+    public void addListener(BootstrapSessionListener listener) {
+        dispatcher.addListener(listener);
+    }
+
+    public void removeListener(BootstrapSessionListener listener) {
+        dispatcher.removeListener(listener);
     }
 
     /**

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
@@ -45,6 +45,7 @@ import org.eclipse.leshan.server.bootstrap.BootstrapConfigStore;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfigStoreTaskProvider;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandlerFactory;
+import org.eclipse.leshan.server.bootstrap.BootstrapSessionListener;
 import org.eclipse.leshan.server.bootstrap.BootstrapSessionManager;
 import org.eclipse.leshan.server.bootstrap.DefaultBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.DefaultBootstrapSessionManager;
@@ -401,8 +402,8 @@ public class LeshanBootstrapServerBuilder {
             bootstrapHandlerFactory = new BootstrapHandlerFactory() {
                 @Override
                 public BootstrapHandler create(LwM2mBootstrapRequestSender sender,
-                        BootstrapSessionManager sessionManager) {
-                    return new DefaultBootstrapHandler(sender, sessionManager);
+                        BootstrapSessionManager sessionManager, BootstrapSessionListener listener) {
+                    return new DefaultBootstrapHandler(sender, sessionManager, listener);
                 }
             };
         if (configStore == null) {

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerTest.java
@@ -28,6 +28,7 @@ import org.eclipse.leshan.server.bootstrap.BootstrapConfigStore;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandlerFactory;
 import org.eclipse.leshan.server.bootstrap.BootstrapSession;
+import org.eclipse.leshan.server.bootstrap.BootstrapSessionListener;
 import org.eclipse.leshan.server.bootstrap.BootstrapSessionManager;
 import org.eclipse.leshan.server.bootstrap.DefaultBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.LwM2mBootstrapRequestSender;
@@ -43,8 +44,9 @@ public class LeshanBootstrapServerTest {
         builder.setBootstrapHandlerFactory(new BootstrapHandlerFactory() {
 
             @Override
-            public BootstrapHandler create(LwM2mBootstrapRequestSender sender, BootstrapSessionManager sessionManager) {
-                bsHandler = new DefaultBootstrapHandler(sender, sessionManager);
+            public BootstrapHandler create(LwM2mBootstrapRequestSender sender, BootstrapSessionManager sessionManager,
+                    BootstrapSessionListener listener) {
+                bsHandler = new DefaultBootstrapHandler(sender, sessionManager, listener);
                 return bsHandler;
             }
         });

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -23,10 +23,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.leshan.core.CertificateUsage;
+import org.eclipse.leshan.core.MatchingType;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.core.util.datatype.ULong;
 
 /**
  * A client configuration to apply to a device during a bootstrap session.
@@ -126,12 +128,49 @@ public class BootstrapConfig {
          */
         public EnumSet<BindingMode> binding = EnumSet.of(BindingMode.U);
 
+        /**
+         * If this resource is defined, it provides a link to the APN connection profile Object Instance (OMNA
+         * registered Object ID:11) to be used to communicate with this server.
+         * <p>
+         * Since Server v1.1
+         */
+        public Integer apnLink = null;
+
+        /**
+         * Using the Trigger Resource a LwM2M Client can indicate whether it is reachable over SMS (value set to 'true')
+         * or not (value set to 'false'). The default value (resource not present) is 'false'. When set to 'true' the
+         * LwM2M Server MAY, for example, request the LwM2M Client to perform operations, such as the "Update" operation
+         * by sending an "Execute" operation on "Registration Update Trigger" Resource via SMS. No SMS response is
+         * expected for such a message.
+         * <p>
+         * Since Server v1.1
+         */
+        public Boolean trigger = null;
+
+        /**
+         * Only a single transport binding SHALL be present. When the LwM2M client supports multiple transports, it MAY
+         * use this transport to initiate a connection. This resource can also be used to switch between multiple
+         * transports e.g. a non-IP device can switch to UDP transport to perform firmware updates.
+         * <p>
+         * Since Server v1.1
+         */
+        public BindingMode preferredTransport = null;
+        /**
+         * If true or the Resource is not present, the LwM2M Client Send command capability is de-activated. If false,
+         * the LwM2M Client Send Command capability is activated. *
+         * <p>
+         * Since Server v1.1
+         */
+        public Boolean muteSend = null;
+
         @Override
         public String toString() {
             return String.format(
-                    "ServerConfig [shortId=%s, lifetime=%s, defaultMinPeriod=%s, defaultMaxPeriod=%s, disableTimeout=%s, notifIfDisabled=%s, binding=%s]",
-                    shortId, lifetime, defaultMinPeriod, defaultMaxPeriod, disableTimeout, notifIfDisabled, binding);
+                    "ServerConfig [shortId=%s, lifetime=%s, defaultMinPeriod=%s, defaultMaxPeriod=%s, disableTimeout=%s, notifIfDisabled=%s, binding=%s, apnLink=%s, trigger=%s, preferredTransport=%s, muteSend=%s]",
+                    shortId, lifetime, defaultMinPeriod, defaultMaxPeriod, disableTimeout, notifIfDisabled, binding,
+                    apnLink, trigger, preferredTransport, muteSend);
         }
+
     }
 
     /**
@@ -243,6 +282,29 @@ public class BootstrapConfig {
         public Integer bootstrapServerAccountTimeout = 0;
 
         /**
+         * The Matching Type Resource specifies how the certificate or raw public key in in the Server Public Key is
+         * presented. Four values are currently defined:
+         * <ul>
+         * <li>0: Exact match. This is the default value and also corresponds to the functionality of LwM2M v1.0. Hence,
+         * if this resource is not present then the content of the Server Public Key Resource corresponds to this value.
+         * <li>1: SHA-256 hash [RFC6234]
+         * <li>2: SHA-384 hash [RFC6234]
+         * <li>3: SHA-512 hash [RFC6234]
+         * </ul>
+         * Since Security v1.1
+         */
+        public MatchingType matchingType = null;
+
+        /**
+         * This resource holds the value of the Server Name Indication (SNI) value to be used during the TLS handshake.
+         * When this resource is present then the LwM2M Server URI acts as the address of the service while the SNI
+         * value is used for matching a presented certificate, or PSK identity. *
+         * <p>
+         * Since Security v1.1
+         */
+        public String sni = null;
+
+        /**
          * The Certificate Usage Resource specifies the semantic of the certificate or raw public key stored in the
          * Server Public Key Resource, which is used to match the certificate presented in the TLS/DTLS handshake.
          * <ul>
@@ -251,17 +313,38 @@ public class BootstrapConfig {
          * <li>2: trust anchor assertion
          * <li>3: domain-issued certificate (default if missing)
          * </ul>
+         * <p>
+         * Since Security v1.1
          */
-        public CertificateUsage certificateUsage;
+        public CertificateUsage certificateUsage = null;
+
+        /**
+         * When this resource is present it instructs the TLS/DTLS client to propose the indicated ciphersuite(s) in the
+         * ClientHello of the handshake. A ciphersuite is indicated as a 32-bit integer value. The IANA TLS ciphersuite
+         * registry is maintained at https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml. As an
+         * example, the TLS_PSK_WITH_AES_128_CCM_8 ciphersuite is represented with the following string "0xC0,0xA8". To
+         * form an integer value the two values are concatenated. In this example, the value is 0xc0a8 or 49320.
+         * <p>
+         * Since Security v1.1
+         */
+        public ULong cipherSuite = null;
+
+        /**
+         * The Object ID of the OSCORE Object Instance that holds the OSCORE configuration to be used by the LWM2M
+         * Client to the LWM2M Server associated with this Security object.
+         * 
+         */
+        public Integer oscoreSecurityMode = null;
 
         @Override
         public String toString() {
             // Note : secretKey and smsBindingKeySecret are explicitly excluded from the display for security purposes
             return String.format(
-                    "ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeySecret=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s, certificateUsage=%s]",
+                    "ServerSecurity [uri=%s, bootstrapServer=%s, securityMode=%s, publicKeyOrId=%s, serverPublicKey=%s, smsSecurityMode=%s, smsBindingKeyParam=%s, serverSmsNumber=%s, serverId=%s, clientOldOffTime=%s, bootstrapServerAccountTimeout=%s, matchingType=%s, certificateUsage=%s, sni=%s, cipherSuite=%s, oscoreSecurityMode=%s]",
                     uri, bootstrapServer, securityMode, Arrays.toString(publicKeyOrId),
                     Arrays.toString(serverPublicKey), smsSecurityMode, Arrays.toString(smsBindingKeyParam),
-                    serverSmsNumber, serverId, clientOldOffTime, bootstrapServerAccountTimeout, certificateUsage);
+                    serverSmsNumber, serverId, clientOldOffTime, bootstrapServerAccountTimeout, matchingType,
+                    certificateUsage, sni, cipherSuite, oscoreSecurityMode);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.BindingMode;
+import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 
 /**
  * A client configuration to apply to a device during a bootstrap session.
@@ -42,6 +43,20 @@ import org.eclipse.leshan.core.request.BindingMode;
  * @see DefaultBootstrapHandler
  */
 public class BootstrapConfig {
+
+    /**
+     * If activated, bootstrap server will start the bootstrap session with a {@link BootstrapDiscoverRequest} to know
+     * what is the Security(object 0) instance ID of bootstrap server on the device, then it will use this information
+     * to automatically attribute IDs to {@link #security} instance. (meaning that ID defined in {@link #security} will
+     * not be used)
+     * <p>
+     * This can be useful because bootstrap server can not be deleted and only 1 Bootstrap server can be present in
+     * Security Object. <br>
+     * See <a href=
+     * "https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/522">OMA_LwM2M_for_Developers#522</a>for
+     * more details .
+     */
+    public boolean autoIdForSecurityObject = false;
 
     /**
      * List of LWM2M path to delete.

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -26,6 +26,7 @@ import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
+import org.eclipse.leshan.core.request.ContentFormat;
 
 /**
  * A client configuration to apply to a device during a bootstrap session.
@@ -57,6 +58,13 @@ public class BootstrapConfig {
      * more details .
      */
     public boolean autoIdForSecurityObject = false;
+
+    /**
+     * Content format used to send requests.
+     * <p>
+     * if <code>null</code> content format used is the preferred one by the client (pct attribute from BootstrapRequest)
+     */
+    public ContentFormat contentFormat = null;
 
     /**
      * List of LWM2M path to delete.

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigStoreTaskProvider.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigStoreTaskProvider.java
@@ -87,11 +87,9 @@ public class BootstrapConfigStoreTaskProvider implements BootstrapTaskProvider {
             }
 
             // We add model for Security(0), Server(0) and ACL(2) which are the only one supported by BootstrapConfig
-            // We use default 1.0 model as currently BootstrapConfig support only this model version (which should be
-            // compatible with models of LWM2M v1.1 but without new resources)
             tasks.supportedObjects = new HashMap<>();
-            tasks.supportedObjects.put(0, "1.0");
-            tasks.supportedObjects.put(1, "1.0");
+            tasks.supportedObjects.put(0, "1.1");
+            tasks.supportedObjects.put(1, "1.1");
             tasks.supportedObjects.put(2, "1.0");
 
             return tasks;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigStoreTaskProvider.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigStoreTaskProvider.java
@@ -76,11 +76,13 @@ public class BootstrapConfigStoreTaskProvider implements BootstrapTaskProvider {
                 }
 
                 // create requests from config
-                tasks.requestsToSend = BootstrapUtil.toRequests(config, session.getContentFormat(),
+                tasks.requestsToSend = BootstrapUtil.toRequests(config,
+                        config.contentFormat != null ? config.contentFormat : session.getContentFormat(),
                         bootstrapServerInstanceId);
             } else {
                 // create requests from config
-                tasks.requestsToSend = BootstrapUtil.toRequests(config, session.getContentFormat());
+                tasks.requestsToSend = BootstrapUtil.toRequests(config,
+                        config.contentFormat != null ? config.contentFormat : session.getContentFormat());
 
             }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandlerFactory.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapHandlerFactory.java
@@ -27,7 +27,9 @@ public interface BootstrapHandlerFactory {
      * 
      * @param sender the class responsible to send LWM2M request during a bootstapSession.
      * @param sessionManager the manager responsible to handle bootstrap session.
+     * @param listener a listener of bootstrap session life-cycle.
      * @return the new {@link BootstrapHandler}.
      */
-    BootstrapHandler create(LwM2mBootstrapRequestSender sender, BootstrapSessionManager sessionManager);
+    BootstrapHandler create(LwM2mBootstrapRequestSender sender, BootstrapSessionManager sessionManager,
+            BootstrapSessionListener listener);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionAdapter.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionAdapter.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap;
+
+import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
+import org.eclipse.leshan.core.request.BootstrapRequest;
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+
+public class BootstrapSessionAdapter implements BootstrapSessionListener {
+
+    @Override
+    public void sessionInitiated(BootstrapRequest request, Identity clientIdentity) {
+    }
+
+    @Override
+    public void unAuthorized(BootstrapRequest request, Identity clientIdentity) {
+    }
+
+    @Override
+    public void authorized(BootstrapSession session) {
+    }
+
+    @Override
+    public void noConfig(BootstrapSession session) {
+    }
+
+    @Override
+    public void sendRequest(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request) {
+    }
+
+    @Override
+    public void onResponseSuccess(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response) {
+    }
+
+    @Override
+    public void onResponseError(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response) {
+    }
+
+    @Override
+    public void onRequestFailure(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            Throwable cause) {
+    }
+
+    @Override
+    public void end(BootstrapSession session) {
+    }
+
+    @Override
+    public void failed(BootstrapSession session, BootstrapFailureCause cause) {
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionDispatcher.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionDispatcher.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
+import org.eclipse.leshan.core.request.BootstrapRequest;
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+
+public class BootstrapSessionDispatcher implements BootstrapSessionListener {
+
+    private List<BootstrapSessionListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void addListener(BootstrapSessionListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(BootstrapSessionListener listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public void sessionInitiated(BootstrapRequest request, Identity clientIdentity) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.sessionInitiated(request, clientIdentity);
+        }
+    }
+
+    @Override
+    public void unAuthorized(BootstrapRequest request, Identity clientIdentity) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.unAuthorized(request, clientIdentity);
+        }
+    }
+
+    @Override
+    public void authorized(BootstrapSession session) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.authorized(session);
+        }
+    }
+
+    @Override
+    public void noConfig(BootstrapSession session) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.noConfig(session);
+        }
+    }
+
+    @Override
+    public void sendRequest(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.sendRequest(session, request);
+        }
+    }
+
+    @Override
+    public void onResponseSuccess(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.onResponseSuccess(session, request, response);
+        }
+    }
+
+    @Override
+    public void onResponseError(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.onResponseError(session, request, response);
+        }
+    }
+
+    @Override
+    public void onRequestFailure(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            Throwable cause) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.onRequestFailure(session, request, cause);
+        }
+    }
+
+    @Override
+    public void end(BootstrapSession session) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.end(session);
+        }
+    }
+
+    @Override
+    public void failed(BootstrapSession session, BootstrapFailureCause cause) {
+        for (BootstrapSessionListener listener : listeners) {
+            listener.failed(session, cause);
+        }
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapSessionListener.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap;
+
+import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
+import org.eclipse.leshan.core.request.BootstrapRequest;
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+
+public interface BootstrapSessionListener {
+
+    /**
+     * Called when a client try to initiate a session
+     */
+    void sessionInitiated(BootstrapRequest request, Identity clientIdentity);
+
+    /**
+     * Called if client is not authorized to start a bootstrap session
+     */
+    void unAuthorized(BootstrapRequest request, Identity clientIdentity);
+
+    /**
+     * Called if client is authorized to start a bootstrap session
+     */
+    void authorized(BootstrapSession session);
+
+    /**
+     * Called if there is no configuration to apply for this client
+     */
+    void noConfig(BootstrapSession session);
+
+    /**
+     * Called when a request is sent
+     */
+    void sendRequest(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request);
+
+    /**
+     * Called when we receive a successful response to a request.
+     * 
+     * @param session the bootstrap session concerned.
+     * @param request The request for which we get a successful response.
+     * @param response The response received.
+     */
+    void onResponseSuccess(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response);
+
+    /**
+     * Called when we receive a error response to a request.
+     * 
+     * @param session the bootstrap session concerned.
+     * @param request The request for which we get a error response.
+     * @param response The response received.
+     * 
+     */
+    public void onResponseError(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            LwM2mResponse response);
+
+    /**
+     * Called when a request failed to be sent.
+     * 
+     * @param session the bootstrap session concerned.
+     * @param request The request which failed to be sent.
+     * @param cause The cause of the failure. Can be null.
+     * 
+     */
+    public void onRequestFailure(BootstrapSession session, BootstrapDownlinkRequest<? extends LwM2mResponse> request,
+            Throwable cause);
+
+    /**
+     * Called when bootstrap session finished successfully
+     */
+    void end(BootstrapSession session);
+
+    /**
+     * Called when bootstrap session failed
+     */
+    void failed(BootstrapSession session, BootstrapFailureCause cause);
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
@@ -28,6 +28,7 @@ import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
+import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
@@ -42,6 +43,7 @@ public class BootstrapUtil {
     public static LwM2mObjectInstance toSecurityInstance(int instanceId, ServerSecurity securityConfig) {
         Collection<LwM2mResource> resources = new ArrayList<>();
 
+        // resources since v1.0
         if (securityConfig.uri != null)
             resources.add(LwM2mSingleResource.newStringResource(0, securityConfig.uri));
         resources.add(LwM2mSingleResource.newBooleanResource(1, securityConfig.bootstrapServer));
@@ -67,9 +69,20 @@ public class BootstrapUtil {
             resources.add(LwM2mSingleResource.newIntegerResource(11, securityConfig.clientOldOffTime));
         if (securityConfig.bootstrapServerAccountTimeout != null)
             resources.add(LwM2mSingleResource.newIntegerResource(12, securityConfig.bootstrapServerAccountTimeout));
+
+        // resources since v1.1
+        if (securityConfig.matchingType != null)
+            resources.add(LwM2mSingleResource.newUnsignedIntegerResource(13, securityConfig.matchingType.code));
+        if (securityConfig.sni != null)
+            resources.add(LwM2mSingleResource.newStringResource(14, securityConfig.sni));
         if (securityConfig.certificateUsage != null)
             resources.add(LwM2mSingleResource.newUnsignedIntegerResource(15, securityConfig.certificateUsage.code));
-
+        if (securityConfig.cipherSuite != null)
+            resources.add(LwM2mSingleResource.newUnsignedIntegerResource(16, securityConfig.cipherSuite));
+        if (securityConfig.oscoreSecurityMode != null) {
+            resources.add(LwM2mSingleResource.newObjectLinkResource(17,
+                    new ObjectLink(21, securityConfig.oscoreSecurityMode)));
+        }
         return new LwM2mObjectInstance(instanceId, resources);
     }
 
@@ -83,6 +96,7 @@ public class BootstrapUtil {
     public static LwM2mObjectInstance toServerInstance(int instanceId, ServerConfig serverConfig) {
         Collection<LwM2mResource> resources = new ArrayList<>();
 
+        // resources since v1.0
         resources.add(LwM2mSingleResource.newIntegerResource(0, serverConfig.shortId));
         resources.add(LwM2mSingleResource.newIntegerResource(1, serverConfig.lifetime));
         if (serverConfig.defaultMinPeriod != null)
@@ -94,6 +108,16 @@ public class BootstrapUtil {
         resources.add(LwM2mSingleResource.newBooleanResource(6, serverConfig.notifIfDisabled));
         if (serverConfig.binding != null)
             resources.add(LwM2mSingleResource.newStringResource(7, BindingMode.toString(serverConfig.binding)));
+
+        // resources since v1.1
+        if (serverConfig.apnLink != null)
+            resources.add(LwM2mSingleResource.newObjectLinkResource(10, new ObjectLink(11, serverConfig.apnLink)));
+        if (serverConfig.trigger != null)
+            resources.add(LwM2mSingleResource.newBooleanResource(21, serverConfig.trigger));
+        if (serverConfig.preferredTransport != null)
+            resources.add(LwM2mSingleResource.newStringResource(22, serverConfig.preferredTransport.toString()));
+        if (serverConfig.muteSend != null)
+            resources.add(LwM2mSingleResource.newBooleanResource(23, serverConfig.muteSend));
 
         return new LwM2mObjectInstance(instanceId, resources);
     }

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapHandlerTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapHandlerTest.java
@@ -49,7 +49,8 @@ public class BootstrapHandlerTest {
         // prepare bootstrapHandler with a session manager which does not authorized any session
         BootstrapSessionManager bsSessionManager = new MockBootstrapSessionManager(false,
                 new InMemoryBootstrapConfigStore());
-        BootstrapHandler bsHandler = new DefaultBootstrapHandler(null, bsSessionManager);
+        BootstrapHandler bsHandler = new DefaultBootstrapHandler(new MockRequestSender(Mode.ALWAYS_SUCCESS),
+                bsSessionManager, new BootstrapSessionDispatcher());
 
         // Try to bootstrap
         BootstrapResponse response = bsHandler
@@ -70,7 +71,8 @@ public class BootstrapHandlerTest {
         bsStore.add("endpoint", new BootstrapConfig());
         MockBootstrapSessionManager bsSessionManager = new MockBootstrapSessionManager(true, bsStore);
 
-        BootstrapHandler bsHandler = new DefaultBootstrapHandler(requestSender, bsSessionManager);
+        BootstrapHandler bsHandler = new DefaultBootstrapHandler(requestSender, bsSessionManager,
+                new BootstrapSessionDispatcher());
 
         // Try to bootstrap
         SendableResponse<BootstrapResponse> sendableResponse = bsHandler
@@ -91,7 +93,8 @@ public class BootstrapHandlerTest {
         EditableBootstrapConfigStore bsStore = new InMemoryBootstrapConfigStore();
         bsStore.add("endpoint", new BootstrapConfig());
         MockBootstrapSessionManager bsSessionManager = new MockBootstrapSessionManager(true, bsStore);
-        BootstrapHandler bsHandler = new DefaultBootstrapHandler(requestSender, bsSessionManager);
+        BootstrapHandler bsHandler = new DefaultBootstrapHandler(requestSender, bsSessionManager,
+                new BootstrapSessionDispatcher());
 
         // Try to bootstrap
         SendableResponse<BootstrapResponse> sendableResponse = bsHandler
@@ -115,7 +118,7 @@ public class BootstrapHandlerTest {
         bsStore.add("endpoint", new BootstrapConfig());
         MockBootstrapSessionManager bsSessionManager = new MockBootstrapSessionManager(true, bsStore);
         BootstrapHandler bsHandler = new DefaultBootstrapHandler(requestSender, bsSessionManager,
-                DefaultBootstrapHandler.DEFAULT_TIMEOUT);
+                new BootstrapSessionDispatcher(), DefaultBootstrapHandler.DEFAULT_TIMEOUT);
 
         // First bootstrap : which will not end (because of sender)
         SendableResponse<BootstrapResponse> first_response = bsHandler


### PR DESCRIPTION
LWM2M does not allow to delete the instance of Security Object(0) related to Bootstrap server.

This could be an issue to apply a bootstrap config if you don't know what is the instance ID of BS server before.

The auto ID mode uses Bootstrap Discover Request to solve this issue.

See for more details : https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/522

Some additional feature was added too : 
- "Bootstrap-Request Trigger" resource (1/?/9) at client side.
- support of "uri" attribute on bootstrap discover
- #1000: Add a BootstrapConsistencyChecker to Leshan Client. 