### PR TITLE
Add color to logback log for leshan-client-demo

### DIFF
--- a/leshan-client-demo/logback-config.xml
+++ b/leshan-client-demo/logback-config.xml
@@ -16,8 +16,10 @@ Contributors:
  -->
 <configuration>
 	<appender name="TERMINAL" class="org.eclipse.leshan.client.demo.cli.interactive.TerminalAppender">
-		<encoder>
-			<pattern>%gray(%30.30logger{0}) %gray(%d) [%highlight(%p)] %m%n</pattern>
+		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+			<layout class="org.eclipse.leshan.client.demo.logback.ColorAwarePatternLayout">
+				<pattern>%gray(%30.30logger{0}) %gray(%d) [%highlight(%p)] %m%n</pattern>
+			</layout>
 		</encoder>
 	</appender>
 

--- a/leshan-client-demo/logback-config.xml
+++ b/leshan-client-demo/logback-config.xml
@@ -17,7 +17,7 @@ Contributors:
 <configuration>
 	<appender name="TERMINAL" class="org.eclipse.leshan.client.demo.cli.interactive.TerminalAppender">
 		<encoder>
-			<pattern>%d %p %C{0} - %m%n</pattern>
+			<pattern>%gray(%30.30logger{0}) %gray(%d) [%highlight(%p)] %m%n</pattern>
 		</encoder>
 	</appender>
 

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/logback/ColorAwarePatternLayout.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/logback/ColorAwarePatternLayout.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.logback;
+
+import ch.qos.logback.classic.PatternLayout;
+import picocli.CommandLine.Help.Ansi;
+
+/**
+ * A Logback Pattern Layout which use Picocli ANSI color heuristic to apply ANSI color only on terminal which support
+ * it.
+ */
+public class ColorAwarePatternLayout extends PatternLayout {
+
+    static {
+        if (!Ansi.AUTO.enabled()) {
+            defaultConverterMap.put("black", NoColorConverter.class.getName());
+            defaultConverterMap.put("red", NoColorConverter.class.getName());
+            defaultConverterMap.put("green", NoColorConverter.class.getName());
+            defaultConverterMap.put("yellow", NoColorConverter.class.getName());
+            defaultConverterMap.put("blue", NoColorConverter.class.getName());
+            defaultConverterMap.put("magenta", NoColorConverter.class.getName());
+            defaultConverterMap.put("cyan", NoColorConverter.class.getName());
+            defaultConverterMap.put("white", NoColorConverter.class.getName());
+            defaultConverterMap.put("gray", NoColorConverter.class.getName());
+            defaultConverterMap.put("boldRed", NoColorConverter.class.getName());
+            defaultConverterMap.put("boldGreen", NoColorConverter.class.getName());
+            defaultConverterMap.put("boldYellow", NoColorConverter.class.getName());
+            defaultConverterMap.put("boldBlue", NoColorConverter.class.getName());
+            defaultConverterMap.put("boldMagenta", NoColorConverter.class.getName());
+            defaultConverterMap.put("boldCyan", NoColorConverter.class.getName());
+            defaultConverterMap.put("boldWhite", NoColorConverter.class.getName());
+            defaultConverterMap.put("highlight", NoColorConverter.class.getName());
+        }
+    }
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/logback/NoColorConverter.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/logback/NoColorConverter.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.logback;
+
+import ch.qos.logback.core.pattern.CompositeConverter;
+
+public class NoColorConverter<E> extends CompositeConverter<E> {
+
+    @Override
+    protected String transform(E event, String in) {
+        return in;
+    }
+}


### PR DESCRIPTION
This aims to implement #568.

To fix issue "using color with logback will add some crappy code color in eclipse console." (see https://github.com/eclipse/leshan/issues/568#issuecomment-429280289 for more details)

We use some workaround using a Custom  `PatternLayout` and using picocli Color Heuristic. 