### PR TITLE
[optimization] Avoid to load whole material design font 

### DIFF
--- a/leshan-bsserver-demo/webapp/package.json
+++ b/leshan-bsserver-demo/webapp/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.0",
-    "@mdi/font": "^6.2.0",
     "axios": "^0.22.0",
     "core-js": "^3.18.0",
     "file-saver": "^2.0.5",
@@ -25,6 +24,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
+    "@mdi/js": "^6.6.96",
     "@vue/cli-plugin-babel": "~5.0.0",
     "@vue/cli-plugin-eslint": "~5.0.0",
     "@vue/cli-service": "~5.0.0",

--- a/leshan-bsserver-demo/webapp/package.json
+++ b/leshan-bsserver-demo/webapp/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve --port 8088",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "report": "vue-cli-service build --report"
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.0",

--- a/leshan-bsserver-demo/webapp/src/components/LeshanNavBar.vue
+++ b/leshan-bsserver-demo/webapp/src/components/LeshanNavBar.vue
@@ -41,12 +41,24 @@
 
 <script>
 export default {
-  data: function() {
+  data: function () {
     return {
       pages: [
-        { title: "Bootstrap", route: "/bootstrap", icon: "mdi-devices" },
-        { title: "Server", route: "/server", icon: "mdi-server-security" },
-        { title: "About", route: "/about", icon: "mdi-information-outline" },
+        {
+          title: "Bootstrap",
+          route: "/bootstrap",
+          icon: this.$icons.mdiDevices,
+        },
+        {
+          title: "Server",
+          route: "/server",
+          icon: this.$icons.mdiServerSecurity,
+        },
+        {
+          title: "About",
+          route: "/about",
+          icon: this.$icons.mdiInformationOutline,
+        },
       ],
     };
   },

--- a/leshan-bsserver-demo/webapp/src/main.js
+++ b/leshan-bsserver-demo/webapp/src/main.js
@@ -13,6 +13,7 @@
 
 import Vue from 'vue'
 import './plugins/axios'
+import './plugins/icons'
 import './plugins/dialog'
 import './plugins/moment'
 import './plugins/sse'

--- a/leshan-bsserver-demo/webapp/src/plugins/icons.js
+++ b/leshan-bsserver-demo/webapp/src/plugins/icons.js
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *******************************************************************************/
+
+import Vue from "vue";
+import {
+  mdiAlertOutline,
+  mdiCloseCircleOutline,
+  mdiAccountCancelOutline,
+  mdiDatabaseRemove,
+  mdiAccountCheckOutline,
+  mdiCheck,
+  mdiCheckBold,
+  mdiDelete,
+  mdiDeleteOutline,
+  mdiDevices,
+  mdiExclamationThick,
+  mdiInformationOutline,
+  mdiKeyPlus,
+  mdiLeadPencil,
+  mdiPlay,
+  mdiMagnify,
+  mdiServerSecurity,
+} from "@mdi/js";
+
+/**
+ * We create a Icons plugin to load plugin using @mdi/js.
+ * This will allow to use wepback treeshaking, and so only embedded used icons instead of the whole mdi font
+ * See :
+ *   https://stackoverflow.com/questions/57552261/vuetifyjs-adding-only-used-icons-to-build
+ *   https://github.com/vuetifyjs/vuetify/issues/8265
+ */
+
+// create plugin which make data accessible on all vues
+const _icons = {
+  mdiAlertOutline,
+  mdiCloseCircleOutline,
+  mdiAccountCancelOutline,
+  mdiDatabaseRemove,
+  mdiAccountCheckOutline,
+  mdiCheck,
+  mdiCheckBold,
+  mdiDelete,
+  mdiDeleteOutline,
+  mdiDevices,
+  mdiExclamationThick,
+  mdiInformationOutline,
+  mdiKeyPlus,
+  mdiLeadPencil,
+  mdiPlay,
+  mdiMagnify,
+  mdiServerSecurity,
+};
+
+let IconsPlugin = {};
+IconsPlugin.install = function (Vue) {
+  Object.defineProperties(Vue.prototype, {
+    $icons: {
+      get() {
+        return _icons;
+      },
+    },
+  });
+};
+
+Vue.use(IconsPlugin);
+
+export default IconsPlugin;

--- a/leshan-bsserver-demo/webapp/src/plugins/vuetify.js
+++ b/leshan-bsserver-demo/webapp/src/plugins/vuetify.js
@@ -1,18 +1,17 @@
 /*******************************************************************************
  * Copyright (c) 2021 Sierra Wireless and others.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- * 
+ *
  * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *******************************************************************************/
 
-import '@mdi/font/css/materialdesignicons.css';
-import "@fontsource/roboto"
+import "@fontsource/roboto";
 import Vue from "vue";
 import Vuetify from "vuetify/lib/framework";
 
@@ -20,6 +19,6 @@ Vue.use(Vuetify);
 
 export default new Vuetify({
   icons: {
-    iconfont: "mdi", // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4' || 'faSvg'
+    iconfont: "mdiSvg", // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4' || 'faSvg'
   },
 });

--- a/leshan-bsserver-demo/webapp/src/views/Bootstrap.vue
+++ b/leshan-bsserver-demo/webapp/src/views/Bootstrap.vue
@@ -35,7 +35,7 @@
           ></v-divider>
           <v-text-field
             v-model="search"
-            append-icon="mdi-magnify"
+            :append-icon="$icons.mdiMagnify"
             label="Search"
             single-line
             hide-details
@@ -49,7 +49,7 @@
               $vuetify.breakpoint.smAndDown ? "" : "Add Clients Configuration"
             }}
             <v-icon :right="!$vuetify.breakpoint.smAndDown" dark>
-              mdi-key-plus
+              {{ $icons.mdiKeyPlus }}
             </v-icon>
           </v-btn>
 
@@ -107,7 +107,9 @@
       </template>
       <!--custom display for "actions" column-->
       <template v-slot:item.actions="{ item }">
-        <v-icon small @click.stop="onDelete(item)"> mdi-delete </v-icon>
+        <v-icon small @click.stop="onDelete(item)">
+          {{ $icons.mdiDelete }}
+        </v-icon>
       </template>
     </v-data-table>
   </div>

--- a/leshan-bsserver-demo/webapp/src/views/Client.vue
+++ b/leshan-bsserver-demo/webapp/src/views/Client.vue
@@ -11,15 +11,17 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
   ----------------------------------------------------------------------------->
 <template>
-  <v-card elevation="0" >
+  <v-card elevation="0">
     <v-card-text>
-      <v-card-title class="justify-center"> Client "{{ $route.params.endpoint }}" </v-card-title>
+      <v-card-title class="justify-center">
+        Client "{{ $route.params.endpoint }}"
+      </v-card-title>
 
