### PR TITLE
Add Send command to leshan-client-demo.

### DIFF
--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ContentFormatConverter.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ContentFormatConverter.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.demo.cli.converters;
+
+import java.util.Arrays;
+
+import org.eclipse.leshan.core.request.ContentFormat;
+
+import picocli.CommandLine.ITypeConverter;
+
+public class ContentFormatConverter implements ITypeConverter<ContentFormat> {
+
+    private final ContentFormat[] allowedContentFormat;
+
+    public ContentFormatConverter() {
+        this.allowedContentFormat = ContentFormat.knownContentFormat;
+    }
+
+    public ContentFormatConverter(ContentFormat... allowedContentFormats) {
+        this.allowedContentFormat = allowedContentFormats;
+    }
+
+    @Override
+    public ContentFormat convert(String value) throws Exception {
+        // try to get format by name
+        ContentFormat ct = ContentFormat.fromName(value);
+
+        // if not found try to get format by code
+        if (ct == null) {
+            try {
+                int code = Integer.parseInt(value);
+                ct = ContentFormat.fromCode(code);
+            } catch (NumberFormatException e) {
+                // we do nothing more if value is not a integer, means user probably try to get the content format by
+                // name
+            }
+        }
+
+        if (ct == null) {
+            throw new IllegalArgumentException(
+                    String.format("%s is not a known content format name. Allowed Content Format are %s.", value,
+                            Arrays.toString(allowedContentFormat)));
+        }
+
+        if (!Arrays.asList(allowedContentFormat).contains(ct)) {
+            throw new IllegalArgumentException(
+                    String.format("%s is not allowed for this operation. Allowed content format are %s.", ct,
+                            Arrays.toString(allowedContentFormat)));
+        }
+
+        return ct;
+    }
+
+}

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/StringLwM2mPathConverter.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/StringLwM2mPathConverter.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.demo.cli.converters;
+
+import org.eclipse.leshan.core.node.LwM2mPath;
+
+import picocli.CommandLine.ITypeConverter;
+
+public class StringLwM2mPathConverter implements ITypeConverter<String> {
+
+    @Override
+    public String convert(String value) throws Exception {
+        // create a LwM2mPath to force validation.
+        new LwM2mPath(value);
+        return value;
+    }
+}


### PR DESCRIPTION
This aims to re-implement  #1031 since we moved to picocli/Jline (see #1064).

The new commands looks like : 
```
Usage:  send [-c=<contentFormat>] [<paths>...]
Send data to server
      [<paths>...]   paths of data to send.
  -c, --content-format=<contentFormat>
                     Name (e.g. SENML_JSON) or code (e.g. 110) of Content
                       Format used to send data.
                     Default : SENML_CBOR
```

Example of usage : 
```
send /3/0/1 /3/0/2 -c SENML_JSON
           InteractiveCommands 2021-09-06 15:15:46,013 [INFO] Sending Data to coap://localhost:5683[LWM2M_SERVER 123] using SENML_JSON(110).
                      MyDevice 2021-09-06 15:15:46,018 [INFO] Read on Device resource /3/0/1
                      MyDevice 2021-09-06 15:15:46,020 [INFO] Read on Device resource /3/0/2
           InteractiveCommands 2021-09-06 15:15:46,110 [INFO] Data sent successfully to coap://localhost:5683[LWM2M_SERVER 123] [CHANGED(204)].
```