### PR TITLE
Send data error handling

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SynchronousSendListener.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SynchronousSendListener.java
@@ -39,7 +39,7 @@ public class SynchronousSendListener implements SendListener {
     }
 
     @Override
-    public void onError(Registration registration, InvalidRequestException e) {
+    public void onError(Registration registration, Exception e) {
 
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SynchronousSendListener.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/SynchronousSendListener.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.request.SendRequest;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.send.SendListener;
 
@@ -35,6 +36,11 @@ public class SynchronousSendListener implements SendListener {
         this.data = data;
         this.registration = registration;
         dataLatch.countDown();
+    }
+
+    @Override
+    public void onError(Registration registration, InvalidRequestException e) {
+
     }
 
     public Map<String, LwM2mNode> getData() {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/send/SendResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/send/SendResource.java
@@ -78,6 +78,7 @@ public class SendResource extends LwM2mCoapResource {
         ContentFormat contentFormat = ContentFormat.fromCode(exchange.getRequestOptions().getContentFormat());
         if (!decoder.isSupported(contentFormat)) {
             exchange.respond(ResponseCode.BAD_REQUEST, "Unsupported content format");
+            sendHandler.onError(registration, new InvalidRequestException("Unsupported content format"));
             return;
         }
         Map<LwM2mPath, LwM2mNode> data = null;

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/send/SendResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/send/SendResource.java
@@ -27,10 +27,12 @@ import org.eclipse.leshan.core.californium.LwM2mCoapResource;
 import org.eclipse.leshan.core.model.LwM2mModel;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.node.codec.CodecException;
 import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.request.SendRequest;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.SendResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
 import org.eclipse.leshan.server.model.LwM2mModelProvider;
@@ -78,7 +80,15 @@ public class SendResource extends LwM2mCoapResource {
             exchange.respond(ResponseCode.BAD_REQUEST, "Unsupported content format");
             return;
         }
-        Map<LwM2mPath, LwM2mNode> data = decoder.decodeNodes(payload, contentFormat, (List<LwM2mPath>) null, model);
+        Map<LwM2mPath, LwM2mNode> data = null;
+
+        try {
+            data = decoder.decodeNodes(payload, contentFormat, (List<LwM2mPath>) null, model);
+        } catch (CodecException e) {
+            InvalidRequestException invalidreqexception = new InvalidRequestException(e);
+            sendHandler.onError(registration, invalidreqexception);
+            throw invalidreqexception;
+        }
 
         // Handle "send op request
         SendRequest sendRequest = new SendRequest(contentFormat, data, coapRequest);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendHandler.java
@@ -69,12 +69,11 @@ public class SendHandler implements SendService {
             listener.dataReceived(registration, Collections.unmodifiableMap(nodes), request);
         }
     }
-    public void onError(Registration registration, InvalidRequestException e)
-    {
+    public void onError(Registration registration, InvalidRequestException e) {
         for (SendListener listener : listeners) {
-
             listener.onError(registration, new InvalidRequestException(e));
 
         }
     }
+
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendHandler.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.SendRequest;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.SendResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
 import org.eclipse.leshan.server.registration.Registration;
@@ -66,6 +67,14 @@ public class SendHandler implements SendService {
 
         for (SendListener listener : listeners) {
             listener.dataReceived(registration, Collections.unmodifiableMap(nodes), request);
+        }
+    }
+    public void onError(Registration registration, InvalidRequestException e)
+    {
+        for (SendListener listener : listeners) {
+
+            listener.onError(registration, new InvalidRequestException(e));
+
         }
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
@@ -40,8 +40,7 @@ public interface SendListener {
 
 
     /**
-     *  Called for any error e.g. if something wrong happened when we handle SendRequest,
-     *  data can't be decoded by server etc.
+     *  Called when data can't be decoded by server (because of e.g. unsupported content format or mistake in payload).
      *
      * @param registration Registration of the client which send the data.
      * @param e exception

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.request.SendRequest;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.server.registration.Registration;
 
 /**
@@ -38,4 +39,5 @@ public interface SendListener {
     void dataReceived(Registration registration, Map<String, LwM2mNode> data, SendRequest request);
 
     // TODO should we add a listener, if called if something wrong happened when we handle SendRequest ?
+    void onError(Registration registration, InvalidRequestException e);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
@@ -38,6 +38,6 @@ public interface SendListener {
      */
     void dataReceived(Registration registration, Map<String, LwM2mNode> data, SendRequest request);
 
-    // TODO should we add a listener, if called if something wrong happened when we handle SendRequest ?
+
     void onError(Registration registration, InvalidRequestException e);
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/send/SendListener.java
@@ -39,5 +39,12 @@ public interface SendListener {
     void dataReceived(Registration registration, Map<String, LwM2mNode> data, SendRequest request);
 
 
-    void onError(Registration registration, InvalidRequestException e);
+    /**
+     *  Called for any error e.g. if something wrong happened when we handle SendRequest,
+     *  data can't be decoded by server etc.
+     *
+     * @param registration Registration of the client which send the data.
+     * @param e exception
+     */
+    void onError(Registration registration, Exception e);
 }

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
@@ -35,6 +35,7 @@ import org.eclipse.leshan.core.observation.CompositeObservation;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.observation.SingleObservation;
 import org.eclipse.leshan.core.request.SendRequest;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.ObserveCompositeResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.server.californium.LeshanServer;
@@ -246,6 +247,11 @@ public class EventServlet extends EventSourceServlet {
                     Log.warn(String.format("Error while processing json [%s] : [%s]", data.toString(), e.getMessage()));
                 }
             }
+        }
+
+        @Override
+        public void onError(Registration registration, InvalidRequestException e) {
+
         }
     };
 

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
@@ -250,7 +250,7 @@ public class EventServlet extends EventSourceServlet {
         }
 
         @Override
-        public void onError(Registration registration, InvalidRequestException e) {
+        public void onError(Registration registration, Exception e) {
 
         }
     };


### PR DESCRIPTION
We noticed the problem in Leshan with the data received by the server using send data. For instance if the declared model is a Boolean and the data sent is “42”. Currently, it leads to a log error and a stack trace (lwm2m o.e.l.core.californium.LwM2mCoapResource : CodecException: Invalid content X for type X for path X).
We suggest that in this case the server should respond with 400 Bad request instead of 500 server error.