-      <v-card-subtitle class="text-center" >
+      <v-card-subtitle class="text-center">
         Watch your client bootstrap session.
 
         <v-btn icon title="Clear timeline" @click="events = []">
-          <v-icon>mdi-delete-sweep-outline</v-icon>
+          <v-icon>{{ $icons.mdiDeleteSweepOutline }}</v-icon>
         </v-btn>
       </v-card-subtitle>
 
@@ -75,7 +77,7 @@ export default {
         event.icon = this.getIcon(event);
         event.color = this.getColor(event);
         this.events.push(event);
-        this.$nextTick(function() {
+        this.$nextTick(function () {
           this.$vuetify.goTo(this.$refs.end);
         });
       })
@@ -96,18 +98,18 @@ export default {
 
     getIcon(event) {
       let icons = {
-        "new session": "mdi-play",
-        unauthorized: "mdi-account-cancel-outline",
-        "no config": "mdi-database-remove",
-        authorized: "mdi-account-check-outline",
-        "send write": "mdi-lead-pencil",
-        "send delete": "mdi-delete-outline",
-        "send discover": "mdi-magnify",
-        "receive success response": "mdi-check",
-        "receive error response": "mdi-alert-outline",
-        finished: "mdi-check-bold",
-        "request failure": "mdi-close-circle-outline",
-        failed: "mdi-exclamation-thick",
+        "new session": this.$icons.mdiPlay,
+        unauthorized: this.$icons.mdiAccountCancelOutline,
+        "no config": this.$icons.mdiDatabaseRemove,
+        authorized: this.$icons.mdiAccountCheckOutline,
+        "send write": this.$icons.mdiLeadPencil,
+        "send delete": this.$icons.mdiDeleteOutline,
+        "send discover": this.$icons.mdiMagnify,
+        "receive success response": this.$icons.mdiCheck,
+        "receive error response": this.$icons.mdiAlertOutline,
+        finished: this.$icons.mdiCheckBold,
+        "request failure": this.$icons.mdiCloseCircleOutline,
+        failed: this.$icons.mdiExclamationThick,
       };
       return icons[event.name];
     },

--- a/leshan-bsserver-demo/webapp/yarn.lock
+++ b/leshan-bsserver-demo/webapp/yarn.lock
@@ -1019,10 +1019,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz#0300943770e04231041a51bd39f0439b5c7ab4f0"
   integrity sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==
 
-"@mdi/font@^6.2.0":
+"@mdi/js@^6.6.96":
   version "6.6.96"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-6.6.96.tgz#4eee6faee5f44d3ec401d354fb95775cd6699575"
-  integrity sha512-FbcvG9z17hwZ7IwX5XeOR1UYGoLq+gTKq6XNPvJFuCpn599GdiPCJbAmmDBJb+jMYXjKYr0lCxfouWGxDA82sA==
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-6.6.96.tgz#119f79fa9327359421167a7d4b8bde26e84702ce"
+  integrity sha512-ke9PN5DjPCOlMfhioxeZYADz8Yiz6v47W0IYRza01SSJD7y1EwESVpwFnnFUso+eCoWtE1CO9cTIvQF6sEreuA==
 
 "@node-ipc/js-queue@2.0.3":
   version "2.0.3"

--- a/leshan-server-core-demo/webapp/src/components/path/PathsInput.vue
+++ b/leshan-server-core-demo/webapp/src/components/path/PathsInput.vue
@@ -30,7 +30,7 @@
         required
         dense
         @input="updatePath(index, $event)"
-        append-outer-icon="mdi-delete"
+        :append-outer-icon="$icon.mdiDelete"
         @click:append-outer="removePath(index)"
       ></v-text-field>
     </div>

--- a/leshan-server-core-demo/webapp/src/components/security/SecurityInfoChip.vue
+++ b/leshan-server-core-demo/webapp/src/components/security/SecurityInfoChip.vue
@@ -21,7 +21,7 @@
   </div>
   <div v-else>
     <v-chip small>
-      <v-icon left small> mdi-lock-open-remove </v-icon>
+      <v-icon left small> {{ $icons.mdiLockOpenRemove }} </v-icon>
       Nothing
     </v-chip>
   </div>

--- a/leshan-server-core-demo/webapp/src/js/securityutils.js
+++ b/leshan-server-core-demo/webapp/src/js/securityutils.js
@@ -10,6 +10,13 @@
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *******************************************************************************/
+import {
+  mdiCertificate,
+  mdiLock,
+  mdiKeyChange,
+  mdiHelpRhombusOutline,
+} from "@mdi/js";
+
 function adaptToUI(sec) {
   // TODO this is a bit tricky, probably better to adapt the REST API
   // But do not want to change it while we have 2 demo UI (old & new)
@@ -30,13 +37,13 @@ function getMode(sec) {
 function getModeIcon(mode) {
   switch (mode) {
     case "x509":
-      return "mdi-certificate";
+      return mdiCertificate;
     case "psk":
-      return "mdi-lock";
+      return mdiLock;
     case "rpk":
-      return "mdi-key-change";
+      return mdiKeyChange;
     default:
-      return "mdi-help-rhombus-outline";
+      return mdiHelpRhombusOutline;
   }
 }
 

--- a/leshan-server-core-demo/webapp/src/views/Server.vue
+++ b/leshan-server-core-demo/webapp/src/views/Server.vue
@@ -14,9 +14,7 @@
   <div class="pa-5">
     <v-card elevation="0">
       <v-card-text>
-        <v-card-title class="justify-center">
-          Server Information
-        </v-card-title>
+        <v-card-title class="justify-center"> Server Information </v-card-title>
 
         <v-card-subtitle class="text-center">
           Here some information about this server.
@@ -28,9 +26,7 @@
         <v-card outlined>
           <v-list-item three-line>
             <v-list-item-content>
-              <div class="text-overline mb-4">
-                CoAP Endpoint
-              </div>
+              <div class="text-overline mb-4">CoAP Endpoint</div>
               <v-list-item-title class="text-h5 mb-1">
                 Server URL
               </v-list-item-title>
@@ -38,7 +34,7 @@
                 >Available endpoints for this server:
               </v-list-item-subtitle>
             </v-list-item-content>
-            <v-icon>mdi-access-point-network</v-icon>
+            <v-icon>{{ $icons.mdiAccessPointNetwork }}</v-icon>
           </v-list-item>
           <v-card-text>
             <ul>
@@ -60,9 +56,7 @@
         <v-card outlined>
           <v-list-item three-line>
             <v-list-item-content>
-              <div class="text-overline mb-4">
-                RPK
-              </div>
+              <div class="text-overline mb-4">RPK</div>
               <v-list-item-title class="text-h5 mb-1">
                 Server Public Key
               </v-list-item-title>
@@ -70,14 +64,14 @@
                 SubjectPublicKeyInfo der encoded
               </v-list-item-subtitle>
             </v-list-item-content>
-            <v-icon>mdi-key</v-icon>
+            <v-icon>{{ $icons.mdiKey }}</v-icon>
             <v-card-actions>
               <v-btn
                 icon
                 title="Download Public Key"
                 @click="saveFile(pubkeyFileName, pubkey.bytesDer)"
               >
-                <v-icon>mdi-download</v-icon>
+                <v-icon>{{ $icons.mdiDownload }}</v-icon>
               </v-btn>
             </v-card-actions>
           </v-list-item>
@@ -119,9 +113,7 @@
         <v-card outlined>
           <v-list-item three-line>
             <v-list-item-content>
-              <div class="text-overline mb-4">
-                x509
-              </div>
+              <div class="text-overline mb-4">x509</div>
               <v-list-item-title class="text-h5 mb-1">
                 Server Certificate
               </v-list-item-title>
@@ -129,16 +121,14 @@
                 x509v3 der encoded
               </v-list-item-subtitle>
             </v-list-item-content>
-            <v-icon>mdi-certificate</v-icon>
+            <v-icon>{{ $icons.mdiCertificate }}</v-icon>
             <v-card-actions>
               <v-btn
                 icon
                 title="Download Certificate"
-                @click="
-                  saveFile(certFileName, certificate.bytesDer)
-                "
+                @click="saveFile(certFileName, certificate.bytesDer)"
               >
-                <v-icon>mdi-download</v-icon>
+                <v-icon>{{ $icons.mdiDownload }}</v-icon>
               </v-btn>
             </v-card-actions>
           </v-list-item>

--- a/leshan-server-demo/webapp/package.json
+++ b/leshan-server-demo/webapp/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve --port 8088",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "report": "vue-cli-service build --report"
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.0",

--- a/leshan-server-demo/webapp/package.json
+++ b/leshan-server-demo/webapp/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@fontsource/roboto": "^4.5.0",
-    "@mdi/font": "^6.2.0",
     "axios": "^0.22.0",
     "core-js": "^3.18.0",
     "file-saver": "^2.0.5",
@@ -25,17 +24,18 @@
   "devDependencies": {
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
+    "@mdi/js": "^6.6.96",
     "@vue/cli-plugin-babel": "~5.0.0",
     "@vue/cli-plugin-eslint": "~5.0.0",
     "@vue/cli-service": "~5.0.0",
-    "webpack":"^5.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-vue": "^8.0.3",
     "sass": "~1.32.0",
     "sass-loader": "^10.0.0",
     "vue-cli-plugin-vuetify": "~2.4.8",
     "vue-template-compiler": "^2.6.14",
-    "vuetify-loader": "^1.7.0"
+    "vuetify-loader": "^1.7.0",
+    "webpack": "^5.0.0"
   },
   "eslintConfig": {
     "root": true,

--- a/leshan-server-demo/webapp/src/components/ClientInfo.vue
+++ b/leshan-server-demo/webapp/src/components/ClientInfo.vue
@@ -15,16 +15,16 @@
     <!-- info icon -->
     <v-tooltip :left="tooltipleft" :bottom="tooltipbottom">
       <template v-slot:activator="{ on }">
-        <v-icon v-on="on" class="pr-2" :small="small">
-          mdi-information
+        <v-icon v-on="on" :small="small">
+          {{ $icons.mdiInformation }}
         </v-icon>
       </template>
       Lifetime : {{ registration.lifetime }}s
       <br />
-      Binding mode : {{ registration.bindingMode }} 
+      Binding mode : {{ registration.bindingMode }}
       <span v-if="registration.queuemode">
-      <br /> 
-      Using QueueMode 
+        <br />
+        Using QueueMode
       </span>
       <br />
       Protocole version : {{ registration.lwM2mVersion }}
@@ -41,8 +41,8 @@
     <!-- secure icon -->
     <v-tooltip :left="tooltipleft" :bottom="tooltipbottom">
       <template v-slot:activator="{ on }">
-        <v-icon v-on="on" class="pr-2" :small="small" v-visible="registration.secure">
-          mdi-lock
+        <v-icon v-on="on" :small="small" v-visible="registration.secure">
+          {{ $icons.mdiLock }}
         </v-icon>
       </template>
       Communication over DTLS
@@ -50,8 +50,8 @@
     <!-- secure icon -->
     <v-tooltip :left="tooltipleft" :bottom="tooltipbottom">
       <template v-slot:activator="{ on }">
-        <v-icon v-on="on" class="pr-2" :small="small" v-visible="registration.sleeping">
-          mdi-sleep
+        <v-icon v-on="on" :small="small" v-visible="registration.sleeping">
+          {{ $icons.mdiSleep }}
         </v-icon>
       </template>
       Device using Queue mode is absent
@@ -64,15 +64,15 @@ export default {
     registration: Object,
     small: {
       type: Boolean,
-      default: false
+      default: false,
     },
-    tooltipleft:{
+    tooltipleft: {
       type: Boolean,
-      default: false
+      default: false,
     },
     tooltipbottom: {
       type: Boolean,
-      default: false
+      default: false,
     },
   },
 };

--- a/leshan-server-demo/webapp/src/components/ClientSetting.vue
+++ b/leshan-server-demo/webapp/src/components/ClientSetting.vue
@@ -22,7 +22,7 @@
         item-value="val"
         item-text="txt"
         v-model="timeout"
-        append-outer-icon="mdi-help-circle-outline"
+        :append-outer-icon="$vuetify.icons.values.account"
         @click:append-outer="openTimeoutHelps"
       ></v-select>
     </div>

--- a/leshan-server-demo/webapp/src/components/LeshanNavBar.vue
+++ b/leshan-server-demo/webapp/src/components/LeshanNavBar.vue
@@ -41,13 +41,25 @@
 
 <script>
 export default {
-  data: function() {
+  data: function () {
     return {
       pages: [
-        { title: "Clients", route: "/clients", icon: "mdi-devices" },
-        { title: "Server", route: "/server", icon: "mdi-server-security" },
-        { title: "Security", route: "/security", icon: "mdi-shield-key" },
-        { title: "About", route: "/about", icon: "mdi-information-outline" },
+        { title: "Clients", route: "/clients", icon: this.$icons.mdiDevices },
+        {
+          title: "Server",
+          route: "/server",
+          icon: this.$icons.mdiServerSecurity,
+        },
+        {
+          title: "Security",
+          route: "/security",
+          icon: this.$icons.mdiShieldKey,
+        },
+        {
+          title: "About",
+          route: "/about",
+          icon: this.$icons.mdiInformationOutline,
+        },
       ],
     };
   },

--- a/leshan-server-demo/webapp/src/components/compositeOperation/CompositeObjectControl.vue
+++ b/leshan-server-demo/webapp/src/components/compositeOperation/CompositeObjectControl.vue
@@ -16,7 +16,9 @@
       >Obs</request-button
     >
     <request-button @on-click="stopObserve" title="Passive Cancel Obverse">
-      <v-icon dense small>mdi-eye-remove-outline</v-icon></request-button
+      <v-icon dense small>{{
+        $icons.mdiEyeRemoveOutline
+      }}</v-icon></request-button
     >
     <request-button @on-click="read" title="Composite Read">R</request-button>
     <request-button @on-click="openWriteDialog" ref="W" title="Composite Write"
@@ -40,7 +42,7 @@
           v-on="on"
           title="Composite Operation Settings"
         >
-          <v-icon small> mdi-tune</v-icon>
+          <v-icon small> {{$icons.mdiTune}</v-icon>
         </v-btn>
       </template>
     </composite-operation-setting-menu>

--- a/leshan-server-demo/webapp/src/components/compositeOperation/CompositeObjectIcons.vue
+++ b/leshan-server-demo/webapp/src/components/compositeOperation/CompositeObjectIcons.vue
@@ -16,7 +16,7 @@
       v-for="(id, index) in objectIds"
       :key="index"
       :objectId="id"
-      invalidObjectIcon="mdi-select"
+      :invalidObjectIcon="$icons.mdiSelect"
     />
   </span>
 </template>
@@ -40,7 +40,7 @@ export default {
         });
       }
       // return only the first 3 one.
-      objectIds = [... objectIds].slice(0, 3);
+      objectIds = [...objectIds].slice(0, 3);
 
       // fill missing one with
       for (let i = objectIds.length; i < 3; i++) {

--- a/leshan-server-demo/webapp/src/components/compositeOperation/CompositeObjectsSelector.vue
+++ b/leshan-server-demo/webapp/src/components/compositeOperation/CompositeObjectsSelector.vue
@@ -25,9 +25,9 @@
             :key="index"
             :to="
               '/clients/' +
-                $route.params.endpoint +
-                '/composite/' +
-                compositeObject.name
+              $route.params.endpoint +
+              '/composite/' +
+              compositeObject.name
             "
           >
             <v-list-item-icon>
@@ -45,13 +45,13 @@
                 @click.prevent="openEditCompositeObject(compositeObject)"
               >
                 <v-icon small>
-                  mdi-pencil
+                  {{ $icons.mdiPencil }}
                 </v-icon>
               </v-btn>
             </v-list-item-action>
             <v-list-item-action>
               <v-btn icon @click.prevent="removeCompositeObject(index)">
-                <v-icon>mdi-delete</v-icon>
+                <v-icon>{{ $icons.mdiDelete }}</v-icon>
               </v-btn>
             </v-list-item-action>
           </v-list-item>

--- a/leshan-server-demo/webapp/src/components/instance/InstanceControl.vue
+++ b/leshan-server-demo/webapp/src/components/instance/InstanceControl.vue
@@ -19,7 +19,9 @@
       @on-click="stopObserve"
       :title="'Passive Cancel Obverse ' + path"
     >
-      <v-icon dense small>mdi-eye-remove-outline</v-icon></request-button
+      <v-icon dense small>{{
+        $icons.mdiEyeRemoveOutline
+      }}</v-icon></request-button
     >
     <request-button @on-click="read" :title="'Read ' + path">R</request-button>
     <request-button @on-click="openWriteDialog" ref="W" :title="'Write ' + path"

--- a/leshan-server-demo/webapp/src/components/instance/InstanceView.vue
+++ b/leshan-server-demo/webapp/src/components/instance/InstanceView.vue
@@ -25,11 +25,11 @@
         />
 
         <v-icon
-          class="pr-3"
+          class="mr-3"
           small
           v-show="state.observed[instancePath]"
           :title="'Instance ' + instancePath + ' observed'"
-          >mdi-eye-outline</v-icon
+          >{{ $icons.mdiEyeOutline }}</v-icon
         >
       </span>
     </h4>

--- a/leshan-server-demo/webapp/src/components/object/ObjectIcon.vue
+++ b/leshan-server-demo/webapp/src/components/object/ObjectIcon.vue
@@ -14,11 +14,49 @@
   <v-icon>{{ idToIcon(objectId) }}</v-icon>
 </template>
 <script>
+import {
+  mdiAlertCircleOutline,
+  mdiAlphaOCircleOutline,
+  mdiArrowExpandVertical,
+  mdiAxisArrow,
+  mdiBellRing,
+  mdiCardTextOutline,
+  mdiCellphoneArrowDown,
+  mdiCellphoneWireless,
+  mdiDatabase,
+  mdiDatabaseSyncOutline,
+  mdiDevices,
+  mdiDoor,
+  mdiFolderMultipleOutline,
+  mdiGauge,
+  mdiGestureTapButton,
+  mdiLightbulbOnOutline,
+  mdiListStatus,
+  mdiMapMarker,
+  mdiPackageDown,
+  mdiPaletteOutline,
+  mdiPuzzleOutline,
+  mdiServer,
+  mdiShieldCheckOutline,
+  mdiSignal,
+  mdiSignalDistanceVariant,
+  mdiSignalVariant,
+  mdiSim,
+  mdiSimOutline,
+  mdiTextBoxOutline,
+  mdiTextRecognition,
+  mdiThermometer,
+  mdiTimerOutline,
+  mdiToggleSwitch,
+  mdiWaterPercent,
+  mdiWidgetsOutline,
+} from "@mdi/js";
+
 export default {
   props: {
     objectId: Number,
-    unknowObjectIcon: { type: String, default: "mdi-alpha-o-circle-outline" },
-    invalidObjectIcon: { type: String, default: "mdi-alert-circle-outline" },
+    unknowObjectIcon: { type: String, default: mdiAlphaOCircleOutline },
+    invalidObjectIcon: { type: String, default: mdiAlertCircleOutline },
   },
   methods: {
     idToIcon(id) {
@@ -26,73 +64,73 @@ export default {
 
       switch (id) {
         case 1: // server
-          return "mdi-server";
+          return mdiServer;
         case 2: // ACL
-          return "mdi-shield-check-outline";
+          return mdiShieldCheckOutline;
         case 3: // device
-          return "mdi-devices";
+          return mdiDevices;
         case 4: // connectivity monitoring
-          return "mdi-signal-variant";
+          return mdiSignalVariant;
         case 5: // firmware update
-          return "mdi-cellphone-arrow-down";
+          return mdiCellphoneArrowDown;
         case 6: // location
-          return "mdi-map-marker";
+          return mdiMapMarker;
         case 7: // connectivity statistics
-          return "mdi-signal-distance-variant";
+          return mdiSignalDistanceVariant;
         case 9: // LWM2M Software Management
-          return "mdi-package-down";
+          return mdiPackageDown;
         case 10: //  LWM2M Cellular Connectivity
-          return "mdi-signal";
+          return mdiSignal;
         case 11: // LWM2M APN Connection Profile
-          return "mdi-sim";
+          return mdiSim;
         case 12: // WLAN connectivity
-          return "mdi-cellphone-wireless";
+          return mdiCellphoneWireless;
         case 13: // LWM2M Bearer Selection
-          return "mdi-sim-outline";
+          return mdiSimOutline;
         case 14: // LWM2M Software Component
-          return "mdi-puzzle-outline";
+          return mdiPuzzleOutline;
         case 15: // DevCapMgmt
-          return "mdi-widgets-outline";
+          return mdiWidgetsOutline;
         case 16: // Portfolio
-          return "mdi-folder-multiple-outline";
+          return mdiFolderMultipleOutline;
         case 19: // BinaryAppDataContainer
-          return "mdi-database-sync-outline";
+          return mdiDatabaseSyncOutline;
         case 3300: // General Sensor
-          return "mdi-gauge";
+          return mdiGauge;
         case 3303: // Temperature
-          return "mdi-thermometer";
+          return mdiThermometer;
         case 3304: // Humidity
-          return "mdi-water-percent";
+          return mdiWaterPercent;
         case 3311: // Light Control
-          return "mdi-lightbulb-on-outline";
+          return mdiLightbulbOnOutline;
         case 3313: // Accelerometer
-          return "mdi-axis-arrow";
+          return mdiAxisArrow;
         case 3323: // Pressure
-          return "mdi-arrow-expand-vertical";
+          return mdiArrowExpandVertical;
         case 3335: // Colour
-          return "mdi-palette-outline";
+          return mdiPaletteOutline;
         case 3338: // Buzzer
-          return "mdi-bell-ring";
+          return mdiBellRing;
         case 3340: // Timer
-          return "mdi-timer-outline";
+          return mdiTimerOutline;
         case 3341: // Addressable Text Display
-          return "mdi-text-recognition";
+          return mdiTextRecognition;
         case 3342: // On/Off Switch
-          return "mdi-toggle-switch";
+          return mdiToggleSwitch;
         case 3347: // Push Button
-          return "mdi-gesture-tap-button";
+          return mdiGestureTapButton;
         case 3441: // LWM2M v1.0 Test Object
-          return "mdi-list-status";
+          return mdiListStatus;
         case 3442: // LWM2M v1.1 Test Object
-          return "mdi-list-status";
+          return mdiListStatus;
         case 3351: // powerupLog
-          return "mdi-card-text-outline";
+          return mdiCardTextOutline;
         case 10259: // System Log
-          return "mdi-text-box-outline";
+          return mdiTextBoxOutline;
         case 10260: // RDB (Runtime Database)
-          return "mdi-database";
+          return mdiDatabase;
         case 10351: // Door
-          return "mdi-door";
+          return mdiDoor;
         default:
           return this.unknowObjectIcon;
       }

--- a/leshan-server-demo/webapp/src/components/object/ObjectSelector.vue
+++ b/leshan-server-demo/webapp/src/components/object/ObjectSelector.vue
@@ -29,7 +29,7 @@
               small
               color="red"
               :title="`The Object ${object.name} ID:${object.id} MUST NOT be part of Update Objects and Object Instances list in Register Request.`"
-              >mdi-alert-circle</v-icon
+              >{{ $mdiAlertCircle }}</v-icon
             ></v-list-item-title
           >
           <v-list-item-subtitle>

--- a/leshan-server-demo/webapp/src/components/resources/ResourceControl.vue
+++ b/leshan-server-demo/webapp/src/components/resources/ResourceControl.vue
@@ -23,7 +23,9 @@
       v-if="readable"
       :title="'Passive Cancel Obverse ' + path"
     >
-      <v-icon dense small>mdi-eye-remove-outline</v-icon></request-button
+      <v-icon dense small>{{
+        $icons.mdiEyeRemoveOutline
+      }}</v-icon></request-button
     >
     <request-button @on-click="read" v-if="readable" :title="'Read ' + path"
       >R</request-button
@@ -45,7 +47,7 @@
       @on-click="execWithParams"
       v-if="executable"
       :title="'Execute with params ' + path"
-      ><v-icon dense small>mdi-cog-outline</v-icon></request-button
+      ><v-icon dense small>{{ $icons.mdiCogOutline }}</v-icon></request-button
     >
     <resource-write-dialog
       v-if="showDialog"

--- a/leshan-server-demo/webapp/src/components/resources/ResourceInstanceControl.vue
+++ b/leshan-server-demo/webapp/src/components/resources/ResourceInstanceControl.vue
@@ -23,7 +23,9 @@
       v-if="readable"
       :title="'Passive Cancel Obverse ' + path"
     >
-      <v-icon dense small>mdi-eye-remove-outline</v-icon></request-button
+      <v-icon dense small>{{
+        $icons.mdiEyeRemoveOutline
+      }}</v-icon></request-button
     >
     <request-button @on-click="read" v-if="readable" :title="'Read ' + path"
       >R</request-button

--- a/leshan-server-demo/webapp/src/components/resources/input/LabelledResourceInput.vue
+++ b/leshan-server-demo/webapp/src/components/resources/input/LabelledResourceInput.vue
@@ -30,7 +30,7 @@
       <v-tooltip left>
         <template v-slot:activator="{ on }">
           <v-icon v-on="on">
-            mdi-help-circle-outline
+            {{ $icons.mdiHelpCircleOutline }}
           </v-icon>
         </template>
         <p style="white-space: pre-wrap">{{ resourcedef.description }}</p>
@@ -47,7 +47,7 @@ import ResourceInput from "./ResourceInput.vue";
 export default {
   components: { ResourceInput },
   props: {
-    value: null, // the input value for this resource (v-model) 
+    value: null, // the input value for this resource (v-model)
     resourcedef: Object, // the model of the resource
   },
   methods: {

--- a/leshan-server-demo/webapp/src/components/resources/input/LabelledResourceInstanceInput.vue
+++ b/leshan-server-demo/webapp/src/components/resources/input/LabelledResourceInstanceInput.vue
@@ -30,7 +30,7 @@
       <v-tooltip left>
         <template v-slot:activator="{ on }">
           <v-icon v-on="on">
-            mdi-help-circle-outline
+            {{ $icons.mdiHelpCircleOutline }}
           </v-icon>
         </template>
         <p style="white-space: pre-wrap">{{ resourcedef.description }}</p>

--- a/leshan-server-demo/webapp/src/components/resources/input/MultiInstanceResourceInput.vue
+++ b/leshan-server-demo/webapp/src/components/resources/input/MultiInstanceResourceInput.vue
@@ -13,13 +13,9 @@
 <template>
   <div class="grey lighten-4 pa-4 mb-1">
     <span class="pa-2">
-      <v-btn small @click="addNewInstance">
-        Add Instance
-      </v-btn>
+      <v-btn small @click="addNewInstance"> Add Instance </v-btn>
     </span>
-    <v-btn small @click="removeAllInstances">
-      Remove All
-    </v-btn>
+    <v-btn small @click="removeAllInstances"> Remove All </v-btn>
     <span v-for="(instance, index) in instances" :key="index">
       <v-row dense align="center">
         <v-col cols="12" md="1">
@@ -44,7 +40,7 @@
         </v-col>
         <v-col cols="1" justify="center">
           <v-btn icon small @click="removeInstance(index)">
-            <v-icon> mdi-delete </v-icon>
+            <v-icon> {{ $icons.mdiDelete }} </v-icon>
           </v-btn>
         </v-col>
       </v-row>

--- a/leshan-server-demo/webapp/src/components/resources/view/MultiInstancesResourceView.vue
+++ b/leshan-server-demo/webapp/src/components/resources/view/MultiInstancesResourceView.vue
@@ -15,14 +15,10 @@
     <template v-slot:default>
       <thead>
         <tr>
-          <th class="px-2 text-left ">
-            Id
-          </th>
+          <th class="px-2 text-left">Id</th>
           <th></th>
           <th></th>
-          <th class="text-left" style="width:100%">
-            Value
-          </th>
+          <th class="text-left" style="width: 100%">Value</th>
         </tr>
       </thead>
       <tbody>
@@ -32,15 +28,16 @@
           style="background-color: transparent !important"
         >
           <td class="px-2 text--disabled">{{ id }}</td>
-          <td class="px-2"> 
-            <v-icon class="pa-0"
+          <td class="px-2">
+            <v-icon
+              class="pa-0"
               x-small
               v-show="state.observed[instancePath(id)]"
               :title="'Instance ' + instancePath(id) + ' observed'"
-              >mdi-eye-outline</v-icon
+              >{{ $icons.mdiEyeOutline }}</v-icon
             >
           </td>
-          <td class="px-2" style="white-space:nowrap">
+          <td class="px-2" style="white-space: nowrap">
             <resource-instance-control
               :endpoint="endpoint"
               :resourcedef="resourcedef"
@@ -61,14 +58,14 @@ import { valueToString } from "../../../js/valueutils.js";
 import ResourceInstanceControl from "../ResourceInstanceControl.vue";
 
 /**
- * Display the state of a "Multi Instance" Resource. 
- * 
- * List all instances with its value and controls to execute operations on it. 
+ * Display the state of a "Multi Instance" Resource.
+ *
+ * List all instances with its value and controls to execute operations on it.
  */
 export default {
   components: { ResourceInstanceControl },
   props: {
-    endpoint: String, // the endpoint of the client 
+    endpoint: String, // the endpoint of the client
     resourcedef: Object, // the model of the resource
     resource: Object, // the resource data as defined in store.js
     path: String, // the path of the resource (e.g. /3/0/1)

--- a/leshan-server-demo/webapp/src/components/resources/view/ResourceExpansionPanel.vue
+++ b/leshan-server-demo/webapp/src/components/resources/view/ResourceExpansionPanel.vue
@@ -12,12 +12,12 @@
   ----------------------------------------------------------------------------->
 <template>
   <v-expansion-panel>
-    <v-expansion-panel-header style="min-height:32px" class="pa-3">
+    <v-expansion-panel-header style="min-height: 32px" class="pa-3">
       <template v-slot:default="{ open }">
         <!-- min-width is needed for avoid shift about truncated text 
           see : https://stackoverflow.com/a/36247448/5088764
           -->
-        <v-container class="pa-0" style="min-width:0">
+        <v-container class="pa-0" style="min-width: 0">
           <v-row>
             <v-col cols="7" lg="3" align-self="center" class="pa-2"
               >{{ resource.def.name }}
@@ -39,7 +39,7 @@
                 x-small
                 v-show="state.observed[resource.path]"
                 :title="'Resource ' + resource.path + ' observed'"
-                >mdi-eye-outline</v-icon
+                >{{ $icons.mdiEyeOutline }}</v-icon
               ></v-col
             >
 

--- a/leshan-server-demo/webapp/src/components/resources/view/ResourceInstanceExpansionPanel.vue
+++ b/leshan-server-demo/webapp/src/components/resources/view/ResourceInstanceExpansionPanel.vue
@@ -12,12 +12,12 @@
   ----------------------------------------------------------------------------->
 <template>
   <v-expansion-panel>
-    <v-expansion-panel-header style="min-height:32px" class="pa-3">
+    <v-expansion-panel-header style="min-height: 32px" class="pa-3">
       <template v-slot:default="{ open }">
         <!-- min-width is needed for avoid shift about truncated text 
           see : https://stackoverflow.com/a/36247448/5088764
           -->
-        <v-container class="pa-0" style="min-width:0">
+        <v-container class="pa-0" style="min-width: 0">
           <v-row>
             <v-col cols="7" lg="3" align-self="center" class="pa-2"
               >{{ resource.def.name }}
@@ -41,7 +41,7 @@
                 :title="
                   'Resource Instance' + resourceInstancePath + ' observed'
                 "
-                >mdi-eye-outline</v-icon
+                >{{ $icons.mdiEyeOutline }}</v-icon
               ></v-col
             >
 
@@ -93,7 +93,7 @@
 </template>
 <script>
 import ResourceInstanceControl from "../ResourceInstanceControl.vue";
-import ResourceInstanceView from './ResourceInstanceView.vue';
+import ResourceInstanceView from "./ResourceInstanceView.vue";
 import SimpleResourceInstanceView from "./SimpleResourceInstanceView.vue";
 
 export default {
@@ -101,7 +101,7 @@ export default {
     ResourceInstanceControl,
     SimpleResourceInstanceView,
     ResourceInstanceView,
-   },
+  },
   props: {
     endpoint: String, // the endpoint name of the client
     resource: Object, // a resource object {path:String, def:Object} (def is the resourcedef)

--- a/leshan-server-demo/webapp/src/components/values/input/BooleanValueInput.vue
+++ b/leshan-server-demo/webapp/src/components/values/input/BooleanValueInput.vue
@@ -18,7 +18,7 @@
         :indeterminate="state !== ''"
         :key="state"
         :indeterminate-icon="icon"
-        off-icon="mdi-close-box-outline"
+        :off-icon="$icons.mdiCloseBoxOutline"
       ></v-checkbox>
     </v-col>
     <v-col>
@@ -91,13 +91,13 @@ export default {
       );
     },
     isNotBoolean() {
-      return typeof(this.booleanValue) !== "boolean";
+      return typeof this.booleanValue !== "boolean";
     },
     icon() {
       if (this.isNotSet) {
-        return "mdi-checkbox-blank-outline";
+        return this.$icons.mdiCheckboxBlankOutline;
       } else if (this.isNotBoolean) {
-        return "mdi-help-box";
+        return this.$icons.mdiHelpBox;
       } else {
         return "";
       }

--- a/leshan-server-demo/webapp/src/main.js
+++ b/leshan-server-demo/webapp/src/main.js
@@ -14,6 +14,7 @@
 import Vue from "vue";
 import "./plugins/axios";
 import "./plugins/store";
+import "./plugins/icons";
 import "./plugins/sse";
 import "./plugins/moment";
 import "./plugins/preferences";
@@ -27,7 +28,7 @@ Vue.config.productionTip = false;
 /**
  * directive to hide content without changing layout unlike v-show or v-if
  */
-Vue.directive("visible", function(el, binding) {
+Vue.directive("visible", function (el, binding) {
   el.style.visibility = binding.value ? "visible" : "hidden";
 });
 

--- a/leshan-server-demo/webapp/src/plugins/icons.js
+++ b/leshan-server-demo/webapp/src/plugins/icons.js
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *******************************************************************************/
+
+import Vue from "vue";
+import {
+  mdiAccessPointNetwork,
+  mdiAlertCircle,
+  mdiCheckboxBlankOutline,
+  mdiCertificate,
+  mdiCloseBoxOutline,
+  mdiCogOutline,
+  mdiDelete,
+  mdiDevices,
+  mdiDownload,
+  mdiExitRun,
+  mdiEyeOutline,
+  mdiEyeRemoveOutline,
+  mdiFormatListCheckbox,
+  mdiHelpBox,
+  mdiHelpCircleOutline,
+  mdiHelpRhombusOutline,
+  mdiInformation,
+  mdiInformationOutline,
+  mdiKey,
+  mdiKeyChange,
+  mdiKeyPlus,
+  mdiLock,
+  mdiLockOpenRemove,
+  mdiMagnify,
+  mdiPencil,
+  mdiSelect,
+  mdiServerSecurity,
+  mdiShieldKey,
+  mdiSleep,
+  mdiTune,
+} from "@mdi/js";
+
+/**
+ * We create a Icons plugin to load plugin using @mdi/js.
+ * This will allow to use wepback treeshaking, and so only embedded used icons instead of the whole mdi font
+ * See :
+ *   https://stackoverflow.com/questions/57552261/vuetifyjs-adding-only-used-icons-to-build
+ *   https://github.com/vuetifyjs/vuetify/issues/8265
+ */
+
+// create plugin which make data accessible on all vues
+const _icons = {
+  mdiAccessPointNetwork,
+  mdiAlertCircle,
+  mdiCheckboxBlankOutline,
+  mdiCertificate,
+  mdiCloseBoxOutline,
+  mdiCogOutline,
+  mdiDelete,
+  mdiDevices,
+  mdiDownload,
+  mdiExitRun,
+  mdiEyeOutline,
+  mdiEyeRemoveOutline,
+  mdiFormatListCheckbox,
+  mdiHelpBox,
+  mdiHelpCircleOutline,
+  mdiHelpRhombusOutline,
+  mdiInformation,
+  mdiInformationOutline,
+  mdiKey,
+  mdiKeyChange,
+  mdiKeyPlus,
+  mdiLock,
+  mdiLockOpenRemove,
+  mdiMagnify,
+  mdiPencil,
+  mdiSelect,
+  mdiServerSecurity,
+  mdiShieldKey,
+  mdiSleep,
+  mdiTune,
+};
+
+let IconsPlugin = {};
+IconsPlugin.install = function (Vue) {
+  Object.defineProperties(Vue.prototype, {
+    $icons: {
+      get() {
+        return _icons;
+      },
+    },
+  });
+};
+
+Vue.use(IconsPlugin);
+
+export default IconsPlugin;

--- a/leshan-server-demo/webapp/src/plugins/vuetify.js
+++ b/leshan-server-demo/webapp/src/plugins/vuetify.js
@@ -1,18 +1,17 @@
 /*******************************************************************************
  * Copyright (c) 2021 Sierra Wireless and others.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- * 
+ *
  * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *******************************************************************************/
 
-import '@mdi/font/css/materialdesignicons.css';
-import "@fontsource/roboto"
+import "@fontsource/roboto";
 import Vue from "vue";
 import Vuetify from "vuetify/lib/framework";
 
@@ -20,6 +19,6 @@ Vue.use(Vuetify);
 
 export default new Vuetify({
   icons: {
-    iconfont: "mdi", // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4' || 'faSvg'
+    iconfont: "mdiSvg", // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4' || 'faSvg'
   },
 });

--- a/leshan-server-demo/webapp/src/views/Client.vue
+++ b/leshan-server-demo/webapp/src/views/Client.vue
@@ -13,16 +13,14 @@
 <template>
   <v-row class="fill-height" no-gutters>
     <v-col cols="12" v-if="deregister">
-      <div style="height: 100px;"></div>
+      <div style="height: 100px"></div>
       <v-card elevation="0" class="text-center">
         <v-card-text class="fill-height">
-          <v-icon x-large> mdi-exit-run</v-icon>
+          <v-icon x-large> {{ $icons.mdiExitRun }}</v-icon>
           <v-card-title class="justify-center">
             {{ $route.params.endpoint }} is deregistered.
           </v-card-title>
-          <v-card-subtitle>
-            Waiting for new registration ?
-          </v-card-subtitle>
+          <v-card-subtitle> Waiting for new registration ? </v-card-subtitle>
         </v-card-text>
       </v-card>
     </v-col>
@@ -30,7 +28,7 @@
       cols="12"
       md="2"
       v-if="registration"
-      style="background-color:#fafafa"
+      style="background-color: #fafafa"
     >
       <!-- registration info -->
       <v-sheet color="grey lighten-5" class="pa-4" width="100%">
@@ -63,7 +61,7 @@
               :to="'/clients/' + $route.params.endpoint + '/composite'"
             >
               <v-list-item-icon class="me-2">
-                <v-icon>mdi-format-list-checkbox</v-icon>
+                <v-icon>{{ $icons.mdiFormatListCheckbox }}</v-icon>
               </v-list-item-icon>
               <v-list-item-content>
                 <v-list-item-title>Composite Operations</v-list-item-title>
@@ -115,7 +113,7 @@ export default {
     objectdefs: [],
   }),
   methods: {
-    updateModels: function() {
+    updateModels: function () {
       this.axios
         .get(
           "api/objectspecs/" + encodeURIComponent(this.$route.params.endpoint)
@@ -124,14 +122,13 @@ export default {
     },
   },
   computed: {
-    objectdef: function() {
+    objectdef: function () {
       return this.objectdefs.find((o) => o.id == this.$route.params.objectid);
     },
-    instances: function() {
+    instances: function () {
       if (this.registration) {
-        let instances = this.registration.availableInstances[
-          this.$route.params.objectid
-        ];
+        let instances =
+          this.registration.availableInstances[this.$route.params.objectid];
         if (instances) return instances;
       }
       return [];

--- a/leshan-server-demo/webapp/src/views/Clients.vue
+++ b/leshan-server-demo/webapp/src/views/Clients.vue
@@ -38,7 +38,7 @@
           ></v-divider>
           <v-text-field
             v-model="search"
-            append-icon="mdi-magnify"
+            :append-icon="$icons.mdiMagnify"
             label="Search"
             single-line
             hide-details

--- a/leshan-server-demo/webapp/src/views/CompositeObjectView.vue
+++ b/leshan-server-demo/webapp/src/views/CompositeObjectView.vue
@@ -27,7 +27,7 @@
           small
           v-show="state.compositeObserved[compositeObservationKey]"
           :title="compositeObservationKey + ' observed'"
-          >mdi-eye-outline</v-icon
+          >{{ icons.mdiEyeOutline }}</v-icon
         >
       </h3>
       <p>

--- a/leshan-server-demo/webapp/src/views/CompositeOperationView.vue
+++ b/leshan-server-demo/webapp/src/views/CompositeOperationView.vue
@@ -21,7 +21,10 @@
   <div v-else>
     <v-sheet color="grey lighten-5" class="pa-4" width="100%">
       <div>
-        <h3><v-icon>mdi-format-list-checkbox</v-icon> Composite Operations</h3>
+        <h3>
+          <v-icon>{{ $icons.mdiFormatListCheckbox }}</v-icon> Composite
+          Operations
+        </h3>
         <p>
           Create your "Composite Object", then you will be able to sent
           Composite Operation on it like Read-Composite, Write-Composite or

--- a/leshan-server-demo/webapp/src/views/Security.vue
+++ b/leshan-server-demo/webapp/src/views/Security.vue
@@ -33,7 +33,7 @@
         ></v-divider>
         <v-text-field
           v-model="search"
-          append-icon="mdi-magnify"
+          :append-icon="$icons.mdiMagnify"
           label="Search"
           single-line
           hide-details
@@ -44,7 +44,7 @@
         <v-btn dark class="mb-2" @click.stop="openNewSec()">
           {{ $vuetify.breakpoint.smAndDown ? "" : "Add Security Information" }}
           <v-icon :right="!$vuetify.breakpoint.smAndDown" dark>
-            mdi-key-plus
+            {{ $icons.mdiKeyPlus }}
           </v-icon>
         </v-btn>
 
@@ -63,19 +63,19 @@
     </template>
     <!--custom display for "details" column-->
     <template v-slot:item.details="{ item }">
-      <div v-if="item.mode == 'psk'" style="word-break:break-all;" class="pa-1">
+      <div v-if="item.mode == 'psk'" style="word-break: break-all" class="pa-1">
         <strong>Identity:</strong> <code>{{ item.details.identity }}</code>
         <br />
         <strong>Key:</strong
         ><code class="text-uppercase">{{ item.details.key }}</code>
       </div>
-      <div v-if="item.mode == 'rpk'" style="word-break:break-all;" class="pa-1">
+      <div v-if="item.mode == 'rpk'" style="word-break: break-all" class="pa-1">
         <strong>Public Key:</strong>
         <code class="text-uppercase">{{ item.details.key }}</code>
       </div>
       <div
         v-if="item.mode == 'x509'"
-        style="word-break:break-all;"
+        style="word-break: break-all"
         class="pa-1"
       >
         <strong>X509 certificate with CN equals :</strong>
@@ -90,10 +90,10 @@
         @click.stop="openEditSec(item)"
         :disabled="item.mode == 'unsupported'"
       >
-        mdi-pencil
+        {{ $icons.mdiPencil }}
       </v-icon>
       <v-icon small @click="deleteSec(item)">
-        mdi-delete
+        {{ $icons.mdiDelete }}
       </v-icon>
     </template>
   </v-data-table>

--- a/leshan-server-demo/webapp/yarn.lock
+++ b/leshan-server-demo/webapp/yarn.lock
@@ -1019,10 +1019,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz#0300943770e04231041a51bd39f0439b5c7ab4f0"
   integrity sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==
 
-"@mdi/font@^6.2.0":
+"@mdi/js@^6.6.96":
   version "6.6.96"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-6.6.96.tgz#4eee6faee5f44d3ec401d354fb95775cd6699575"
-  integrity sha512-FbcvG9z17hwZ7IwX5XeOR1UYGoLq+gTKq6XNPvJFuCpn599GdiPCJbAmmDBJb+jMYXjKYr0lCxfouWGxDA82sA==
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-6.6.96.tgz#119f79fa9327359421167a7d4b8bde26e84702ce"
+  integrity sha512-ke9PN5DjPCOlMfhioxeZYADz8Yiz6v47W0IYRza01SSJD7y1EwESVpwFnnFUso+eCoWtE1CO9cTIvQF6sEreuA==
 
 "@node-ipc/js-queue@2.0.3":
   version "2.0.3"


### PR DESCRIPTION
## Issue

Currently we load the whole material design fond, this is not so good :grimacing: ...

This is arround 350 Ko and 1.1Mo downloaded  (depending format used by the browser) which is mainly not used.

This PR aims to use @mdi/js  which supports webpack tree shaking to only get used icons.
See : https://stackoverflow.com/questions/57552261/vuetifyjs-adding-only-used-icons-to-build

## Results

This PR removes warnings below raised by webpack (#1239): 
```
asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  fonts/materialdesignicons-webfont.aaf5968f.eot (1.11 MiB)
  fonts/materialdesignicons-webfont.ad0f7b3f.woff2 (358 KiB)
  fonts/materialdesignicons-webfont.f5b84261.ttf (1.11 MiB)
  fonts/materialdesignicons-webfont.fabeafb8.woff (516 KiB)
```

Following Firefox devTools, among of data to load to open main web page is reduced about 600 ko :
 -  from `1.67 Mo` to `1.05 Mo` for **leshan-server-demo** 
 - from `1.62 Mo` to `0.99 Mo` for  **leshan-bsserver-demo**
 
Both jars also reduce about ~600Ko : 
 - from `15.1 Mo` to `14.5 Mo` for **leshan-server-demo** 
 - from `13.2 Mo` to `12,8 Mo` for **leshan-bsserver-demo**
 
 This also increases the lighthouse(#1240) score from ~10 point. (But score seems to not be exactly the same each runs...)  
E.g. for server-demo, before : 
![Capture d’écran de 2022-04-21 19-04-13](https://user-images.githubusercontent.com/840294/164513447-802bb32a-e2a4-451f-b2b8-2ae8f1f15c03.png)
Then after :
![Capture d’écran de 2022-04-21 19-03-44](https://user-images.githubusercontent.com/840294/164513474-d4b79533-8c88-41ea-8bc6-10a99bfd8a58.png)