### PR TITLE
Replace usage of OSCoreCtx(from cf) by OscoreSeting in SecurityInfo

### DIFF
--- a/leshan-client-cf/pom.xml
+++ b/leshan-client-cf/pom.xml
@@ -46,6 +46,11 @@ Contributors:
             <groupId>org.eclipse.californium</groupId>
             <artifactId>scandium</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.californium</groupId>
+            <artifactId>cf-oscore</artifactId>
+            <version>${californium.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClient.java
@@ -295,6 +295,8 @@ public class LeshanClient implements LwM2mClient {
         requestSender.destroy();
         objectTree.destroy();
 
+        OscoreClientHandler.purge();
+
         LOG.info("Leshan client destroyed.");
     }
 

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreClientHandler.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/OscoreClientHandler.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.client.californium;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+//TODO OSCORE : remove this class and static access.
+public class OscoreClientHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+
+    public static void purge() {
+        db = null;
+    }
+}

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/request/CaliforniumLwM2mRequestSender.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/request/CaliforniumLwM2mRequestSender.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Zebra Technologies - initial API and implementation
  *     Michał Wadowski (Orange) - Improved compliance with rfc6690
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.client.californium.request;
 
@@ -23,7 +24,11 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.client.californium.CaliforniumEndpointsManager;
+import org.eclipse.leshan.client.californium.OscoreClientHandler;
 import org.eclipse.leshan.client.request.LwM2mRequestSender;
 import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.californium.AsyncRequestObserver;
@@ -78,6 +83,18 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
         request.accept(coapClientRequestBuilder);
         Request coapRequest = coapClientRequestBuilder.getRequest();
 
