### PR TITLE
OSCORE integration & unit tests

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/BootstrapConfigSecurityStore.java
@@ -28,7 +28,7 @@ import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.SecurityUtil;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.OscoreObject;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
@@ -106,7 +106,7 @@ public class BootstrapConfigSecurityStore implements BootstrapSecurityStore {
                 if (security.bootstrapServer && oscoreInstanceId != null) {
                     OscoreObject oscoreObject = bsConfig.oscore.get(oscoreInstanceId);
 
-                    HashMapCtxDB db = OscoreHandler.getContextDB();
+                    HashMapCtxDB db = OscoreBootstrapHandler.getContextDB();
                     byte[] rid = Hex.decodeHex(oscoreObject.oscoreRecipientId.toCharArray());
                     OSCoreCtx ctx = db.getContext(rid);
 

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
@@ -50,7 +50,7 @@ import org.eclipse.leshan.core.model.ObjectLoader;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.StaticModel;
 import org.eclipse.leshan.core.util.SecurityUtil;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfigurationStoreAdapter;
 import org.eclipse.leshan.server.bootstrap.demo.servlet.BootstrapServlet;
 import org.eclipse.leshan.server.bootstrap.demo.servlet.ServerServlet;
@@ -352,10 +352,6 @@ public class LeshanBootstrapServerDemo {
             boolean supportDeprecatedCiphers, PublicKey publicKey, PrivateKey privateKey, X509Certificate[] certificate,
             List<Certificate> trustStore, Integer cid) throws Exception {
 
-        // Enable OSCORE stack (fine to do even when using DTLS or only CoAP)
-        // TODO OSCORE : this should be done in DefaultEndpointFactory ?
-        OSCoreCoapStackFactory.useAsDefault(OscoreHandler.getContextDB());
-
         // Create Models
         List<ObjectModel> models = ObjectLoader.loadDefault();
         if (modelsFolderPath != null) {
@@ -364,6 +360,9 @@ public class LeshanBootstrapServerDemo {
 
         // Prepare and start bootstrap server
         LeshanBootstrapServerBuilder builder = new LeshanBootstrapServerBuilder();
+
+        builder.setOscoreCtxDB(OscoreBootstrapHandler.getContextDB());
+
         JSONFileBootstrapStore bsStore = new JSONFileBootstrapStore(configFilename);
         builder.setConfigStore(new BootstrapConfigurationStoreAdapter(bsStore));
         builder.setSecurityStore(new BootstrapConfigSecurityStore(bsStore));

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/CaliforniumEndpointsManager.java
@@ -218,7 +218,7 @@ public class CaliforniumEndpointsManager implements EndpointsManager {
             // oscore only mode
             LOG.info("Adding OSCORE context for " + serverInfo.getFullUri().toASCIIString());
             // TODO OSCORE : use OscoreStore instead ?
-            HashMapCtxDB db = OscoreHandler.getContextDB();
+            HashMapCtxDB db = OscoreClientHandler.getContextDB();
 
             AlgorithmID hkdfAlg = null;
             try {

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -275,6 +275,8 @@ public class LeshanClient implements LwM2mClient {
         requestSender.destroy();
         objectTree.destroy();
 
+        OscoreClientHandler.purge();
+
         LOG.info("Leshan client destroyed.");
     }
 

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreClientHandler.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreClientHandler.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.client.californium;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+//TODO OSCORE : remove this class and static access.
+public class OscoreClientHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+
+    public static void purge() {
+        db = null;
+    }
+}

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/request/CaliforniumLwM2mRequestSender.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/request/CaliforniumLwM2mRequestSender.java
@@ -27,7 +27,7 @@ import org.eclipse.californium.elements.util.Bytes;
 import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.client.californium.CaliforniumEndpointsManager;
-import org.eclipse.leshan.client.californium.OscoreHandler;
+import org.eclipse.leshan.client.californium.OscoreClientHandler;
 import org.eclipse.leshan.client.request.LwM2mRequestSender;
 import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.californium.AsyncRequestObserver;
@@ -79,7 +79,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
 
         // TODO OSCORE : this should be added in CoapRequestBuilder
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
-        HashMapCtxDB db = OscoreHandler.getContextDB();
+        HashMapCtxDB db = OscoreClientHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);
@@ -118,7 +118,7 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
 
         // TODO OSCORE : this should be added in CoapRequestBuilder
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
-        HashMapCtxDB db = OscoreHandler.getContextDB();
+        HashMapCtxDB db = OscoreClientHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -83,7 +83,7 @@ public class Security extends BaseInstanceEnabler {
     /**
      * Returns a new security instance (OSCORE only) for a bootstrap server.
      */
-    public static Security oscoreOnlyBootstrap(String serverUri, int shortServerId, int oscoreObjectInstanceId) {
+    public static Security oscoreOnlyBootstrap(String serverUri, Integer shortServerId, int oscoreObjectInstanceId) {
         return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0],
                 shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code,
                 new ObjectLink(OSCORE, oscoreObjectInstanceId));

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -53,8 +53,6 @@ import org.eclipse.californium.cose.AlgorithmID;
 import org.eclipse.californium.cose.CoseException;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.util.SslContextUtil;
-import org.eclipse.californium.oscore.HashMapCtxDB;
-import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.ClientHandshaker;
@@ -70,7 +68,6 @@ import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
-import org.eclipse.leshan.client.californium.OscoreHandler;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Oscore;
 import org.eclipse.leshan.client.object.Server;
@@ -651,10 +648,6 @@ public class LeshanClientDemo {
 
         // Get models folder
         String modelsFolderPath = cl.getOptionValue("m");
-
-        // TODO OSCORE : OSCoreCoapStack should be create in Default endpoint factory
-        HashMapCtxDB db = OscoreHandler.getContextDB();
-        OSCoreCoapStackFactory.useAsDefault(db);
 
         // Set parameters controlling OSCORE usage
         OSCoreSettings oscoreSettings = null;

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
 import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 
@@ -104,7 +105,11 @@ public class DefaultEndpointFactory implements EndpointFactory {
     public CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, NetworkConfig coapConfig,
             ObservationStore store, HashMapCtxDB db) {
         // TODO OSCORE : db should maybe be replaced by OscoreEStore
-        return createUnsecuredEndpointBuilder(address, coapConfig, store).build();
+        Builder builder = createUnsecuredEndpointBuilder(address, coapConfig, store);
+        if (db != null) {
+            builder.setCustomCoapStackArgument(db).setCoapStackFactory(new OSCoreCoapStackFactory());
+        }
+        return builder.build();
     }
 
     /**

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.resource.SimpleInstanceEnabler;
@@ -43,6 +44,7 @@ import org.eclipse.leshan.server.security.NonUniqueSecurityInfoException;
 import org.eclipse.leshan.server.security.SecurityInfo;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class BootstrapTest {
@@ -183,7 +185,7 @@ public class BootstrapTest {
         helper.assertClientRegisterered();
         assertNotNull(helper.lastDiscoverAnswer);
         assertEquals(ResponseCode.CONTENT, helper.lastDiscoverAnswer.getCode());
-        assertEquals("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>,</1>;ver=1.1,</3>;ver=1.1,</3/0>",
+        assertEquals("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>,</1>;ver=1.1,</3>;ver=1.1,</3/0>,</21>",
                 Link.serialize(helper.lastDiscoverAnswer.getObjectLinks()));
     }
 
@@ -439,6 +441,76 @@ public class BootstrapTest {
         helper.waitForRegistrationAtServerSide(1);
 
         // check the client is registered
+        helper.assertClientRegisterered();
+    }
+
+    @Test
+    public void bootstrapUnsecuredToServerWithOscore() throws NonUniqueSecurityInfoException {
+        helper.createServer();
+        helper.server.start();
+
+        helper.createBootstrapServer(null, helper.unsecuredBootstrapStoreWithOscoreServer());
+        helper.bootstrapServer.start();
+
+        // Check client is not registered
+        helper.createClient();
+        helper.assertClientNotRegisterered();
+
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+
+        // Start it and wait for registration
+        helper.client.start();
+
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
+        helper.assertClientRegisterered();
+    }
+
+    @Test
+    public void bootstrapViaOscoreToServerWithOscore() throws NonUniqueSecurityInfoException {
+        helper.createServer();
+        helper.server.start();
+
+
+        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC), helper.oscoreBootstrapStoreWithOscoreServer());
+        helper.bootstrapServer.start();
+
+        // Check client is not registered
+        helper.createOscoreOnlyBootstrapClient();
+        helper.assertClientNotRegisterered();
+
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+
+        // Start it and wait for registration
+        helper.client.start();
+
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
+        helper.assertClientRegisterered();
+    }
+
+    @Test
+    @Ignore
+    // TODO OSCORE: Test shows that current implementation can't bootstrap via OSCORE to non-OSCORE server
+    public void bootstrapViaOscoreToUnsecuredServer() throws OSException {
+        helper.createServer();
+        helper.server.start();
+
+        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC), helper.oscoreBootstrapStoreWithUnsecuredServer());
+        helper.bootstrapServer.start();
+
+        // Check client is not registered
+        helper.createOscoreOnlyBootstrapClient();
+        helper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        helper.client.start();
+
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
         helper.assertClientRegisterered();
     }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
@@ -102,6 +102,32 @@ public class SecurityTest {
     }
 
     @Test
+    public void registered_device_with_oscore_to_server_with_oscore()
+            throws NonUniqueSecurityInfoException, InterruptedException {
+
+        helper.createServer();
+        helper.server.start();
+
+        helper.createOscoreClient();
+
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+
+        // Check client is not registered
+        helper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        helper.client.start();
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
+        helper.assertClientRegisterered();
+
+        // check we can send request to client.
+        ReadResponse response = helper.server.send(helper.getCurrentRegistration(), new ReadRequest(3, 0, 1), 500);
+        assertTrue(response.isSuccess());
+    }
+
+    @Test
     public void dont_sent_request_if_identity_change()
             throws NonUniqueSecurityInfoException, InterruptedException, IOException {
         // Create PSK server & start it

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/BootstrapIntegrationTestHelper.java
@@ -16,6 +16,8 @@
 
 package org.eclipse.leshan.integration.tests.util;
 
+import static org.eclipse.leshan.client.object.Security.*;
+import static org.eclipse.leshan.core.LwM2mId.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
@@ -42,9 +44,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Device;
+import org.eclipse.leshan.client.object.Oscore;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
@@ -58,6 +64,7 @@ import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapDiscoverResponse;
 import org.eclipse.leshan.core.util.Hex;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ACLConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerConfig;
@@ -85,6 +92,11 @@ import org.eclipse.leshan.server.security.SecurityInfo;
  * 
  */
 public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper {
+
+    public static final byte[] OSCORE_BOOTSTRAP_MASTER_SECRET = Hex.decodeHex("BB1234567890".toCharArray());
+    public static final byte[] OSCORE_BOOTSTRAP_MASTER_SALT = Hex.decodeHex("BB0987654321".toCharArray());
+    public static final byte[] OSCORE_BOOTSTRAP_SENDER_ID = Hex.decodeHex("BBABCDEF".toCharArray());
+    public static final byte[] OSCORE_BOOTSTRAP_RECIPIENT_ID = Hex.decodeHex("BBFEDCBA".toCharArray());
 
     public LeshanBootstrapServer bootstrapServer;
     public final PublicKey bootstrapServerPublicKey;
@@ -154,6 +166,8 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
             }
         });
 
+        builder.setOscoreCtxDB(OscoreBootstrapHandler.getContextDB());
+
         return builder;
     }
 
@@ -208,6 +222,16 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
         return Security.noSecBootstap(bsUrl);
     }
 
+    public void createOscoreOnlyBootstrapClient() {
+        String bsServerUri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
+                + bootstrapServer.getUnsecuredAddress().getPort();
+
+        Oscore oscoreObject = getOscoreBootstrapClientObject();
+        ObjectsInitializer initializer = new TestObjectsInitializer();
+        initializer.setInstancesForObject(OSCORE, oscoreObject);
+        createClient(oscoreOnlyBootstrap(bsServerUri, null, oscoreObject.getId()), initializer);
+    }
+
     @Override
     public void createClient() {
         createClient(withoutSecurity(), null);
@@ -258,6 +282,7 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
         initializer.setInstancesForObject(LwM2mId.DEVICE,
                 new Device("Eclipse Leshan", IntegrationTestHelper.MODEL_NUMBER, "12345"));
         initializer.setClassForObject(LwM2mId.SERVER, DummyInstanceEnabler.class);
+        initializer.setClassForObject(LwM2mId.OSCORE, Oscore.class);
         createClient(initializer, additionalAttributes, preferredContentFormat, supportedContentFormat);
     }
 
@@ -312,6 +337,15 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
                         return Arrays.asList(info).iterator();
                     } else if (mode == SecurityMode.RPK) {
                         info = rpkSecurityInfo();
+                        return Arrays.asList(info).iterator();
+                    } else  if (mode == SecurityMode.NO_SEC) {
+                        byte[] rid = OSCORE_BOOTSTRAP_SENDER_ID;
+
+                        HashMapCtxDB db = OscoreBootstrapHandler.getContextDB();
+                        OSCoreCtx ctx = db.getContext(rid);
+
+                        // Create the security info (will re-add the context to the db)
+                        info = SecurityInfo.newOSCoreInfo(endpoint, ctx);
                         return Arrays.asList(info).iterator();
                     }
                 }
@@ -523,6 +557,154 @@ public class BootstrapIntegrationTestHelper extends SecureIntegrationTestHelper 
                 return new BootstrapConfiguration(BootstrapUtil.toRequests(bsConfig, session.getContentFormat()));
             }
         };
