### PR TITLE
Add OSCORE Support to leshan-bsserver-demo

### DIFF
--- a/leshan-bsserver-demo/webapp/src/components/bsconfig/ServerInput.vue
+++ b/leshan-bsserver-demo/webapp/src/components/bsconfig/ServerInput.vue
@@ -27,9 +27,9 @@
       class="examplePatch"
     ></v-text-field>
     <security-input
-      :mode.sync="server.mode"
+      :mode.sync="server.security.mode"
       @update:mode="$emit('input', server)"
-      :details.sync="server.details"
+      :details.sync="server.security.details"
       @update:details="$emit('input', server)"
       :defaultrpk="defaultrpk"
       :defaultx509="defaultx509"
@@ -46,13 +46,13 @@ export default {
     defaultNoSecValue: String,
     defaultSecureValue: String,
     defaultrpk: {
-      default: function() {
+      default: function () {
         return {};
       },
       type: Object,
     },
     defaultx509: {
-      default: function() {
+      default: function () {
         return {};
       },
       type: Object,
@@ -60,13 +60,13 @@ export default {
   },
   data() {
     return {
-      server: { mode: "no_sec" }, // internal server Config
+      server: { security: { mode: "no_sec" } }, // internal server Config
     };
   },
   watch: {
     value(v) {
       if (!v) {
-        this.server = { mode: "no_sec" };
+        this.server = { security: { mode: "no_sec" } };
       } else {
         this.server = v;
       }

--- a/leshan-bsserver-demo/webapp/src/components/wizard/BootstrapServerStep.vue
+++ b/leshan-bsserver-demo/webapp/src/components/wizard/BootstrapServerStep.vue
@@ -15,12 +15,10 @@
     <v-card-text class="pb-0">
       <p>
         This information will be used to add a
-        <strong>LWM2M Bootstrap Server</strong> to your LWM2M Client during the bootstrap
-        Session by writing 1 instance for object <code>/0</code>.
+        <strong>LWM2M Bootstrap Server</strong> to your LWM2M Client during the
+        bootstrap Session by writing 1 instance for object <code>/0</code>.
       </p>
-      <p>
-        By default no LWM2M Bootstrap server is added.
-      </p>
+      <p>By default no LWM2M Bootstrap server is added.</p>
     </v-card-text>
     <v-form
       ref="form"
@@ -60,14 +58,14 @@ export default {
   data() {
     return {
       addServer: false,
-      internalServer: { mode: "no_sec" }, // internal Bootstrap server Config
+      internalServer: { security: { mode: "no_sec" } }, // internal Bootstrap server Config
     };
   },
   watch: {
     value(v) {
       if (!v) {
         this.addServer = false;
-        this.internalServer = { mode: "no_sec" };
+        this.internalServer = { security: { mode: "no_sec" } };
       } else {
         this.addServer = true;
         this.internalServer = v;

--- a/leshan-bsserver-demo/webapp/src/components/wizard/ClientConfigDialog.vue
+++ b/leshan-bsserver-demo/webapp/src/components/wizard/ClientConfigDialog.vue
@@ -115,9 +115,7 @@
         >
           Previous
         </v-btn>
-        <v-btn text @click="close">
-          Cancel
-        </v-btn>
+        <v-btn text @click="close"> Cancel </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -193,7 +191,7 @@ export default {
         this.config = {
           endpoint: null,
           security: null,
-          dm: { mode: "no_sec" },
+          dm: { security: { mode: "no_sec" } },
           bs: null,
           toDelete: ["/0", "/1"],
           autoIdForSecurityObject: false,
@@ -217,7 +215,7 @@ export default {
       if (res.dm) {
         if (!res.dm.url) {
           res.dm.url =
-            res.dm.mode == "no_sec"
+            res.dm.security.mode == "no_sec"
               ? this.defval.dm.url.nosec
               : this.defval.dm.url.sec;
         }
@@ -226,24 +224,24 @@ export default {
       if (res.bs) {
         if (!res.bs.url) {
           res.bs.url =
-            res.bs.mode == "no_sec"
+            res.bs.security.mode == "no_sec"
               ? this.defval.bs.url.nosec
               : this.defval.bs.url.sec;
         }
 
         // apply default rpk value for bs server
-        if (res.bs.mode == "rpk") {
+        if (res.bs.security.mode == "rpk") {
           for (const key in this.defaultrpk) {
-            if (!res.bs.details[key]) {
-              res.bs.details[key] = this.defaultrpk[key];
+            if (!res.bs.security.details[key]) {
+              res.bs.security.details[key] = this.defaultrpk[key];
             }
           }
         }
         // apply default x509 value for bs server
-        if (res.bs.mode == "x509") {
+        if (res.bs.security.mode == "x509") {
           for (const key in this.defaultx509) {
-            if (!res.bs.details[key]) {
-              res.bs.details[key] = this.defaultx509[key];
+            if (!res.bs.security.details[key]) {
+              res.bs.security.details[key] = this.defaultx509[key];
             }
           }
         }

--- a/leshan-bsserver-demo/webapp/src/components/wizard/ClientConfigDialog.vue
+++ b/leshan-bsserver-demo/webapp/src/components/wizard/ClientConfigDialog.vue
@@ -193,7 +193,7 @@ export default {
           security: null,
           dm: { security: { mode: "no_sec" } },
           bs: null,
-          toDelete: ["/0", "/1"],
+          toDelete: ["/0", "/1", "/21"],
           autoIdForSecurityObject: false,
         };
         this.currentStep = 1;

--- a/leshan-bsserver-demo/webapp/src/components/wizard/DeleteStep.vue
+++ b/leshan-bsserver-demo/webapp/src/components/wizard/DeleteStep.vue
@@ -18,7 +18,7 @@
         existing configuration on the <strong>LWM2M client</strong>.
       </p>
       <p>
-        By default, objects <code>/0</code> and <code>/1</code> are deleted,
+        By default, objects <code>/0</code>, <code>/1</code> and <code>/21</code> are deleted,
         then you will be able to define LWM2M Server and LWM2M Bootstrap Server
         to add.
       </p>

--- a/leshan-bsserver-demo/webapp/src/components/wizard/ServerStep.vue
+++ b/leshan-bsserver-demo/webapp/src/components/wizard/ServerStep.vue
@@ -58,14 +58,14 @@ export default {
   data() {
     return {
       addServer: true,
-      internalServer: { mode: "no_sec" }, // internal server Config
+      internalServer: { security: { mode: "no_sec" } }, // internal server Config
     };
   },
   watch: {
     value(v) {
       if (!v) {
         this.addServer = false;
-        this.internalServer = { mode: "no_sec" };
+        this.internalServer = { security: { mode: "no_sec" } };
       } else {
         this.addServer = true;
         this.internalServer = v;

--- a/leshan-bsserver-demo/webapp/src/views/Bootstrap.vue
+++ b/leshan-bsserver-demo/webapp/src/views/Bootstrap.vue
@@ -186,23 +186,23 @@ export default {
 
     formatData(c) {
       let s = {};
-      s.securityMode = c.mode.toUpperCase();
+      s.securityMode = c.security.mode.toUpperCase();
       s.uri = c.url;
-      switch (c.mode) {
+      switch (c.security.mode) {
         case "psk":
-          s.publicKeyOrId = fromAscii(c.details.identity);
-          s.secretKey = fromHex(c.details.key);
+          s.publicKeyOrId = fromAscii(c.security.details.identity);
+          s.secretKey = fromHex(c.security.details.key);
           break;
         case "rpk":
-          s.publicKeyOrId = fromHex(c.details.client_pub_key);
-          s.secretKey = fromHex(c.details.client_pri_key);
-          s.serverPublicKey = fromHex(c.details.server_pub_key);
+          s.publicKeyOrId = fromHex(c.security.details.client_pub_key);
+          s.secretKey = fromHex(c.security.details.client_pri_key);
+          s.serverPublicKey = fromHex(c.security.details.server_pub_key);
           break;
         case "x509":
-          s.publicKeyOrId = fromHex(c.details.client_certificate);
-          s.secretKey = fromHex(c.details.client_pri_key);
-          s.serverPublicKey = fromHex(c.details.server_certificate);
-          s.certificateUsage = c.details.certificate_usage;
+          s.publicKeyOrId = fromHex(c.security.details.client_certificate);
+          s.secretKey = fromHex(c.security.details.client_pri_key);
+          s.serverPublicKey = fromHex(c.security.details.server_certificate);
+          s.certificateUsage = c.security.details.certificate_usage;
           break;
       }
       return s;

--- a/leshan-bsserver-demo/webapp/src/views/Bootstrap.vue
+++ b/leshan-bsserver-demo/webapp/src/views/Bootstrap.vue
@@ -88,6 +88,15 @@
                 {{ server.security.securityMode.toLowerCase() }}
               </v-chip>
             </span>
+            <span v-if="server.oscore">
+              with
+              <v-chip small>
+                <v-icon left small>
+                  {{ oscoreIcon() }}
+                </v-icon>
+                OSCORE
+              </v-chip>
+            </span>
             <br />
           </span>
           <!-- LWM2M Bootstrap Server to add -->
@@ -100,6 +109,15 @@
                   {{ modeIcon(server.security.securityMode.toLowerCase()) }}
                 </v-icon>
                 {{ server.security.securityMode.toLowerCase() }}
+              </v-chip>
+            </span>
+            <span v-if="server.oscore">
+              with
+              <v-chip small>
+                <v-icon left small>
+                  {{ oscoreIcon() }}
+                </v-icon>
+                OSCORE
               </v-chip>
             </span>
           </span>
@@ -119,7 +137,10 @@ import { configsFromRestToUI, configFromUIToRest } from "../js/bsconfigutil.js";
 import { fromHex, fromAscii } from "@leshan-server-core-demo/js/byteutils.js";
 import SecurityInfoChip from "@leshan-server-core-demo/components/security/SecurityInfoChip.vue";
 import ClientConfigDialog from "../components/wizard/ClientConfigDialog.vue";
-import { getModeIcon } from "@leshan-server-core-demo/js/securityutils.js";
+import {
+  getModeIcon,
+  getOscoreIcon,
+} from "@leshan-server-core-demo/js/securityutils.js";
 
 export default {
   components: { ClientConfigDialog, SecurityInfoChip },
@@ -183,6 +204,9 @@ export default {
     modeIcon(securitymode) {
       return getModeIcon(securitymode);
     },
+    oscoreIcon() {
+      return getOscoreIcon();
+    },
 
     formatData(c) {
       let s = {};
@@ -204,6 +228,12 @@ export default {
           s.serverPublicKey = fromHex(c.security.details.server_certificate);
           s.certificateUsage = c.security.details.certificate_usage;
           break;
+      }
+      if (c.oscore) {
+        s.oscore = {};
+        s.oscore.oscoreSenderId = fromHex(c.oscore.sid);
+        s.oscore.oscoreMasterSecret = fromHex(c.oscore.msec);
+        s.oscore.oscoreRecipientId = fromHex(c.oscore.rid);
       }
       return s;
     },
@@ -257,6 +287,13 @@ export default {
             },
           },
         ];
+        if (dmServer.oscore) {
+          c.dm[0].oscore = {
+            oscoreSenderId: dmServer.oscore.oscoreSenderId,
+            oscoreMasterSecret: dmServer.oscore.oscoreMasterSecret,
+            oscoreRecipientId: dmServer.oscore.oscoreRecipientId,
+          };
+        }
       }
       if (config.bs) {
         let bsServer = this.formatData(config.bs);
@@ -278,6 +315,13 @@ export default {
             },
           },
         ];
+        if (bsServer.oscore) {
+          c.bs[0].oscore = {
+            oscoreSenderId: bsServer.oscore.oscoreSenderId,
+            oscoreMasterSecret: bsServer.oscore.oscoreMasterSecret,
+            oscoreRecipientId: bsServer.oscore.oscoreRecipientId,
+          };
+        }
       }
 
       if (config.security) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
@@ -163,12 +163,21 @@ public class Oscore extends BaseInstanceEnabler {
             return ReadResponse.success(resourceid, recipientId);
 
         case OSCORE_AEAD_ALGORITHM:
+            if (aeadAlgorithm == null) {
+                return ReadResponse.notFound();
+            }
             return ReadResponse.success(resourceid, aeadAlgorithm.getValue());
 
         case OSCORE_HMAC_ALGORITHM:
+            if (hkdfAlgorithm == null) {
+                return ReadResponse.notFound();
+            }
             return ReadResponse.success(resourceid, hkdfAlgorithm.getValue());
 
         case OSCORE_MASTER_SALT:
+            if (masterSalt == null) {
+                return ReadResponse.notFound();
+            }
             return ReadResponse.success(resourceid, masterSalt);
 
         default:

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -390,16 +390,27 @@ public class ServersInfoExtractor {
     }
 
     public static long getAeadAlgorithm(LwM2mObjectInstance oscoreInstance) {
-        return (long) oscoreInstance.getResource(OSCORE_AEAD_ALGORITHM).getValue();
+        LwM2mResource resource = oscoreInstance.getResource(OSCORE_AEAD_ALGORITHM);
+        if (resource != null)
+            return (long) resource.getValue();
+        // return default one from https://datatracker.ietf.org/doc/html/rfc8613#section-3.2
+        return AeadAlgorithm.AES_CCM_16_64_128.getValue();
     }
 
     public static long getHkdfAlgorithm(LwM2mObjectInstance oscoreInstance) {
-        return (long) oscoreInstance.getResource(OSCORE_HMAC_ALGORITHM).getValue();
+        LwM2mResource resource = oscoreInstance.getResource(OSCORE_HMAC_ALGORITHM);
+        if (resource != null)
+            return (long) resource.getValue();
+        // return default one from https://datatracker.ietf.org/doc/html/rfc8613#section-3.2
+        return HkdfAlgorithm.HKDF_HMAC_SHA_256.getValue();
     }
 
     public static byte[] getMasterSalt(LwM2mObjectInstance oscoreInstance) {
-        byte[] value = (byte[]) oscoreInstance.getResource(OSCORE_MASTER_SALT).getValue();
+        LwM2mResource resource = oscoreInstance.getResource(OSCORE_MASTER_SALT);
+        if (resource == null)
+            return null;
 
+        byte[] value = (byte[]) resource.getValue();
         if (value.length == 0) {
             return null;
         } else {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -214,6 +214,19 @@ public class ServersInfoExtractor {
         return info.deviceManagements.get(shortID);
     }
 
+    public static LwM2mObjectInstance getBootstrapSecurityInstance(LwM2mObjectEnabler securityEnabler) {
+        LwM2mObject securities = (LwM2mObject) securityEnabler.read(SYSTEM, new ReadRequest(SECURITY)).getContent();
+        if (securities != null) {
+            for (LwM2mObjectInstance instance : securities.getInstances().values()) {
+                if (isBootstrapServer(instance)) {
+                    return instance;
+                }
+            }
+        }
+
+        return null;
+    }
+
     public static ServerInfo getBootstrapServerInfo(Map<Integer, LwM2mObjectEnabler> objectEnablers) {
         ServersInfo info = getInfo(objectEnablers);
         if (info == null)
@@ -366,6 +379,14 @@ public class ServersInfoExtractor {
 
         LwM2mResource isBootstrap = (LwM2mResource) response.getContent();
         return (Boolean) isBootstrap.getValue();
+    }
+
+    public static boolean isBootstrapServer(LwM2mObjectInstance instance) {
+        LwM2mResource resource = instance.getResource(SEC_BOOTSTRAP);
+        if (resource == null) {
+            return false;
+        }
+        return (Boolean) resource.getValue();
     }
 
     // OSCORE related methods below

--- a/leshan-server-core-demo/webapp/src/components/security/SecurityInfoChip.vue
+++ b/leshan-server-core-demo/webapp/src/components/security/SecurityInfoChip.vue
@@ -19,25 +19,35 @@
       {{ securityInfo.tls.mode }}
     </v-chip>
     <v-chip small v-if="securityInfo.oscore">
-      <v-icon left small> {{$icons.mdiLockOutline}} </v-icon>
+      <v-icon left small> {{ oscoreIcon }} </v-icon>
       oscore
     </v-chip>
   </div>
   <div v-else>
     <v-chip small>
-      <v-icon left small> {{ $icons.mdiLockOpenRemove }} </v-icon>
+      <v-icon left small> {{ noSecIcon }} </v-icon>
       Nothing
     </v-chip>
   </div>
 </template>
 <script>
-import { getModeIcon } from "../../js/securityutils.js";
+import {
+  getModeIcon,
+  getOscoreIcon,
+  getNoSecIcon,
+} from "../../js/securityutils.js";
 
 export default {
   props: { securityInfo: Object /*securityInfo to display*/ },
   computed: {
     modeIcon() {
       return getModeIcon(this.securityInfo.tls.mode);
+    },
+    oscoreIcon() {
+      return getOscoreIcon();
+    },
+    noSecIcon() {
+      return getNoSecIcon();
     },
   },
 };

--- a/leshan-server-core-demo/webapp/src/js/securityutils.js
+++ b/leshan-server-core-demo/webapp/src/js/securityutils.js
@@ -13,6 +13,8 @@
 import {
   mdiCertificate,
   mdiLock,
+  mdiLockOpenRemove,
+  mdiLockOutline,
   mdiKeyChange,
   mdiHelpRhombusOutline,
 } from "@mdi/js";
@@ -37,4 +39,12 @@ function getModeIcon(mode) {
   }
 }
 
-export { getMode, getModeIcon };
+function getOscoreIcon() {
+  return mdiLockOutline;
+}
+
+function getNoSecIcon() {
+  return mdiLockOpenRemove;
+}
+
+export { getMode, getModeIcon, getOscoreIcon, getNoSecIcon };


### PR DESCRIPTION
This aims to add support of OSCORE in the bootstrap configuration.

~This is work in progress.~

Some missing feature : 
- ~making oscore/dtls exclusive~ Not needed :x:
- ~display  oscore is used in the bootstrap config list~ :heavy_check_mark: 
- ~add support for bootstrap server wizard step (only dm is supported for now)~ :heavy_check_mark: 
- ~handle object 21 deletion.~ :heavy_check_mark:  