### PR TITLE
Adapt for "latest" cleanup in Californium's Configuration in RC2.

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -393,6 +393,6 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
                 filteredCiphers.add(cipher);
             }
         }
-        dtlsConfigurationBuilder.setSupportedCipherSuites(filteredCiphers);
+        dtlsConfigurationBuilder.set(DtlsConfig.DTLS_CIPHER_SUITES, filteredCiphers);
     }
 }

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -208,7 +208,7 @@ public class LeshanClientDemo {
         dtlsConfig.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, !cli.dtls.supportDeprecatedCiphers);
         dtlsConfig.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, cli.dtls.cid);
         if (cli.dtls.ciphers != null) {
-            dtlsConfig.setSupportedCipherSuites(cli.dtls.ciphers);
+            dtlsConfig.set(DtlsConfig.DTLS_CIPHER_SUITES, cli.dtls.ciphers);
         }
 
         // Configure Registration Engine

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SecureIntegrationTestHelper.java
@@ -246,7 +246,7 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
         builder.setLocalAddress(clientAddress.getHostString(), clientAddress.getPort());
         builder.setObjects(objects);
         builder.setDtlsConfig(DtlsConnectorConfig.builder(configuration)
-                .setSupportedCipherSuites(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8));
+                .setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_PSK_WITH_AES_128_CCM_8));
 
         // set an editable PSK store for tests
         builder.setEndpointFactory(new EndpointFactory() {

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerBuilderTest.java
@@ -122,7 +122,7 @@ public class LeshanServerBuilderTest {
     @Test
     public void create_server_without_psk_cipher() {
         Configuration coapConfiguration = LeshanServerBuilder.createDefaultCoapConfiguration();
-        coapConfiguration.setList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
+        coapConfiguration.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
         builder.setCoapConfig(coapConfiguration);
         builder.setPrivateKey(privateKey);
         builder.setPublicKey(publicKey);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilderTest.java
@@ -165,7 +165,7 @@ public class LeshanBootstrapServerBuilderTest {
     @Test
     public void create_server_without_psk_cipher() {
         Configuration coapConfiguration = LeshanServerBuilder.createDefaultCoapConfiguration();
-        coapConfiguration.setList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
+        coapConfiguration.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
         builder.setCoapConfig(coapConfiguration);
         builder.setPrivateKey(privateKey);
         builder.setPublicKey(publicKey);

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ Contributors:
         <test.exclusion.pattern>**/Redis*.java</test.exclusion.pattern>
 
         <!-- dependencies version -->
-        <californium.version>3.0.0-RC1</californium.version>
+        <californium.version>3.0.0-RC2</californium.version>
         <logback.version>1.2.6</logback.version>
         <slf4j.api.version>1.7.32</slf4j.api.version>
         <!-- stuck to 9.4.x for java8 compliance -->


### PR DESCRIPTION
Use generic setter instead of removed specific ones.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>