+    }
+
+    public BootstrapConfigurationStore unsecuredBootstrapStoreWithOscoreServer() {
+        return new BootstrapConfigurationStore() {
+
+            @Override
+            public BootstrapConfiguration get(String endpoint, Identity deviceIdentity, BootstrapSession session) {
+
+                BootstrapConfig bsConfig = new BootstrapConfig();
+
+                // security for BS server
+                ServerSecurity bsSecurity = new ServerSecurity();
+                bsSecurity.bootstrapServer = true;
+                bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
+                        + bootstrapServer.getUnsecuredAddress().getPort();
+                bsSecurity.securityMode = SecurityMode.NO_SEC;
+                bsConfig.security.put(0, bsSecurity);
+
+                // security for DM server
+                ServerSecurity dmSecurity = new ServerSecurity();
+                dmSecurity.uri = "coap://" + server.getUnsecuredAddress().getHostString() + ":"
+                        + server.getUnsecuredAddress().getPort();
+                dmSecurity.serverId = 2222;
+                dmSecurity.securityMode = SecurityMode.NO_SEC;
+                dmSecurity.oscoreSecurityMode = 1;
+                bsConfig.security.put(1, dmSecurity);
+                bsConfig.oscore.put(1, getOscoreBootstrapObject(false));
+
+                // DM server
+                ServerConfig dmConfig = new ServerConfig();
+                dmConfig.shortId = 2222;
+                bsConfig.servers.put(0, dmConfig);
+
+                return new BootstrapConfiguration(BootstrapUtil.toRequests(bsConfig, session.getContentFormat()));
+            }
+        };
+    }
+
+    public BootstrapConfigurationStore oscoreBootstrapStoreWithOscoreServer() {
+        OscoreBootstrapHandler.getContextDB().addContext(getOsCoreBootstrapCtx());
+
+        return new BootstrapConfigurationStore() {
+
+            @Override
+            public BootstrapConfiguration get(String endpoint, Identity deviceIdentity, BootstrapSession session) {
+
+                BootstrapConfig bsConfig = new BootstrapConfig();
+
+                // security for BS server
+                ServerSecurity bsSecurity = new ServerSecurity();
+                bsSecurity.bootstrapServer = true;
+                bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
+                        + bootstrapServer.getUnsecuredAddress().getPort();
+                bsSecurity.securityMode = SecurityMode.NO_SEC;
+                bsSecurity.oscoreSecurityMode = 1;
+                bsConfig.security.put(0, bsSecurity);
+                bsConfig.oscore.put(0, getOscoreBootstrapObject(true));
+
+                // security for DM server
+                ServerSecurity dmSecurity = new ServerSecurity();
+                dmSecurity.uri = "coap://" + server.getUnsecuredAddress().getHostString() + ":"
+                        + server.getUnsecuredAddress().getPort();
+                dmSecurity.serverId = 2222;
+                dmSecurity.securityMode = SecurityMode.NO_SEC;
+                dmSecurity.oscoreSecurityMode = 1;
+                bsConfig.security.put(1, dmSecurity);
+                bsConfig.oscore.put(1, getOscoreBootstrapObject(false));
+
+                // DM server
+                ServerConfig dmConfig = new ServerConfig();
+                dmConfig.shortId = 2222;
+                bsConfig.servers.put(0, dmConfig);
+
+                return new BootstrapConfiguration(BootstrapUtil.toRequests(bsConfig, session.getContentFormat()));
+            }
+        };
+    }
+
+    public BootstrapConfigurationStore oscoreBootstrapStoreWithUnsecuredServer() {
+        OscoreBootstrapHandler.getContextDB().addContext(BootstrapIntegrationTestHelper.getOsCoreBootstrapCtx());
+
+        return new BootstrapConfigurationStore() {
+
+            @Override
+            public BootstrapConfiguration get(String endpoint, Identity deviceIdentity, BootstrapSession session) {
+
+                BootstrapConfig bsConfig = new BootstrapConfig();
+
+                // security for BS server
+                ServerSecurity bsSecurity = new ServerSecurity();
+                bsSecurity.bootstrapServer = true;
+                bsSecurity.uri = "coap://" + bootstrapServer.getUnsecuredAddress().getHostString() + ":"
+                        + bootstrapServer.getUnsecuredAddress().getPort();
+                bsSecurity.securityMode = SecurityMode.NO_SEC;
+                bsSecurity.oscoreSecurityMode = 1;
+                bsConfig.security.put(0, bsSecurity);
+                bsConfig.oscore.put(0, getOscoreBootstrapObject(true));
+
+                // security for DM server
+                ServerSecurity dmSecurity = new ServerSecurity();
+                dmSecurity.uri = "coap://" + server.getUnsecuredAddress().getHostString() + ":"
+                        + server.getUnsecuredAddress().getPort();
+                dmSecurity.serverId = 2222;
+                dmSecurity.securityMode = SecurityMode.NO_SEC;
+                bsConfig.security.put(1, dmSecurity);
+
+                // DM server
+                ServerConfig dmConfig = new ServerConfig();
+                dmConfig.shortId = 2222;
+                bsConfig.servers.put(0, dmConfig);
+
+                return new BootstrapConfiguration(BootstrapUtil.toRequests(bsConfig, session.getContentFormat()));
+            }
+        };
+    }
+
+    protected static Oscore getOscoreBootstrapClientObject() {
+        return new Oscore(12345,
+                new String(Hex.encodeHex(OSCORE_BOOTSTRAP_MASTER_SECRET)),
+                new String(Hex.encodeHex(OSCORE_BOOTSTRAP_SENDER_ID)),
+                new String(Hex.encodeHex(OSCORE_BOOTSTRAP_RECIPIENT_ID)),
+                OSCORE_ALGORITHM.AsCBOR().AsInt32(),
+                OSCORE_KDF_ALGORITHM.AsCBOR().AsInt32(),
+                new String(Hex.encodeHex(OSCORE_BOOTSTRAP_MASTER_SALT)));
+    }
+
+    protected static BootstrapConfig.OscoreObject getOscoreBootstrapObject(boolean bootstrap) {
+        BootstrapConfig.OscoreObject oscoreObject = new BootstrapConfig.OscoreObject();
+
+        oscoreObject.oscoreMasterSecret = new String(Hex.encodeHex(bootstrap ? OSCORE_BOOTSTRAP_MASTER_SECRET : OSCORE_MASTER_SECRET));
+        oscoreObject.oscoreSenderId = new String(Hex.encodeHex(bootstrap ? OSCORE_BOOTSTRAP_SENDER_ID : OSCORE_SENDER_ID));
+        oscoreObject.oscoreRecipientId = new String(Hex.encodeHex(bootstrap ? OSCORE_BOOTSTRAP_RECIPIENT_ID : OSCORE_RECIPIENT_ID));
+        oscoreObject.oscoreAeadAlgorithm = OSCORE_ALGORITHM.AsCBOR().AsInt32();
+        oscoreObject.oscoreHmacAlgorithm = OSCORE_KDF_ALGORITHM.AsCBOR().AsInt32();
+        oscoreObject.oscoreMasterSalt = new String(Hex.encodeHex(bootstrap ? OSCORE_BOOTSTRAP_MASTER_SALT : OSCORE_MASTER_SALT));
+
+        return oscoreObject;
+    }
+
+    public static OSCoreCtx getOsCoreBootstrapCtx() {
+        try {
+            OSCoreCtx osCoreCtx = new OSCoreCtx(OSCORE_BOOTSTRAP_MASTER_SECRET, true, OSCORE_ALGORITHM, OSCORE_BOOTSTRAP_RECIPIENT_ID,
+                    OSCORE_BOOTSTRAP_SENDER_ID, OSCORE_KDF_ALGORITHM, 32, OSCORE_BOOTSTRAP_MASTER_SALT, null);
+            osCoreCtx.setContextRederivationEnabled(true);
+            return osCoreCtx;
+        } catch (OSException ignored) {
+            return null;
+        }
     }
 
     @Override

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/IntegrationTestHelper.java
@@ -53,6 +53,7 @@ import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.request.UplinkRequest;
 import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.californium.LeshanServer;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.model.VersionedModelProvider;
