### PR TITLE
Add MdcConnectionListener to all Demo.

### DIFF
--- a/leshan-bsserver-demo/logback-config.xml
+++ b/leshan-bsserver-demo/logback-config.xml
@@ -18,7 +18,7 @@ Contributors:
 	<appender name="TERMINAL" class="org.eclipse.leshan.core.demo.cli.interactive.TerminalAppender">
 		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
 			<layout class="org.eclipse.leshan.core.demo.logback.ColorAwarePatternLayout">
-				<pattern>%gray(%d) %gray(%-25logger{0}) [%highlight(%p)] %m%n</pattern>
+				<pattern>%gray(%d) %gray(%-25logger{0}) [%highlight(%p)] %m %yellow(%X) %n</pattern>
 			</layout>
 		</encoder>
 	</appender>

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
@@ -31,6 +31,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.leshan.core.californium.PrincipalMdcConnectionListener;
 import org.eclipse.leshan.core.demo.cli.ShortErrorMessageHandler;
 import org.eclipse.leshan.core.model.ObjectLoader;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -138,6 +139,10 @@ public class LeshanBootstrapServerDemo {
         dtlsConfig.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, !cli.dtls.supportDeprecatedCiphers);
         if (cli.dtls.cid != null) {
             dtlsConfig.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, cli.dtls.cid);