+        // TODO OSCORE : this should be added in CoapRequestBuilder
+        // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
+        HashMapCtxDB db = OscoreClientHandler.getContextDB();
+        try {
+            if (db.getContext(coapRequest.getURI()) != null) {
+                coapRequest.getOptions().setOscore(Bytes.EMPTY);
+            }
+        } catch (OSException e) {
+            System.err.println("Failed to retrieve OSCORE Context for request");
+            e.printStackTrace();
+        }
+
         // Send CoAP request synchronously
         SyncRequestObserver<T> syncMessageObserver = new SyncRequestObserver<T>(coapRequest, timeout) {
             @Override
@@ -105,6 +122,18 @@ public class CaliforniumLwM2mRequestSender implements LwM2mRequestSender {
                 linkSerializer);
         request.accept(coapClientRequestBuilder);
         Request coapRequest = coapClientRequestBuilder.getRequest();
+
+        // TODO OSCORE : this should be added in CoapRequestBuilder
+        // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
+        HashMapCtxDB db = OscoreClientHandler.getContextDB();
+        try {
+            if (db.getContext(coapRequest.getURI()) != null) {
+                coapRequest.getOptions().setOscore(Bytes.EMPTY);
+            }
+        } catch (OSException e) {
+            System.err.println("Failed to retrieve OSCORE Context for request");
+            e.printStackTrace();
+        }
 
         // Add CoAP request callback
         MessageObserver obs = new AsyncRequestObserver<T>(coapRequest, responseCallback, errorCallback, timeout,

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *
+ *******************************************************************************/
+package org.eclipse.leshan.client.object;
+
+import static org.eclipse.leshan.core.LwM2mId.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
+import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
+import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.response.ReadResponse;
+import org.eclipse.leshan.core.response.WriteResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple {@link LwM2mInstanceEnabler} for the OSCORE Security (21) object.
+ */
+public class Oscore extends BaseInstanceEnabler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Security.class);
+
+    private final static List<Integer> supportedResources = Arrays.asList(OSCORE_Master_Secret, OSCORE_Sender_ID,
+            OSCORE_Recipient_ID, OSCORE_AEAD_Algorithm, OSCORE_HMAC_Algorithm, OSCORE_Master_Salt);
+
+    private String masterSecret;
+    private String senderId;
+    private String recipientId;
+    private int aeadAlgorithm;
+    private int hkdfAlgorithm;
+    private String masterSalt;
+
+    public Oscore() {
+
+    }
+
+    /**
+     * Default constructor.
+     */
+    public Oscore(int instanceId, String masterSecret, String senderId, String recipientId, int aeadAlgorithm,
+            int hkdfAlgorithm, String masterSalt) {
+        super(instanceId);
+        this.masterSecret = masterSecret;
+        this.senderId = senderId;
+        this.recipientId = recipientId;
+        this.aeadAlgorithm = aeadAlgorithm;
+        this.hkdfAlgorithm = hkdfAlgorithm;
+        this.masterSalt = masterSalt;
+    }
+
+    /**
+     * Constructor providing some default values.
+     *
+     * aeadAlgorithm = 10; //AES_CCM_16_64_128m hmacAlgorithm = -10; //HKDF_HMAC_SHA_256, masterSalt = "";
+     *
+     */
+    public Oscore(int instanceId, String masterSecret, String senderId, String recipientId) {
+        this(instanceId, masterSecret, senderId, recipientId, 10, -10, "");
+    }
+
+    @Override
+    public WriteResponse write(ServerIdentity identity, boolean replace, int resourceId, LwM2mResource value) {
+        LOG.debug("Write on resource {}: {}", resourceId, value);
+
+        // restricted to BS server?
+
+        switch (resourceId) {
+
+        case OSCORE_Master_Secret:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            masterSecret = (String) value.getValue();
+            return WriteResponse.success();
+
+        case OSCORE_Sender_ID:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            senderId = (String) value.getValue();
+            return WriteResponse.success();
+
+        case OSCORE_Recipient_ID:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            recipientId = (String) value.getValue();
+            return WriteResponse.success();
+
+        case OSCORE_AEAD_Algorithm:
+            if (value.getType() != Type.INTEGER) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            aeadAlgorithm = ((Long) value.getValue()).intValue();
+            return WriteResponse.success();
+
+        case OSCORE_HMAC_Algorithm:
+            if (value.getType() != Type.INTEGER) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            hkdfAlgorithm = ((Long) value.getValue()).intValue();
+            return WriteResponse.success();
+
+        case OSCORE_Master_Salt:
+            if (value.getType() != Type.STRING) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            masterSalt = (String) value.getValue();
+            return WriteResponse.success();
+
+        default:
+            return super.write(identity, replace, resourceId, value);
+        }
+
+    }
+
+    @Override
+    public ReadResponse read(ServerIdentity identity, int resourceid) {
+        LOG.debug("Read on resource {}", resourceid);
+        // only accessible for internal read?
+
+        switch (resourceid) {
+
+        case OSCORE_Master_Secret:
+            return ReadResponse.success(resourceid, masterSecret);
+
+        case OSCORE_Sender_ID:
+            return ReadResponse.success(resourceid, senderId);
+
+        case OSCORE_Recipient_ID:
+            return ReadResponse.success(resourceid, recipientId);
+
+        case OSCORE_AEAD_Algorithm:
+            return ReadResponse.success(resourceid, aeadAlgorithm);
+
+        case OSCORE_HMAC_Algorithm:
+            return ReadResponse.success(resourceid, hkdfAlgorithm);
+
+        case OSCORE_Master_Salt:
+            return ReadResponse.success(resourceid, masterSalt);
+
+        default:
+            return super.read(identity, resourceid);
+        }
+    }
+
+    @Override
+    public List<Integer> getAvailableResourceIds(ObjectModel model) {
+        return supportedResources;
+    }
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Security.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.client.object;
 
@@ -29,6 +30,7 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.request.argument.Arguments;
+import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
@@ -45,7 +47,7 @@ public class Security extends BaseInstanceEnabler {
 
     private final static List<Integer> supportedResources = Arrays.asList(SEC_SERVER_URI, SEC_BOOTSTRAP,
             SEC_SECURITY_MODE, SEC_PUBKEY_IDENTITY, SEC_SERVER_PUBKEY, SEC_SECRET_KEY, SEC_SERVER_ID,
-            SEC_CERTIFICATE_USAGE);
+            SEC_CERTIFICATE_USAGE, SEC_OSCORE_SECURITY_MODE);
 
     private String serverUri; /* coaps://host:port */
     private boolean bootstrapServer;
@@ -56,6 +58,7 @@ public class Security extends BaseInstanceEnabler {
     private byte[] secretKey;
 
     private Integer shortServerId;
+    private ObjectLink oscoreSecurityMode;
 
     private ULong certificateUsage;
 
@@ -65,7 +68,8 @@ public class Security extends BaseInstanceEnabler {
     }
 
     public Security(String serverUri, boolean bootstrapServer, int securityMode, byte[] publicKeyOrIdentity,
-            byte[] serverPublicKey, byte[] secretKey, Integer shortServerId, ULong certificateUsage) {
+            byte[] serverPublicKey, byte[] secretKey, Integer shortServerId, ULong certificateUsage,
+            ObjectLink oscoreSecurityMode) {
         this.serverUri = serverUri;
         this.bootstrapServer = bootstrapServer;
         this.securityMode = securityMode;
@@ -74,6 +78,16 @@ public class Security extends BaseInstanceEnabler {
         this.secretKey = secretKey;
         this.shortServerId = shortServerId;
         this.certificateUsage = certificateUsage;
+        this.oscoreSecurityMode = oscoreSecurityMode;
+    }
+
+    /**
+     * Returns a new security instance (OSCORE only) for a bootstrap server.
+     */
+    public static Security oscoreOnlyBootstrap(String serverUri, Integer shortServerId, int oscoreObjectInstanceId) {
+        return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0],
+                shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code,
+                new ObjectLink(OSCORE, oscoreObjectInstanceId));
     }
 
     /**
@@ -81,7 +95,7 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security noSecBootstap(String serverUri) {
         return new Security(serverUri, true, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0], null,
-                CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code, new ObjectLink());
     }
 
     /**
@@ -89,7 +103,7 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security pskBootstrap(String serverUri, byte[] pskIdentity, byte[] privateKey) {
         return new Security(serverUri, true, SecurityMode.PSK.code, pskIdentity.clone(), new byte[0],
-                privateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                privateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code, new ObjectLink());
     }
 
     /**
@@ -98,7 +112,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security rpkBootstrap(String serverUri, byte[] clientPublicKey, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, true, SecurityMode.RPK.code, clientPublicKey.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                clientPrivateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code, new ObjectLink());
     }
 
     /**
@@ -107,7 +121,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security x509Bootstrap(String serverUri, byte[] clientCertificate, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, true, SecurityMode.X509.code, clientCertificate.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                clientPrivateKey.clone(), null, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code, new ObjectLink());
     }
 
     /**
@@ -116,7 +130,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security x509Bootstrap(String serverUri, byte[] clientCertificate, byte[] clientPrivateKey,
             byte[] serverPublicKey, ULong certificateUsage) {
         return new Security(serverUri, true, SecurityMode.X509.code, clientCertificate.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), null, certificateUsage);
+                clientPrivateKey.clone(), null, certificateUsage, new ObjectLink());
     }
 
     /**
@@ -124,7 +138,16 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security noSec(String serverUri, int shortServerId) {
         return new Security(serverUri, false, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0],
-                shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code, new ObjectLink());
+    }
+
+    /**
+     * Returns a new security instance (OSCORE only) for a device management server.
+     */
+    public static Security oscoreOnly(String serverUri, int shortServerId, int oscoreObjectInstanceId) {
+        return new Security(serverUri, false, SecurityMode.NO_SEC.code, new byte[0], new byte[0], new byte[0],
+                shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code,
+                new ObjectLink(OSCORE, oscoreObjectInstanceId));
     }
 
     /**
@@ -132,7 +155,7 @@ public class Security extends BaseInstanceEnabler {
      */
     public static Security psk(String serverUri, int shortServerId, byte[] pskIdentity, byte[] privateKey) {
         return new Security(serverUri, false, SecurityMode.PSK.code, pskIdentity.clone(), new byte[0],
-                privateKey.clone(), shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                privateKey.clone(), shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code, new ObjectLink());
     }
 
     /**
@@ -141,7 +164,8 @@ public class Security extends BaseInstanceEnabler {
     public static Security rpk(String serverUri, int shortServerId, byte[] clientPublicKey, byte[] clientPrivateKey,
             byte[] serverPublicKey) {
         return new Security(serverUri, false, SecurityMode.RPK.code, clientPublicKey.clone(), serverPublicKey.clone(),
-                clientPrivateKey.clone(), shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                clientPrivateKey.clone(), shortServerId, CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code,
+                new ObjectLink());
     }
 
     /**
@@ -151,7 +175,7 @@ public class Security extends BaseInstanceEnabler {
             byte[] serverPublicKey) {
         return new Security(serverUri, false, SecurityMode.X509.code, clientCertificate.clone(),
                 serverPublicKey.clone(), clientPrivateKey.clone(), shortServerId,
-                CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code);
+                CertificateUsage.DOMAIN_ISSUER_CERTIFICATE.code, new ObjectLink());
     }
 
     /**
@@ -160,7 +184,7 @@ public class Security extends BaseInstanceEnabler {
     public static Security x509(String serverUri, int shortServerId, byte[] clientCertificate, byte[] clientPrivateKey,
             byte[] serverPublicKey, ULong certificateUsage) {
         return new Security(serverUri, false, SecurityMode.X509.code, clientCertificate.clone(),
-                serverPublicKey.clone(), clientPrivateKey.clone(), shortServerId, certificateUsage);
+                serverPublicKey.clone(), clientPrivateKey.clone(), shortServerId, certificateUsage, new ObjectLink());
     }
 
     @Override
@@ -221,6 +245,13 @@ public class Security extends BaseInstanceEnabler {
             certificateUsage = (ULong) value.getValue();
             return WriteResponse.success();
 
+        case SEC_OSCORE_SECURITY_MODE: // oscore security mode
+            if (value.getType() != Type.OBJLNK) {
+                return WriteResponse.badRequest("invalid type");
+            }
+            oscoreSecurityMode = (ObjectLink) value.getValue();
+            return WriteResponse.success();
+
         default:
             return super.write(identity, replace, resourceId, value);
         }
@@ -257,6 +288,9 @@ public class Security extends BaseInstanceEnabler {
                 return ReadResponse.notFound();
         case SEC_CERTIFICATE_USAGE: // certificate usage
             return ReadResponse.success(resourceid, certificateUsage);
+
+        case SEC_OSCORE_SECURITY_MODE: // oscore security mode
+            return ReadResponse.success(resourceid, oscoreSecurityMode == null ? new ObjectLink() : oscoreSecurityMode);
 
         default:
             return super.read(identity, resourceid);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServerInfo.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
@@ -53,6 +54,15 @@ public class ServerInfo {
     public Certificate serverCertificate;
 
     public PrivateKey privateKey;
+
+    // OSCORE parameters
+    public boolean useOscore;
+    public byte[] masterSecret;
+    public byte[] senderId;
+    public byte[] recipientId;
+    public long aeadAlgorithm;
+    public long hkdfAlgorithm;
+    public byte[] masterSalt;
 
     public InetSocketAddress getAddress() {
         return getAddress(serverUri);

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/util/LinkFormatHelperTest.java
@@ -304,6 +304,7 @@ public class LinkFormatHelperTest {
         Link[] links = LinkFormatHelper.getBootstrapClientDescription(objectEnablers);
         String strLinks = serializer.serialize(links);
 
+        // TODO : handle version correctly
         assertEquals("</>;lwm2m=1.0,</0/0>;ssid=111;uri=\"coap://localhost:11\"," //
                 + "</0/1>;uri=\"coap://localhost:1\"," //
                 + "</0/2>;ssid=222;uri=\"coap://localhost:22\"," //

--- a/leshan-core-cf/pom.xml
+++ b/leshan-core-cf/pom.xml
@@ -13,6 +13,7 @@ and the Eclipse Distribution License is available at
 
 Contributors:
     Sierra Wireless - initial API and implementation
+    Rikard Höglund (RISE SICS) - Additions to support OSCORE
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -39,6 +40,11 @@ Contributors:
         <dependency>
             <groupId>org.eclipse.californium</groupId>
             <artifactId>scandium</artifactId>
+        </dependency>
+        <dependency>
+                <groupId>org.eclipse.californium</groupId>
+                <artifactId>cf-oscore</artifactId>
+                <version>${californium.version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/DefaultEndpointFactory.java
@@ -26,7 +26,9 @@ import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
 import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.oscore.OSCoreCoapStackFactory;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 
@@ -101,8 +103,13 @@ public class DefaultEndpointFactory implements EndpointFactory {
 
     @Override
     public CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, Configuration coapConfig,
-            ObservationStore store) {
-        return createUnsecuredEndpointBuilder(address, coapConfig, store).build();
+            ObservationStore store, HashMapCtxDB db) {
+        // TODO OSCORE : db should maybe be replaced by OscoreEStore
+        Builder builder = createUnsecuredEndpointBuilder(address, coapConfig, store);
+        if (db != null) {
+            builder.setCustomCoapStackArgument(db).setCoapStackFactory(new OSCoreCoapStackFactory());
+        }
+        return builder.build();
     }
 
     /**
@@ -149,7 +156,8 @@ public class DefaultEndpointFactory implements EndpointFactory {
 
     @Override
     public CoapEndpoint createSecuredEndpoint(DtlsConnectorConfig dtlsConfig, Configuration coapConfig,
-            ObservationStore store) {
+            ObservationStore store, HashMapCtxDB db) {
+        // TODO OSCORE : db should maybe be replaced by OscoreEStore
         return createSecuredEndpointBuilder(dtlsConfig, coapConfig, store).build();
     }
 

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointContextUtil.java
@@ -14,6 +14,7 @@
  *     Sierra Wireless - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - add support for californium
  *                                                     endpoint context
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.core.californium;
 
@@ -33,6 +34,7 @@ import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
 import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
+import org.eclipse.californium.oscore.OSCoreEndpointContextInfo;
 import org.eclipse.leshan.core.request.Identity;
 
 /**
@@ -66,12 +68,22 @@ public class EndpointContextUtil {
             throw new IllegalStateException(
                     String.format("Unable to extract sender identity : unexpected type of Principal %s [%s]",
                             senderIdentity.getClass(), senderIdentity.toString()));
+        } else {
+            // Build identity for OSCORE if it is used
+            if (context.get(OSCoreEndpointContextInfo.OSCORE_SENDER_ID) != null) {
+                String oscoreIdentity = "sid=" + context.get(OSCoreEndpointContextInfo.OSCORE_SENDER_ID) + ",rid="
+                        + context.get(OSCoreEndpointContextInfo.OSCORE_RECIPIENT_ID);
+                return Identity.oscoreOnly(peerAddress, oscoreIdentity.toLowerCase());
+            }
         }
         return Identity.unsecure(peerAddress);
     }
 
     /**
      * Create Californium {@link EndpointContext} from Leshan {@link Identity}.
+     * <p>
+     * OSCORE does not use a Principal but automatically sets properties in the endpoint context at message
+     * transmission/reception.
      * 
      * @param identity The Leshan {@link Identity} to convert.
      * @param allowConnectionInitiation This request can initiate a Handshake if there is no DTLS connection.
@@ -90,6 +102,8 @@ public class EndpointContextUtil {
                 peerIdentity = new X500Principal("CN=" + identity.getX509CommonName());
             }
         }
+
+        // TODO OSCORE : should we add properties to endpoint context ?
 
         if (peerIdentity != null && allowConnectionInitiation) {
             return new MapBasedEndpointContext(identity.getPeerAddress(), peerIdentity, new Attributes()

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointFactory.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/EndpointFactory.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.core.californium;
 
@@ -20,6 +21,7 @@ import java.net.InetSocketAddress;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.observe.ObservationStore;
 import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 
 /**
@@ -29,8 +31,9 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
  */
 public interface EndpointFactory {
 
-    CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, Configuration coapConfig, ObservationStore store);
+    CoapEndpoint createUnsecuredEndpoint(InetSocketAddress address, Configuration coapConfig, ObservationStore store,
+            HashMapCtxDB db);
 
-    CoapEndpoint createSecuredEndpoint(DtlsConnectorConfig dtlsConfig, Configuration coapConfig,
-            ObservationStore store);
+    CoapEndpoint createSecuredEndpoint(DtlsConnectorConfig dtlsConfig, Configuration coapConfig, ObservationStore store,
+            HashMapCtxDB db);
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2mId.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2mId.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.core;
 
@@ -43,6 +44,16 @@ public interface LwM2mId {
     public static final int SEC_SECRET_KEY = 5;
     public static final int SEC_SERVER_ID = 10;
     public static final int SEC_CERTIFICATE_USAGE = 15;
+    public static final int SEC_OSCORE_SECURITY_MODE = 17;
+
+    /* OSCORE RESOURCES */
+
+    public static final int OSCORE_Master_Secret = 0;
+    public static final int OSCORE_Sender_ID = 1;
+    public static final int OSCORE_Recipient_ID = 2;
+    public static final int OSCORE_AEAD_Algorithm = 3;
+    public static final int OSCORE_HMAC_Algorithm = 4;
+    public static final int OSCORE_Master_Salt = 5;
 
     /* SERVER RESOURCES */
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/Identity.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - add protected constructor for sub-classing
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
@@ -32,13 +33,16 @@ public class Identity {
     private final String pskIdentity;
     private final PublicKey rawPublicKey;
     private final String x509CommonName;
+    private final String oscoreIdentity;
 
-    private Identity(InetSocketAddress peerAddress, String pskIdentity, PublicKey rawPublicKey, String x509CommonName) {
+    private Identity(InetSocketAddress peerAddress, String pskIdentity, PublicKey rawPublicKey, String x509CommonName,
+            String oscoreIdentity) {
         Validate.notNull(peerAddress);
         this.peerAddress = peerAddress;
         this.pskIdentity = pskIdentity;
         this.rawPublicKey = rawPublicKey;
         this.x509CommonName = x509CommonName;
+        this.oscoreIdentity = oscoreIdentity;
     }
 
     protected Identity(Identity identity) {
@@ -46,6 +50,7 @@ public class Identity {
         this.pskIdentity = identity.pskIdentity;
         this.rawPublicKey = identity.rawPublicKey;
         this.x509CommonName = identity.x509CommonName;
+        this.oscoreIdentity = identity.oscoreIdentity;
     }
 
     public InetSocketAddress getPeerAddress() {
@@ -64,6 +69,10 @@ public class Identity {
         return x509CommonName;
     }
 
+    public String getOscoreIdentity() {
+        return oscoreIdentity;
+    }
+
     public boolean isPSK() {
         return pskIdentity != null && !pskIdentity.isEmpty();
     }
@@ -76,40 +85,52 @@ public class Identity {
         return x509CommonName != null && !x509CommonName.isEmpty();
     }
 
+    public boolean isOSCORE() {
+        return oscoreIdentity != null && !oscoreIdentity.isEmpty();
+    }
+
     public boolean isSecure() {
         return isPSK() || isRPK() || isX509();
     }
 
     public static Identity unsecure(InetSocketAddress peerAddress) {
-        return new Identity(peerAddress, null, null, null);
+        return new Identity(peerAddress, null, null, null, null);
     }
 
     public static Identity unsecure(InetAddress address, int port) {
-        return new Identity(new InetSocketAddress(address, port), null, null, null);
+        return new Identity(new InetSocketAddress(address, port), null, null, null, null);
     }
 
     public static Identity psk(InetSocketAddress peerAddress, String identity) {
-        return new Identity(peerAddress, identity, null, null);
+        return new Identity(peerAddress, identity, null, null, null);
     }
 
     public static Identity psk(InetAddress address, int port, String identity) {
-        return new Identity(new InetSocketAddress(address, port), identity, null, null);
+        return new Identity(new InetSocketAddress(address, port), identity, null, null, null);
     }
 
     public static Identity rpk(InetSocketAddress peerAddress, PublicKey publicKey) {
-        return new Identity(peerAddress, null, publicKey, null);
+        return new Identity(peerAddress, null, publicKey, null, null);
     }
 
     public static Identity rpk(InetAddress address, int port, PublicKey publicKey) {
-        return new Identity(new InetSocketAddress(address, port), null, publicKey, null);
+        return new Identity(new InetSocketAddress(address, port), null, publicKey, null, null);
     }
 
     public static Identity x509(InetSocketAddress peerAddress, String commonName) {
-        return new Identity(peerAddress, null, null, commonName);
+        return new Identity(peerAddress, null, null, commonName, null);
     }
 
     public static Identity x509(InetAddress address, int port, String commonName) {
-        return new Identity(new InetSocketAddress(address, port), null, null, commonName);
+        return new Identity(new InetSocketAddress(address, port), null, null, commonName, null);
+    }
+
+    public static Identity oscoreOnly(InetSocketAddress peerAddress, String oscoreIdentity) {
+        return new Identity(peerAddress, null, null, null, oscoreIdentity);
+    }
+
+    public static Identity oscoreOnly(InetAddress address, int port, String oscoreIdentity) {
+        return new Identity(new InetSocketAddress(address, port), null, null, null, oscoreIdentity);
     }
 
     @Override
@@ -120,6 +141,8 @@ public class Identity {
             return String.format("Identity %s[rpk=%s]", peerAddress, rawPublicKey);
         else if (x509CommonName != null)
             return String.format("Identity %s[x509=%s]", peerAddress, x509CommonName);
+        else if (oscoreIdentity != null)
+            return String.format("Identity %s[oscore=%s]", peerAddress, oscoreIdentity);
         else
             return String.format("Identity %s[unsecure]", peerAddress);
     }
@@ -132,6 +155,7 @@ public class Identity {
         result = prime * result + ((pskIdentity == null) ? 0 : pskIdentity.hashCode());
         result = prime * result + ((rawPublicKey == null) ? 0 : rawPublicKey.hashCode());
         result = prime * result + ((x509CommonName == null) ? 0 : x509CommonName.hashCode());
+        result = prime * result + ((oscoreIdentity == null) ? 0 : oscoreIdentity.hashCode());
         return result;
     }
 
@@ -163,6 +187,11 @@ public class Identity {
             if (other.x509CommonName != null)
                 return false;
         } else if (!x509CommonName.equals(other.x509CommonName))
+            return false;
+        if (oscoreIdentity == null) {
+            if (other.oscoreIdentity != null)
+                return false;
+        } else if (!oscoreIdentity.equals(other.oscoreIdentity))
             return false;
         return true;
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.resource.SimpleInstanceEnabler;
@@ -53,6 +54,7 @@ import org.eclipse.leshan.server.security.NonUniqueSecurityInfoException;
 import org.eclipse.leshan.server.security.SecurityInfo;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class BootstrapTest {
@@ -231,7 +233,7 @@ public class BootstrapTest {
         BootstrapDiscoverResponse lastDiscoverAnswer = (BootstrapDiscoverResponse) helper.lastCustomResponse;
         assertEquals(ResponseCode.CONTENT, lastDiscoverAnswer.getCode());
         assertEquals(
-                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>",
+                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>,</21>",
                         helper.bootstrapServer.getUnsecuredAddress().getHostString(),
                         helper.bootstrapServer.getUnsecuredAddress().getPort()),
                 linkSerializer.serialize(lastDiscoverAnswer.getObjectLinks()));
@@ -262,7 +264,7 @@ public class BootstrapTest {
         BootstrapDiscoverResponse lastDiscoverAnswer = (BootstrapDiscoverResponse) helper.lastCustomResponse;
         assertEquals(ResponseCode.CONTENT, lastDiscoverAnswer.getCode());
         assertEquals(
-                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>",
+                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>,</21>",
                         helper.bootstrapServer.getUnsecuredAddress().getHostString(),
                         helper.bootstrapServer.getUnsecuredAddress().getPort()),
                 linkSerializer.serialize(lastDiscoverAnswer.getObjectLinks()));
@@ -285,7 +287,7 @@ public class BootstrapTest {
         lastDiscoverAnswer = (BootstrapDiscoverResponse) helper.lastCustomResponse;
         assertEquals(ResponseCode.CONTENT, lastDiscoverAnswer.getCode());
         assertEquals(String.format(
-                "</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</0/1>;ssid=2222;uri=\"coap://%s:%d\",</1>;ver=1.1,</1/0>;ssid=2222,</3>;ver=1.1,</3/0>",
+                "</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</0/1>;ssid=2222;uri=\"coap://%s:%d\",</1>;ver=1.1,</1/0>;ssid=2222,</3>;ver=1.1,</3/0>,</21>",
                 helper.bootstrapServer.getUnsecuredAddress().getHostString(),
                 helper.bootstrapServer.getUnsecuredAddress().getPort(),
                 helper.server.getUnsecuredAddress().getHostString(), helper.server.getUnsecuredAddress().getPort()),
@@ -649,6 +651,74 @@ public class BootstrapTest {
         helper.waitForRegistrationAtServerSide(1);
 
         // check the client is registered
+        helper.assertClientRegisterered();
+    }
+
+    @Test
+    public void bootstrapUnsecuredToServerWithOscore() throws NonUniqueSecurityInfoException {
+        helper.createServer();
+        helper.server.start();
+
+        helper.createBootstrapServer(null, helper.unsecuredBootstrapStoreWithOscoreServer());
+        helper.bootstrapServer.start();
+
+        // Check client is not registered
+        helper.createClient();
+        helper.assertClientNotRegisterered();
+
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+
+        // Start it and wait for registration
+        helper.client.start();
+
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
+        helper.assertClientRegisterered();
+    }
+
+    @Test
+    public void bootstrapViaOscoreToServerWithOscore() throws NonUniqueSecurityInfoException {
+        helper.createServer();
+        helper.server.start();
+
+
+        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC), helper.oscoreBootstrapStoreWithOscoreServer());
+        helper.bootstrapServer.start();
+
+        // Check client is not registered
+        helper.createOscoreOnlyBootstrapClient();
+        helper.assertClientNotRegisterered();
+
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+
+        // Start it and wait for registration
+        helper.client.start();
+
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
+        helper.assertClientRegisterered();
+    }
+
+    @Test
+    public void bootstrapViaOscoreToUnsecuredServer() throws OSException {
+        helper.createServer();
+        helper.server.start();
+
+        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC), helper.oscoreBootstrapStoreWithUnsecuredServer());
+        helper.bootstrapServer.start();
+
+        // Check client is not registered
+        helper.createOscoreOnlyBootstrapClient();
+        helper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        helper.client.start();
+
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
         helper.assertClientRegisterered();
     }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/BootstrapTest.java
@@ -54,7 +54,6 @@ import org.eclipse.leshan.server.security.NonUniqueSecurityInfoException;
 import org.eclipse.leshan.server.security.SecurityInfo;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class BootstrapTest {
@@ -233,7 +232,8 @@ public class BootstrapTest {
         BootstrapDiscoverResponse lastDiscoverAnswer = (BootstrapDiscoverResponse) helper.lastCustomResponse;
         assertEquals(ResponseCode.CONTENT, lastDiscoverAnswer.getCode());
         assertEquals(
-                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>,</21>",
+                String.format(
+                        "</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>,</21>",
                         helper.bootstrapServer.getUnsecuredAddress().getHostString(),
                         helper.bootstrapServer.getUnsecuredAddress().getPort()),
                 linkSerializer.serialize(lastDiscoverAnswer.getObjectLinks()));
@@ -264,7 +264,8 @@ public class BootstrapTest {
         BootstrapDiscoverResponse lastDiscoverAnswer = (BootstrapDiscoverResponse) helper.lastCustomResponse;
         assertEquals(ResponseCode.CONTENT, lastDiscoverAnswer.getCode());
         assertEquals(
-                String.format("</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>,</21>",
+                String.format(
+                        "</>;lwm2m=1.0,</0>;ver=1.1,</0/0>;uri=\"coap://%s:%d\",</1>;ver=1.1,</3>;ver=1.1,</3/0>,</21>",
                         helper.bootstrapServer.getUnsecuredAddress().getHostString(),
                         helper.bootstrapServer.getUnsecuredAddress().getPort()),
                 linkSerializer.serialize(lastDiscoverAnswer.getObjectLinks()));
@@ -666,7 +667,7 @@ public class BootstrapTest {
         helper.createClient();
         helper.assertClientNotRegisterered();
 
-        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreSetting()));
 
         // Start it and wait for registration
         helper.client.start();
@@ -682,15 +683,15 @@ public class BootstrapTest {
         helper.createServer();
         helper.server.start();
 
-
-        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC), helper.oscoreBootstrapStoreWithOscoreServer());
+        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC),
+                helper.oscoreBootstrapStoreWithOscoreServer());
         helper.bootstrapServer.start();
 
         // Check client is not registered
         helper.createOscoreOnlyBootstrapClient();
         helper.assertClientNotRegisterered();
 
-        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreSetting()));
 
         // Start it and wait for registration
         helper.client.start();
@@ -706,7 +707,8 @@ public class BootstrapTest {
         helper.createServer();
         helper.server.start();
 
-        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC), helper.oscoreBootstrapStoreWithUnsecuredServer());
+        helper.createBootstrapServer(helper.bsSecurityStore(SecurityMode.NO_SEC),
+                helper.oscoreBootstrapStoreWithUnsecuredServer());
         helper.bootstrapServer.start();
 
         // Check client is not registered

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisSecurityTest.java
@@ -16,9 +16,21 @@
 package org.eclipse.leshan.integration.tests;
 
 import org.eclipse.leshan.integration.tests.util.RedisSecureIntegrationTestHelper;
+import org.eclipse.leshan.server.security.NonUniqueSecurityInfoException;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class RedisSecurityTest extends SecurityTest {
     public RedisSecurityTest() {
         helper = new RedisSecureIntegrationTestHelper();
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void registered_device_with_oscore_to_server_with_oscore()
+            throws NonUniqueSecurityInfoException, InterruptedException {
+        // TODO OSCORE : https://github.com/eclipse/leshan/pull/1180#issuecomment-1007587985
+        // Redis security store does support oscore for now.
     }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
@@ -113,7 +113,7 @@ public class SecurityTest {
 
         helper.createOscoreClient();
 
-        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreSetting()));
 
         // Check client is not registered
         helper.assertClientNotRegisterered();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/SecurityTest.java
@@ -105,6 +105,32 @@ public class SecurityTest {
     }
 
     @Test
+    public void registered_device_with_oscore_to_server_with_oscore()
+            throws NonUniqueSecurityInfoException, InterruptedException {
+
+        helper.createServer();
+        helper.server.start();
+
+        helper.createOscoreClient();
+
+        helper.getSecurityStore().add(SecurityInfo.newOSCoreInfo(helper.getCurrentEndpoint(), getOscoreCtx()));
+
+        // Check client is not registered
+        helper.assertClientNotRegisterered();
+
+        // Start it and wait for registration
+        helper.client.start();
+        helper.waitForRegistrationAtServerSide(1);
+
+        // Check client is well registered
+        helper.assertClientRegisterered();
+
+        // check we can send request to client.
+        ReadResponse response = helper.server.send(helper.getCurrentRegistration(), new ReadRequest(3, 0, 1), 500);
+        assertTrue(response.isSuccess());
+    }
+
+    @Test
     public void dont_sent_request_if_identity_change()
             throws NonUniqueSecurityInfoException, InterruptedException, IOException {
         // Create PSK server & start it

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/IntegrationTestHelper.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/IntegrationTestHelper.java
@@ -58,6 +58,7 @@ import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.request.UplinkRequest;
 import org.eclipse.leshan.core.request.argument.Arguments;
 import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.californium.LeshanServer;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.model.VersionedModelProvider;
@@ -236,6 +237,7 @@ public class IntegrationTestHelper {
                 return super.isAuthorized(request, registration, senderIdentity);
             }
         });
+        builder.setOscoreCtxDB(OscoreServerHandler.getContextDB());
         return builder;
     }
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServer.java
@@ -50,6 +50,7 @@ import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.californium.observation.ObservationServiceImpl;
 import org.eclipse.leshan.server.californium.registration.CaliforniumRegistrationStore;
 import org.eclipse.leshan.server.californium.registration.RegisterResource;
@@ -431,6 +432,8 @@ public class LeshanServer {
         }
 
         presenceService.destroy();
+
+        OscoreServerHandler.purge();
 
         LOG.info("LWM2M server destroyed.");
     }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/LeshanServerBuilder.java