@@ -222,6 +223,7 @@ public class IntegrationTestHelper {
                 return super.isAuthorized(request, registration, senderIdentity);
             }
         });
+        builder.setOscoreCtxDB(OscoreServerHandler.getContextDB());
         return builder;
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SecureIntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SecureIntegrationTestHelper.java
@@ -16,6 +16,9 @@
 
 package org.eclipse.leshan.integration.tests.util;
 
+import static org.eclipse.leshan.client.object.Security.oscoreOnly;
+import static org.eclipse.leshan.core.LwM2mId.*;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -47,7 +50,10 @@ import javax.security.auth.x500.X500Principal;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.californium.cose.AlgorithmID;
 import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
@@ -59,6 +65,7 @@ import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.californium.X509Util;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Device;
+import org.eclipse.leshan.client.object.Oscore;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
@@ -84,6 +91,15 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
     public static final String BAD_PSK_ID = "Bad_Client_identity";
     public static final byte[] BAD_PSK_KEY = Hex.decodeHex("010101010101010101".toCharArray());
     public static final String BAD_ENDPOINT = "bad_endpoint";
+
+    public static final byte[] OSCORE_MASTER_SECRET = Hex.decodeHex("1234567890".toCharArray());
+    public static final byte[] OSCORE_MASTER_SALT = Hex.decodeHex("0987654321".toCharArray());
+    public static final byte[] OSCORE_SENDER_ID = Hex.decodeHex("ABCDEF".toCharArray());
+    public static final byte[] OSCORE_RECIPIENT_ID = Hex.decodeHex("FEDCBA".toCharArray());
+
+    public static final AlgorithmID OSCORE_ALGORITHM = AlgorithmID.AES_CCM_16_64_128;
+    public static final AlgorithmID OSCORE_KDF_ALGORITHM = AlgorithmID.HKDF_HMAC_SHA_256;
+
     private SinglePSKStore singlePSKStore;
     protected SecurityStore securityStore;
 
