### PR TITLE
Fix bad request when creating X509 security info via REST API of `leshan-server-demo` 

### DIFF
--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/JacksonSecurityDeserializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/JacksonSecurityDeserializer.java
@@ -101,7 +101,7 @@ public class JacksonSecurityDeserializer extends JsonDeserializer<SecurityInfo> 
                     throw new JsonParseException(p, "Invalid security info content", e);
                 }
                 info = SecurityInfo.newRawPublicKeyInfo(endpoint, key);
-            } else if (x509.isMissingNode() && x509.asBoolean()) {
+            } else if (x509 != null && x509.asBoolean()) {
                 info = SecurityInfo.newX509CertInfo(endpoint);
             } else {
                 throw new JsonParseException(p, "Invalid security info content");


### PR DESCRIPTION
This aims to fix #1163.