@@ -35,6 +35,7 @@ import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.SystemConfig;
 import org.eclipse.californium.elements.config.UdpConfig;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole;
@@ -302,7 +303,7 @@ public class LeshanServerBuilder {
      * <p>
      * This is strongly recommended to create the {@link Configuration} with {@link #createDefaultCoapConfiguration()}
      * before to modify it.
-     * 
+     *
      */
     public LeshanServerBuilder setCoapConfig(Configuration config) {
         this.coapConfig = config;
@@ -421,6 +422,13 @@ public class LeshanServerBuilder {
         networkConfig.set(DtlsConfig.DTLS_ROLE, DtlsRole.BOTH);
 
         return networkConfig;
+    }
+
+    HashMapCtxDB oscoreCtxDB;
+
+    public LeshanServerBuilder setOscoreCtxDB(HashMapCtxDB oscoreCtxDB) {
+        this.oscoreCtxDB = oscoreCtxDB;
+        return this;
     }
 
     /**
@@ -554,12 +562,13 @@ public class LeshanServerBuilder {
         // create endpoints
         CoapEndpoint unsecuredEndpoint = null;
         if (!noUnsecuredEndpoint) {
-            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, registrationStore);
+            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, registrationStore,
+                    oscoreCtxDB);
         }
 
         CoapEndpoint securedEndpoint = null;
         if (!noSecuredEndpoint && dtlsConfig != null) {
-            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, registrationStore);
+            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, registrationStore, null);
         }
 
         if (securedEndpoint == null && unsecuredEndpoint == null) {
@@ -600,7 +609,7 @@ public class LeshanServerBuilder {
      * @param registrationIdProvider to provide registrationId using for location-path option values on response of
      *        Register operation.
      * @param linkParser a parser {@link LinkParser} used to parse a CoRE Link.
-     * 
+     *
      * @return the LWM2M server
      */
     protected LeshanServer createServer(CoapEndpoint unsecuredEndpoint, CoapEndpoint securedEndpoint,

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/BootstrapResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/BootstrapResource.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.bootstrap;
 
@@ -24,12 +25,16 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.californium.LwM2mCoapResource;
 import org.eclipse.leshan.core.request.BootstrapRequest;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.response.BootstrapResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +59,24 @@ public class BootstrapResource extends LwM2mCoapResource {
     public void handlePOST(CoapExchange exchange) {
         Request request = exchange.advanced().getRequest();
         LOG.trace("POST received : {}", request);
+
+        // TODO OSCORE : should we really need to do this ?
+        // Check if this incoming request is using OSCORE
+        if (exchange.advanced().getRequest().getOptions().getOscore() != null) {
+            LOG.trace("Client bootstrapped using OSCORE");
+
+            // Update the URI of the associated OSCORE Context with the client's URI
+            // So the server can send requests to the client
+            HashMapCtxDB db = OscoreBootstrapHandler.getContextDB();
+            OSCoreCtx clientCtx = db.getContext(exchange.advanced().getCryptographicContextID());
+
+            try {
+                db.addContext(request.getScheme() + "://"
+                        + request.getSourceContext().getPeerAddress().getHostString().toString(), clientCtx);
+            } catch (OSException e) {
+                LOG.error("Failed to update OSCORE Context for registering client.", request, e);
+            }
+        }
 
         // The LW M2M spec (section 8.2) mandates the usage of Confirmable
         // messages

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServer.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServer.java
@@ -31,6 +31,7 @@ import org.eclipse.leshan.core.link.LinkParser;
 import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
 import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapHandlerFactory;
 import org.eclipse.leshan.server.bootstrap.BootstrapSessionDispatcher;
@@ -162,6 +163,9 @@ public class LeshanBootstrapServer {
         } else if (requestSender instanceof Stoppable) {
             ((Stoppable) requestSender).stop();
         }
+
+        OscoreBootstrapHandler.purge();
+
         LOG.info("Bootstrap server destroyed.");
     }
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilder.java
@@ -31,6 +31,7 @@ import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.SystemConfig;
 import org.eclipse.californium.elements.config.UdpConfig;
+import org.eclipse.californium.oscore.HashMapCtxDB;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole;
@@ -243,7 +244,7 @@ public class LeshanBootstrapServerBuilder {
      * 
      * @param configStore the bootstrap configuration store.
      * @return the builder for fluent Bootstrap Server creation.
-     * 
+     *
      */
     public LeshanBootstrapServerBuilder setConfigStore(BootstrapConfigStore configStore) {
         this.configStore = configStore;
@@ -298,7 +299,7 @@ public class LeshanBootstrapServerBuilder {
      * Set your {@link LwM2mBootstrapModelProvider} implementation.
      * </p>
      * By default the {@link StandardBootstrapModelProvider}.
-     * 
+     *
      */
     public LeshanBootstrapServerBuilder setObjectModelProvider(LwM2mBootstrapModelProvider objectModelProvider) {
         this.modelProvider = objectModelProvider;
@@ -411,6 +412,13 @@ public class LeshanBootstrapServerBuilder {
         networkConfig.set(CoapConfig.MID_TRACKER, TrackerMode.NULL);
         networkConfig.set(DtlsConfig.DTLS_ROLE, DtlsRole.SERVER_ONLY);
         return networkConfig;
+    }
+
+    HashMapCtxDB oscoreCtxDB;
+
+    public LeshanBootstrapServerBuilder setOscoreCtxDB(HashMapCtxDB oscoreCtxDB) {
+        this.oscoreCtxDB = oscoreCtxDB;
+        return this;
     }
 
     /**
@@ -548,12 +556,12 @@ public class LeshanBootstrapServerBuilder {
 
         CoapEndpoint unsecuredEndpoint = null;
         if (!noUnsecuredEndpoint) {
-            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null);
+            unsecuredEndpoint = endpointFactory.createUnsecuredEndpoint(localAddress, coapConfig, null, oscoreCtxDB);
         }
 
         CoapEndpoint securedEndpoint = null;
         if (!noSecuredEndpoint && dtlsConfig != null) {
-            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, null);
+            securedEndpoint = endpointFactory.createSecuredEndpoint(dtlsConfig, coapConfig, null, null);
         }
 
         if (securedEndpoint == null && unsecuredEndpoint == null) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/registration/RegisterResource.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *     Michał Wadowski (Orange) - Improved compliance with rfc6690
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.registration;
 
@@ -28,6 +29,9 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.californium.LwM2mCoapResource;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.link.LinkParseException;
@@ -41,6 +45,7 @@ import org.eclipse.leshan.core.response.DeregisterResponse;
 import org.eclipse.leshan.core.response.RegisterResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
 import org.eclipse.leshan.core.response.UpdateResponse;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.registration.RegistrationHandler;
 import org.eclipse.leshan.server.registration.RegistrationService;
 import org.slf4j.Logger;
@@ -126,6 +131,24 @@ public class RegisterResource extends LwM2mCoapResource {
     }
 
     protected void handleRegister(CoapExchange exchange, Request request) {
+        // TODO OSCORE : should we really need to do this ?
+        // Check if this incoming request is using OSCORE
+        if (exchange.advanced().getRequest().getOptions().getOscore() != null) {
+            LOG.trace("Client registered using OSCORE");
+
+            // Update the URI of the associated OSCORE Context with the client's URI
+            // So the server can send requests to the client
+            HashMapCtxDB db = OscoreServerHandler.getContextDB();
+            OSCoreCtx clientCtx = db.getContext(exchange.advanced().getCryptographicContextID());
+
+            try {
+                db.addContext(request.getScheme() + "://"
+                        + request.getSourceContext().getPeerAddress().getHostString().toString(), clientCtx);
+            } catch (OSException e) {
+                LOG.error("Failed to update OSCORE Context for registering client.", request, e);
+            }
+        }
+
         // Get identity
         // --------------------------------
         Identity sender = extractIdentity(request.getSourceContext());

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/LwM2mResponseBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/LwM2mResponseBuilder.java
@@ -15,6 +15,7 @@
  *     Michał Wadowski (Orange) - Add Observe-Composite feature.
  *     Michał Wadowski (Orange) - Add Cancel Composite-Observation feature.
  *     Michał Wadowski (Orange) - Improved compliance with rfc6690.
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.request;
 
@@ -247,6 +248,21 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkRe
             LwM2mNode content = decodeCoapResponse(request.getPath(), coapResponse, request, clientEndpoint);
             SingleObservation observation = null;
             if (coapResponse.getOptions().hasObserve()) {
+
+                /*
+                 * Note: When using OSCORE and Observe the first coapRequest sent to register an observation can have
+                 * its Token missing here. Is this because OSCORE re-creates the request before sending? When looking in
+                 * Wireshark all messages have a Token as they should. The lines below fixes this by taking the Token
+                 * from the response that came to the request (since the request actually has a Token when going out the
+                 * response will have the same correct Token.
+                 *
+                 * TODO OSCORE : This should probably not be done here.
+                 * should we fix this ? should we check if oscore is used ?
+                 */
+                if (coapRequest.getTokenBytes() == null) {
+                    coapRequest.setToken(coapResponse.getTokenBytes());
+                }
+
                 // observe request successful
                 observation = ObserveUtil.createLwM2mObservation(coapRequest);
             }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/RequestSender.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/request/RequestSender.java
@@ -13,6 +13,7 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *     Michał Wadowski (Orange) - Improved compliance with rfc6690
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.request;
 
@@ -30,6 +31,9 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.Destroyable;
 import org.eclipse.leshan.core.californium.AsyncRequestObserver;
 import org.eclipse.leshan.core.californium.CoapAsyncRequestObserver;
@@ -56,6 +60,7 @@ import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.core.util.NamedThreadFactory;
 import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.OscoreServerHandler;
 import org.eclipse.leshan.server.request.LowerLayerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,6 +144,18 @@ public class RequestSender implements Destroyable {
         request.accept(coapClientRequestBuilder);
         final Request coapRequest = coapClientRequestBuilder.getRequest();
 
+        // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
+        // TODO OSCORE : this should be added in CoapRequestBuilder
+        HashMapCtxDB db = OscoreServerHandler.getContextDB();
+        try {
+            if (db.getContext(coapRequest.getURI()) != null) {
+                coapRequest.getOptions().setOscore(Bytes.EMPTY);
+            }
+        } catch (OSException e) {
+            System.err.println("Failed to retrieve OSCORE Context for request");
+            e.printStackTrace();
+        }
+
         // Send CoAP request synchronously
         SyncRequestObserver<T> syncMessageObserver = new SyncRequestObserver<T>(coapRequest, timeoutInMs) {
             @Override
@@ -215,6 +232,18 @@ public class RequestSender implements Destroyable {
         request.accept(coapClientRequestBuilder);
         final Request coapRequest = coapClientRequestBuilder.getRequest();
 
+        // Toggle OSCORE use in the request if the target URI of the request has an OSCORE context registered
+        // TODO OSCORE : this should be added in CoapRequestBuilder
+        HashMapCtxDB db = OscoreServerHandler.getContextDB();
+        try {
+            if (db.getContext(coapRequest.getURI()) != null) {
+                coapRequest.getOptions().setOscore(Bytes.EMPTY);
+            }
+        } catch (OSException e) {
+            System.err.println("Failed to retrieve OSCORE Context for request");
+            e.printStackTrace();
+        }
+
         // Add CoAP request callback
         MessageObserver obs = new AsyncRequestObserver<T>(coapRequest, responseCallback, errorCallback, timeoutInMs,
                 executor) {
@@ -274,6 +303,8 @@ public class RequestSender implements Destroyable {
                     "Destination context was not set by Leshan for this request. The context is used to ensure you talk to the right peer. Bad usage could bring to security issue. {}",
                     coapRequest);
         }
+
+        // TODO OSCORE : should we add the OSCORE option automatically here too ?
 
         // Send CoAP request synchronously
         CoapSyncRequestObserver syncMessageObserver = new CoapSyncRequestObserver(coapRequest, timeoutInMs);
@@ -335,6 +366,8 @@ public class RequestSender implements Destroyable {
                     "Destination context was not set by Leshan for this request. The context is used to ensure you talk to the right peer. Bad usage could bring to security issue.{}",
                     coapRequest);
         }
+
+        // TODO OSCORE : should we add the OSCORE option automatically here too ?
 
         // Add CoAP request callback
         MessageObserver obs = new CoapAsyncRequestObserver(coapRequest, responseCallback, errorCallback, timeoutInMs,

--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -33,6 +33,11 @@ Contributors:
             <groupId>org.eclipse.leshan</groupId>
             <artifactId>leshan-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.californium</groupId>
+            <artifactId>cf-oscore</artifactId>
+            <version>${californium.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreBootstrapHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreBootstrapHandler.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.server;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+// TODO OSCORE : remove this class and static access.
+public class OscoreBootstrapHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+
+    public static void purge() {
+        db = null;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreServerHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/OscoreServerHandler.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
+ *******************************************************************************/
+package org.eclipse.leshan.server;
+
+import org.eclipse.californium.oscore.HashMapCtxDB;
+
+// TODO OSCORE : remove this class and static access.
+public class OscoreServerHandler {
+
+    private static HashMapCtxDB db;
+
+    public static HashMapCtxDB getContextDB() {
+        if (db == null) {
+            db = new HashMapCtxDB();
+        }
+        return db;
+    }
+
+    public static void purge() {
+        db = null;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -12,9 +12,11 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -87,6 +89,11 @@ public class BootstrapConfig {
      * Map indexed by ACL Instance Id. Key is the ACL Instance to write.
      */
     public Map<Integer, ACLConfig> acls = new HashMap<>();
+
+    /**
+     * Map indexed by OSCORE Object Instance Id. Key is the OSCORE Object Instance to write.
+     */
+    public Map<Integer, OscoreObject> oscore = new HashMap<>();
 
     /** Server Configuration (object 1) as defined in LWM2M 1.0.x TS. */
     public static class ServerConfig {
@@ -280,6 +287,12 @@ public class BootstrapConfig {
          * Bootstrap-Server Account lifetime is infinite.
          */
         public Integer bootstrapServerAccountTimeout = 0;
+        /**
+         * The Object ID of the OSCORE Object Instance that holds the OSCORE configuration to be used by the LWM2M
+         * Client to the LWM2M Server associated with this Security object.
+         * 
+         */
+        public Integer oscoreSecurityMode;
 
         /**
          * The Matching Type Resource specifies how the certificate or raw public key in in the Server Public Key is
@@ -328,13 +341,6 @@ public class BootstrapConfig {
          * Since Security v1.1
          */
         public ULong cipherSuite = null;
-
-        /**
-         * The Object ID of the OSCORE Object Instance that holds the OSCORE configuration to be used by the LWM2M
-         * Client to the LWM2M Server associated with this Security object.
-         * 
-         */
-        public Integer oscoreSecurityMode = null;
 
         @Override
         public String toString() {
@@ -394,8 +400,32 @@ public class BootstrapConfig {
         }
     }
 
+    /** oscore configuration (object 17) */
+    // TODO OSCORE : add some javadoc
+    public static class OscoreObject implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        public String oscoreMasterSecret = "";
+        public String oscoreSenderId = "";
+        public String oscoreRecipientId = "";
+        public Integer oscoreAeadAlgorithm = null;
+        public Integer oscoreHmacAlgorithm = null;
+        public String oscoreMasterSalt = "";
+
+        @Override
+        public String toString() {
+            // Note : oscoreMasterSecret and oscoreMasterSalt are explicitly excluded from the display for security
+            // purposes
+            return String.format(
+                    "OscoreObject [oscoreSenderId=%s, oscoreRecipientId=%s, oscoreAeadAlgorithm=%s, oscoreHmacAlgorithm=%s]",
+                    oscoreSenderId, oscoreRecipientId, oscoreAeadAlgorithm, oscoreHmacAlgorithm);
+        }
+    }
+
     @Override
     public String toString() {
+        // TODO OSCORE : should we add OSCORE to toString ? or is it to sensitive data.
+        // this question remain for other config.
         return String.format("BootstrapConfig [servers=%s, security=%s, acls=%s]", servers, security, acls);
     }
 }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/ConfigurationChecker.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/ConfigurationChecker.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
@@ -52,6 +53,19 @@ public class ConfigurationChecker {
         // check security configurations
         for (Map.Entry<Integer, BootstrapConfig.ServerSecurity> e : config.security.entrySet()) {
             BootstrapConfig.ServerSecurity sec = e.getValue();
+
+            // Retrieve the OSCORE object for this bootstrap server security object
+            if (sec.bootstrapServer && sec.oscoreSecurityMode != null) {
+                BootstrapConfig.OscoreObject osc = config.oscore.get(sec.oscoreSecurityMode);
+                if (osc != null) {
+                    assertIf(StringUtils.isEmpty(osc.oscoreMasterSecret), "master secret must not be empty");
+                    assertIf(StringUtils.isEmpty(osc.oscoreSenderId) && StringUtils.isEmpty(osc.oscoreRecipientId),
+                            "either sender ID or recipient ID must be filled");
+                } else {
+                    throw new InvalidConfigurationException(
+                            "Bootstrap server is set to use OSCORE, its OSCORE object must not be empty");
+                }
+            }
 
             // checks security config
             switch (sec.securityMode) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/InMemoryBootstrapConfigStore.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *     Sierra Wireless - initial API and implementation
+ *     Rikard Höglund (RISE) - additions to support OSCORE
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
@@ -19,15 +20,28 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.californium.cose.AlgorithmID;
+import org.eclipse.californium.cose.CoseException;
+import org.eclipse.californium.oscore.HashMapCtxDB;
+import org.eclipse.californium.oscore.OSCoreCtx;
+import org.eclipse.californium.oscore.OSException;
 import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.util.Hex;
+import org.eclipse.leshan.server.OscoreBootstrapHandler;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerSecurity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.upokecenter.cbor.CBORObject;
 
 /**
  * Simple bootstrap store implementation storing bootstrap configuration information in memory.
- * 
+ *
  */
 public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InMemoryBootstrapConfigStore.class);
 
     protected final ConfigurationChecker configChecker = new ConfigurationChecker();
 
@@ -63,6 +77,7 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
         if (pskToAdd != null) {
             bootstrapByPskId.put(pskToAdd, config);
         }
+        addOscoreContext(config);
     }
 
     protected void checkConfig(String endpoint, BootstrapConfig config) throws InvalidConfigurationException {
@@ -95,6 +110,55 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
     @Override
     public Map<String, BootstrapConfig> getAll() {
         return Collections.unmodifiableMap(bootstrapByEndpoint);
+    }
+
+    // If an OSCORE configuration came, add it to the context db
+    // TODO this should be done via a kind of OSCORE Store
+    public void addOscoreContext(BootstrapConfig config) {
+        HashMapCtxDB db = OscoreBootstrapHandler.getContextDB();
+        for (ServerSecurity security : config.security.values()) {
+            // Make sure to only add OSCORE context for the BS-Client connection
+            BootstrapConfig.OscoreObject osc = config.oscore.get(security.oscoreSecurityMode);
+            if (!security.bootstrapServer || osc == null) {
+                continue;
+            }
+            LOG.trace("Adding OSCORE context information to the context database");
+            try {
+
+                // Parse hexadecimal context parameters
+                byte[] masterSecret = Hex.decodeHex(osc.oscoreMasterSecret.toCharArray());
+                byte[] senderId = Hex.decodeHex(osc.oscoreSenderId.toCharArray());
+                byte[] recipientId = Hex.decodeHex(osc.oscoreRecipientId.toCharArray());
+
+                // Parse master salt which, should be conveyed as null if empty
+                byte[] masterSalt = Hex.decodeHex(osc.oscoreMasterSalt.toCharArray());
+                if (masterSalt.length == 0) {
+                    masterSalt = null;
+                }
+
+                // Parse AEAD Algorithm
+                AlgorithmID aeadAlg = AlgorithmID.FromCBOR(CBORObject.FromObject(osc.oscoreAeadAlgorithm));
+
+                // Parse HKDF Algorithm
+                AlgorithmID hkdfAlg = AlgorithmID.FromCBOR(CBORObject.FromObject(osc.oscoreHmacAlgorithm));
+
+                // ID Context is not supported
+                byte[] idContext = null;
+
+                // Replay window default value
+                int replayWindow = 32;
+
+                OSCoreCtx ctx = new OSCoreCtx(masterSecret, false, aeadAlg, senderId, recipientId, hkdfAlg,
+                        replayWindow, masterSalt, idContext, 1000);
+                // Support Appendix B.2 functionality
+                ctx.setContextRederivationEnabled(true);
+
+                db.addContext(ctx);
+
+            } catch (OSException | CoseException e) {
+                LOG.error("Failed to add OSCORE context to context database.", e);
+            }
+        }
     }
 
     protected static class PskByServer {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/oscore/OscoreSetting.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/security/oscore/OscoreSetting.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.security.oscore;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+import org.eclipse.leshan.core.util.Hex;
+
+public class OscoreSetting implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final byte[] senderId;
+    private final byte[] recipientId;
+    private final byte[] masterSecret;
+    private final Integer aeadAlgorithm;
+    private final Integer hmacAlgorithm;
+    private final byte[] masterSalt;
+
+    public OscoreSetting(byte[] senderId, byte[] recipientId, byte[] masterSecret, Integer aeadAlgorithm,
+            Integer hmacAlgorithm, byte[] masterSalt) {
+        this.senderId = senderId;
+        this.recipientId = recipientId;
+        this.masterSecret = masterSecret;
+        this.aeadAlgorithm = aeadAlgorithm;
+        this.hmacAlgorithm = hmacAlgorithm;
+        this.masterSalt = masterSalt;
+    }
+
+    public byte[] getSenderId() {
+        return senderId;
+    }
+
+    public byte[] getRecipientId() {
+        return recipientId;
+    }
+
+    public byte[] getMasterSecret() {
+        return masterSecret;
+    }
+
+    public Integer getAeadAlgorithm() {
+        return aeadAlgorithm;
+    }
+
+    public Integer getHmacAlgorithm() {
+        return hmacAlgorithm;
+    }
+
+    public byte[] getMasterSalt() {
+        return masterSalt;
+    }
+
+    @Override
+    public String toString() {
+        // Note : oscoreMasterSecret and oscoreMasterSalt are explicitly excluded from the display for security
+        // purposes
+        return String.format("OscoreSetting [senderId=%s, recipientId=%s, aeadAlgorithm=%s, hmacAlgorithm=%s]",
+                Hex.encodeHexString(senderId), Hex.encodeHexString(recipientId), aeadAlgorithm, hmacAlgorithm);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((aeadAlgorithm == null) ? 0 : aeadAlgorithm.hashCode());
+        result = prime * result + ((hmacAlgorithm == null) ? 0 : hmacAlgorithm.hashCode());
+        result = prime * result + Arrays.hashCode(masterSalt);
+        result = prime * result + Arrays.hashCode(masterSecret);
+        result = prime * result + Arrays.hashCode(recipientId);
+        result = prime * result + Arrays.hashCode(senderId);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        OscoreSetting other = (OscoreSetting) obj;
+        if (aeadAlgorithm == null) {
+            if (other.aeadAlgorithm != null)
+                return false;
+        } else if (!aeadAlgorithm.equals(other.aeadAlgorithm))
+            return false;
+        if (hmacAlgorithm == null) {
+            if (other.hmacAlgorithm != null)
+                return false;
+        } else if (!hmacAlgorithm.equals(other.hmacAlgorithm))
+            return false;
+        if (!Arrays.equals(masterSalt, other.masterSalt))
+            return false;
+        if (!Arrays.equals(masterSecret, other.masterSecret))
+            return false;
+        if (!Arrays.equals(recipientId, other.recipientId))
+            return false;
+        if (!Arrays.equals(senderId, other.senderId))
+            return false;
+        return true;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,10 @@ Contributors:
                              <logback.configurationFile>logback-leshan-test.xml</logback.configurationFile>
                         </systemPropertyVariables>
                         <parallel>classes</parallel>
-                        <threadCount>4</threadCount>
+                        <!--  TODO OSCORE threadcount should be set to 4 again as soon as instability was resolved
+                              see : https://github.com/eclipse/leshan/pull/1180#issuecomment-1007587985
+                         -->
+                        <threadCount>1</threadCount>
                         <excludes>
                             <exclude>**/*$*</exclude>
                         </excludes>


### PR DESCRIPTION
I cherry-pick some @Michal-Wadowski's improvement from #1175.
Which should allow to start to work on support of Oscore in server demos. (#1204)