@@ -454,6 +470,47 @@ public class SecureIntegrationTestHelper extends IntegrationTestHelper {
         server = builder.build();
         // monitor client registration
         setupServerMonitoring();
+    }
+
+    public void createOscoreClient() {
+        ObjectsInitializer initializer = new TestObjectsInitializer();
+
+        String serverUri =
+                "coap://" + server.getUnsecuredAddress().getHostString() + ":" + server.getUnsecuredAddress().getPort();
+
+        Oscore oscoreObject = getOscoreClientObject();
+        initializer.setInstancesForObject(SECURITY, oscoreOnly(serverUri, 12345, oscoreObject.getId()));
+        initializer.setInstancesForObject(OSCORE, oscoreObject);
+
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new Device("Eclipse Leshan", MODEL_NUMBER, "12345"));
+        List<LwM2mObjectEnabler> objects = initializer.createAll();
+
+        InetSocketAddress clientAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        LeshanClientBuilder builder = new LeshanClientBuilder(getCurrentEndpoint());
+        builder.setLocalAddress(clientAddress.getHostString(), clientAddress.getPort());
+
+        builder.setObjects(objects);
+        client = builder.build();
+        setupClientMonitoring();
+    }
+
+    public static OSCoreCtx getOscoreCtx() {
+        try {
+            OSCoreCtx osCoreCtx = new OSCoreCtx(OSCORE_MASTER_SECRET, true, OSCORE_ALGORITHM, OSCORE_RECIPIENT_ID,
+                    OSCORE_SENDER_ID, OSCORE_KDF_ALGORITHM, 32, OSCORE_MASTER_SALT, null);
+            osCoreCtx.setContextRederivationEnabled(true);
+            return osCoreCtx;
+        } catch (OSException ignored) {
+            return null;
+        }
+    }
+
+    protected static Oscore getOscoreClientObject() {
+        return new Oscore(12345, new String(Hex.encodeHex(OSCORE_MASTER_SECRET)),
+                new String(Hex.encodeHex(OSCORE_SENDER_ID)), new String(Hex.encodeHex(OSCORE_RECIPIENT_ID)),
+                OSCORE_ALGORITHM.AsCBOR().AsInt32(), OSCORE_KDF_ALGORITHM.AsCBOR().AsInt32(),
+                new String(Hex.encodeHex(OSCORE_MASTER_SALT)));
     }
 
     public PublicKey getServerPublicKey() {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServer.java
@@ -48,6 +48,7 @@ import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.californium.observation.ObservationServiceImpl;
 import org.eclipse.leshan.server.californium.registration.CaliforniumRegistrationStore;
 import org.eclipse.leshan.server.californium.registration.RegisterResource;
@@ -423,6 +424,8 @@ public class LeshanServer {
         }
 
         presenceService.destroy();
+
+        OscoreServerHandler.purge();
 
         LOG.info("LWM2M server destroyed.");
     }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -30,6 +30,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