+        }
+        // Add MDC for connection logs
+        if (cli.helpsOptions.getVerboseLevel() > 0) {
+            dtlsConfig.setConnectionListener(new PrincipalMdcConnectionListener());
         }
 
         if (cli.identity.isx509()) {

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/cli/LeshanBsServerDemoCLI.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/cli/LeshanBsServerDemoCLI.java
@@ -45,7 +45,7 @@ import picocli.CommandLine.Spec;
 public class LeshanBsServerDemoCLI implements Runnable {
 
     @Mixin
-    private StandardHelpOptions helpsOptions;
+    public StandardHelpOptions helpsOptions;
 
     /* ********************************** General Section ******************************** */
     @ArgGroup(validate = false, heading = "%n")

--- a/leshan-client-demo/logback-config.xml
+++ b/leshan-client-demo/logback-config.xml
@@ -18,7 +18,7 @@ Contributors:
 	<appender name="TERMINAL" class="org.eclipse.leshan.core.demo.cli.interactive.TerminalAppender">
 		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
 			<layout class="org.eclipse.leshan.core.demo.logback.ColorAwarePatternLayout">
-				<pattern>%gray(%30.30logger{0}) %gray(%d) [%highlight(%p)] %m%n</pattern>
+				<pattern>%gray(%30.30logger{0}) %gray(%d) [%highlight(%p)] %m %yellow(%mdc) %n</pattern>
 			</layout>
 		</encoder>
 	</appender>

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -59,6 +59,7 @@ import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;
 import org.eclipse.leshan.client.send.ManualDataSender;
+import org.eclipse.leshan.core.californium.PrincipalMdcConnectionListener;
 import org.eclipse.leshan.core.demo.LwM2mDemoConstant;
 import org.eclipse.leshan.core.demo.cli.ShortErrorMessageHandler;
 import org.eclipse.leshan.core.demo.cli.interactive.InteractiveCLI;
@@ -255,6 +256,11 @@ public class LeshanClientDemo {
         engineFactory.setReconnectOnUpdate(cli.dtls.reconnectOnUpdate);
         engineFactory.setResumeOnConnect(!cli.dtls.forceFullhandshake);
         engineFactory.setQueueMode(cli.main.queueMode);
+
+        // Add MDC for connection logs
+        if (cli.helpsOptions.getVerboseLevel() > 0) {
+            dtlsConfig.setConnectionListener(new PrincipalMdcConnectionListener());
+        }
 
         // Log Session lifecycle
         dtlsConfig.setSessionListener(new SessionAdapter() {

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
@@ -68,7 +68,7 @@ public class LeshanClientDemoCLI implements Runnable {
     }
 
     @Mixin
-    private StandardHelpOptions helpsOptions;
+    public StandardHelpOptions helpsOptions;
 
     /* ********************************** General Section ******************************** */
     @ArgGroup(validate = false, heading = "%n")

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/PrincipalMdcConnectionListener.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/PrincipalMdcConnectionListener.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.californium;
+
+import java.security.Principal;
+
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.MdcConnectionListener;
+import org.eclipse.californium.scandium.dtls.Connection;
+import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.slf4j.MDC;
+
+/**
+ * An {@link MdcConnectionListener} which also display {@link Principal}
+ */
+public class PrincipalMdcConnectionListener extends MdcConnectionListener {
+    @Override
+    public void beforeExecution(Connection connection) {
+        if (DTLSConnector.MDC_SUPPORT) {
+            DTLSSession session = connection.getSession();
+            if (session != null) {
+                Principal pincipal = session.getPeerIdentity();
+                if (pincipal != null) {
+                    MDC.put("PRINCIPAL", pincipal.toString());
+                }
+            }
+        }
+        super.beforeExecution(connection);
+    }
+}

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/StandardHelpOptions.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/StandardHelpOptions.java
@@ -33,6 +33,8 @@ public class StandardHelpOptions {
     @Option(names = { "-V", "--version" }, description = "Print version information and exit.", versionHelp = true)
     private boolean versionRequested;
 
+    private int verboseLevel = 0;
+
     @Option(names = { "-v", "--verbose" },
             description = { "Specify multiple -v options to increase verbosity.", //
                     "For example, `-v -v -v` or `-vvv`", //
@@ -41,6 +43,8 @@ public class StandardHelpOptions {
                             " see 'How to activate more log ?' in FAQ:", //
                     "  https://github.com/eclipse/leshan/wiki/F.A.Q./" })
     public void setVerbose(boolean[] verbose) {
+        verboseLevel = verbose.length;
+
         // set CLI verbosity. (See ShortErrorMessageHandler)
         if (verbose.length > 0) {
             System.setProperty("leshan.cli", "DEBUG");
@@ -75,5 +79,9 @@ public class StandardHelpOptions {
         Logger logger = loggerContext.getLogger(loggerName);
         if (logger != null)
             logger.setLevel(level);
+    }
+
+    public int getVerboseLevel() {
+        return verboseLevel;
     }
 }

--- a/leshan-server-demo/logback-config.xml
+++ b/leshan-server-demo/logback-config.xml
@@ -18,7 +18,7 @@ Contributors:
 	<appender name="TERMINAL" class="org.eclipse.leshan.core.demo.cli.interactive.TerminalAppender">
 		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
 			<layout class="org.eclipse.leshan.core.demo.logback.ColorAwarePatternLayout">
-				<pattern>%gray(%d) %gray(%-20logger{0}) [%highlight(%p)] %m%n</pattern>
+				<pattern>%gray(%d) %gray(%-20logger{0}) [%highlight(%p)] %m %yellow(%X) %n</pattern>
 			</layout>
 		</encoder>
 	</appender>

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -37,6 +37,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.leshan.core.californium.PrincipalMdcConnectionListener;
 import org.eclipse.leshan.core.demo.LwM2mDemoConstant;
 import org.eclipse.leshan.core.demo.cli.ShortErrorMessageHandler;
 import org.eclipse.leshan.core.model.ObjectLoader;
@@ -162,6 +163,9 @@ public class LeshanServerDemo {
         if (cli.dtls.cid != null) {
             dtlsConfig.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, cli.dtls.cid);
         }
+        // Add MDC for connection logs
+        if (cli.helpsOptions.getVerboseLevel() > 0)
+            dtlsConfig.setConnectionListener(new PrincipalMdcConnectionListener());
 
         if (cli.identity.isx509()) {
             // use X.509 mode (+ RPK)

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/cli/LeshanServerDemoCLI.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/cli/LeshanServerDemoCLI.java
@@ -48,7 +48,7 @@ import redis.clients.jedis.JedisPool;
 public class LeshanServerDemoCLI implements Runnable {
 
     @Mixin
-    private StandardHelpOptions helpsOptions;
+    public StandardHelpOptions helpsOptions;
 
     /* ********************************** General Section ******************************** */
     @ArgGroup(validate = false, heading = "%n")


### PR DESCRIPTION
Scandium MdcConnectionListener add some connection/identity information to log relative to DTLS. 

e.g : PEER=127.0.0.1:42748, PRINCIPAL=PreSharedKey Identity [identity: myPskId], CONNECTION_ID=A52B3AE6554B, SESSION_ID=A13DCB6A466C587010DC4CBC5AA07F2D6DE8D5A4B8B830682929ED45C4B0FC11 