@@ -394,6 +395,13 @@ public class LeshanServerBuilder {
         return networkConfig;
     }
 
+    HashMapCtxDB oscoreCtxDB;
+
+    public LeshanServerBuilder setOscoreCtxDB(HashMapCtxDB oscoreCtxDB) {
+        this.oscoreCtxDB = oscoreCtxDB;
+        return this;
+    }
+
     /**
      * Create the {@link LeshanServer}.
      * <p>
@@ -565,7 +573,7 @@ public class LeshanServerBuilder {
         CoapEndpoint unsecuredEndpoint = null;
         if (!noUnsecuredEndpoint) {
             unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, registrationStore,
-                    null);
+                    oscoreCtxDB);
         }
 
         CoapEndpoint securedEndpoint = null;

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/BootstrapResource.java
@@ -34,7 +34,7 @@ import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +67,7 @@ public class BootstrapResource extends LwM2mCoapResource {
 
             // Update the URI of the associated OSCORE Context with the client's URI
             // So the server can send requests to the client
-            HashMapCtxDB db = OscoreHandler.getContextDB();
+            HashMapCtxDB db = OscoreBootstrapHandler.getContextDB();
             OSCoreCtx clientCtx = db.getContext(exchange.advanced().getCryptographicContextID());
 
             try {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServer.java
@@ -30,6 +30,7 @@ import org.eclipse.leshan.core.util.Validate;
 import org.eclipse.leshan.core.Destroyable;
 import org.eclipse.leshan.core.Startable;
 import org.eclipse.leshan.core.Stoppable;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfigurationStore;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandlerFactory;
@@ -187,6 +188,9 @@ public class LeshanBootstrapServer {
         } else if (requestSender instanceof Stoppable) {
             ((Stoppable) requestSender).stop();
         }
+
+        OscoreBootstrapHandler.purge();
+
         LOG.info("Bootstrap server destroyed.");
     }
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
@@ -27,6 +27,7 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
@@ -391,6 +392,13 @@ public class LeshanBootstrapServerBuilder {
         return networkConfig;
     }
 
+    HashMapCtxDB oscoreCtxDB;
+
+    public LeshanBootstrapServerBuilder setOscoreCtxDB(HashMapCtxDB oscoreCtxDB) {
+        this.oscoreCtxDB = oscoreCtxDB;
+        return this;
+    }
+
     /**
      * Create the {@link LeshanBootstrapServer}.
      * <p>
@@ -553,7 +561,7 @@ public class LeshanBootstrapServerBuilder {
 
         CoapEndpoint unsecuredEndpoint = null;
         if (!noUnsecuredEndpoint) {
-            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, null);
+            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, oscoreCtxDB);
         }
 
         CoapEndpoint securedEndpoint = null;

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
@@ -42,7 +42,7 @@ import org.eclipse.leshan.core.response.DeregisterResponse;
 import org.eclipse.leshan.core.response.RegisterResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
 import org.eclipse.leshan.core.response.UpdateResponse;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.registration.RegistrationHandler;
 import org.eclipse.leshan.server.registration.RegistrationService;
 import org.slf4j.Logger;
@@ -132,7 +132,7 @@ public class RegisterResource extends LwM2mCoapResource {
 
             // Update the URI of the associated OSCORE Context with the client's URI
             // So the server can send requests to the client
-            HashMapCtxDB db = OscoreHandler.getContextDB();
+            HashMapCtxDB db = OscoreServerHandler.getContextDB();
             OSCoreCtx clientCtx = db.getContext(exchange.advanced().getCryptographicContextID());
 
             try {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/RequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/RequestSender.java
@@ -58,7 +58,7 @@ import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.core.util.NamedThreadFactory;
 import org.eclipse.leshan.core.util.Validate;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.request.LowerLayerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,7 +141,7 @@ public class RequestSender implements Destroyable {
 
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
         // TODO OSCORE : this should be added in CoapRequestBuilder
-        HashMapCtxDB db = OscoreHandler.getContextDB();
+        HashMapCtxDB db = OscoreServerHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);
@@ -229,7 +229,7 @@ public class RequestSender implements Destroyable {
 
         // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
         // TODO OSCORE : this should be added in CoapRequestBuilder
-        HashMapCtxDB db = OscoreHandler.getContextDB();
+        HashMapCtxDB db = OscoreServerHandler.getContextDB();
         try {
             if (db.getContext(coapRequest.getURI()) != null) {
                 coapRequest.getOptions().setOscore(Bytes.EMPTY);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreBootstrapHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreBootstrapHandler.java
@@ -18,7 +18,7 @@ package org.eclipse.leshan.server;
 import org.eclipse.californium.oscore.HashMapCtxDB;
 
 // TODO OSCORE : remove this class and static access.
-public class OscoreHandler {
+public class OscoreBootstrapHandler {
 
     private static HashMapCtxDB db;
 
@@ -27,5 +27,9 @@ public class OscoreHandler {
             db = new HashMapCtxDB();
         }
         return db;
+    }
+
+    public static void purge() {
+        db = null;
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreServerHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreServerHandler.java
@@ -13,12 +13,12 @@
  * Contributors:
  *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
-package org.eclipse.leshan.client.californium;
+package org.eclipse.leshan.server;
 
 import org.eclipse.californium.oscore.HashMapCtxDB;
 
-//TODO OSCORE : remove this class and static access.
-public class OscoreHandler {
+// TODO OSCORE : remove this class and static access.
+public class OscoreServerHandler {
 
     private static HashMapCtxDB db;
 
@@ -27,5 +27,9 @@ public class OscoreHandler {
             db = new HashMapCtxDB();
         }
         return db;
+    }
+
+    public static void purge() {
+        db = null;
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
@@ -28,7 +28,7 @@ import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.util.Hex;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,7 +119,7 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
     // If an OSCORE configuration came, add it to the context db
     // TODO this should be done via a kind of OSCORE Store
     public void addOscoreContext(BootstrapConfig config) {
-        HashMapCtxDB db = OscoreHandler.getContextDB();
+        HashMapCtxDB db = OscoreBootstrapHandler.getContextDB();
         for (ServerSecurity security : config.security.values()) {
             // Make sure to only add OSCORE context for the BS-Client connection
             BootstrapConfig.OscoreObject osc = config.oscore.get(security.oscoreSecurityMode);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/SecurityInfo.java
@@ -24,7 +24,7 @@ import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.oscore.OSCoreCtx;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.Validate;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreServerHandler;
 
 /**
  * The security info for a client.
@@ -118,7 +118,7 @@ public class SecurityInfo implements Serializable {
         Validate.notNull(oscoreCtx);
 
         // Add the OSCORE Context to the context database
-        HashMapCtxDB db = OscoreHandler.getContextDB();
+        HashMapCtxDB db = OscoreServerHandler.getContextDB();
         db.addContext(oscoreCtx);
 
         return new SecurityInfo(endpoint, null, null, null, false, oscoreCtx);

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -48,7 +48,6 @@ import org.apache.commons.cli.ParseException;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.elements.util.SslContextUtil;
-import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.jetty.server.Server;
@@ -62,7 +61,7 @@ import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeEncoder;
 import org.eclipse.leshan.core.node.codec.LwM2mNodeDecoder;
 import org.eclipse.leshan.core.util.SecurityUtil;
-import org.eclipse.leshan.server.OscoreHandler;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.californium.LeshanServer;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.demo.servlet.ClientServlet;
@@ -419,9 +418,7 @@ public class LeshanServerDemo {
         LwM2mNodeDecoder decoder = new DefaultLwM2mNodeDecoder();
         builder.setDecoder(decoder);
 
-        // Enable OSCORE stack (fine to do even when using DTLS or only CoAP)
-        // TODO OSCORE : OSCoreCoapStack should be created in DefaultEndpointFactory.
-        OSCoreCoapStackFactory.useAsDefault(OscoreHandler.getContextDB());
+        builder.setOscoreCtxDB(OscoreServerHandler.getContextDB());
 
         // Create CoAP Config
         NetworkConfig coapConfig;


### PR DESCRIPTION
I added few integration tests to check combinations:

- OSCORE client to OSCORE server
- client bootstrap via OSCORE to OSCORE server
- client bootstrap unsecured to OSCORE server
- client bootstrap via OSCORE to unsecured server

The last test is disabled because current implementation seems not working well with this combination.

In RedisSecurityTest the "registered_device_with_oscore_to_server_with_oscore" test fails because redis serializer is not adjusted to OSCORE yet.

By the way of the tests I had to split OscoreHandler to three classes (OscoreBootstrapHandler, OscoreServerHandler, OscoreClientHandler) because they use static field and while testing the client/server/bootstrap messed up each other's context.