### PR TITLE
Add some basic CI (build + tests) for PR on master.

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,32 @@
+name: "Build Code"
+description: "Build repository with Maven"
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Build
+    id: build
+    shell: bash
+    run: mvn -B package -DskipTests -Dskip.yarn
+
+
+  - name: Add comment
+    if: failure()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Build Failed
+      message: |
+        :x: **Maven Build failed !** [(more details)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+        Ensure your code build locally using: 
+        ```
+        mvn clean install
+        ```
+
+  - name: Delete comment
+    if: success()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Build Failed
+      delete: true

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -1,0 +1,38 @@
+name: "Integration Tests"
+description: "Run Integration Tests with Maven"
+
+runs:
+  using: "composite"
+  steps:
+  - name: Run Integration Tests 
+    shell: bash
+    run: mvn -B test '-Dtest=org.eclipse.leshan.integration.tests.**,!**/Redis*.java' -Dsurefire.rerunFailingTestsCount=10 -DfailIfNoTests=false -Dskip.yarn 
+
+  - name: Add comment
+    if: failure()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Integration Tests Failed
+      message: |
+        :x: **Integration Tests failed !** [(more details)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+        Ensure your code build locally using: 
+        ```
+        mvn clean install
+        ```
+        Or just launch all tests : 
+        ```
+        mvn test -Dskip.yarn
+        ```
+        To launch integration tests only : 
+        ```
+        mvn test '-Dtest=org.eclipse.leshan.integration.tests.**,!**/Redis*.java' -Dsurefire.rerunFailingTestsCount=3 -DfailIfNoTests=false -Dskip.yarn
+        ```
+        Currently, some of our integration tests are flaky :unamused: ,so do not hesitate to re-run in case of failure. 
+
+  - name: Delete comment
+    if: success()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Integration Tests Failed
+      delete: true

--- a/.github/actions/javadoc/action.yml
+++ b/.github/actions/javadoc/action.yml
@@ -1,0 +1,31 @@
+name: "Generate Javadoc"
+description: "Generate Javadoc with Maven"
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Generate Javadoc
+    id: javadoc
+    shell: bash
+    run: mvn -B package javadoc:javadoc -DskipTests -Dskip.yarn
+
+  - name: Add comment
+    if: failure()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Javadoc Generation Failed
+      message: |
+        :x: **Javadoc Generation failed !** [(more details)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+        Ensure you can generate javadoc locally using: 
+        ```
+        mvn clean javadoc:javadoc
+        ```
+
+  - name: Delete comment
+    if: success()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Javadoc Generation Failed
+      delete: true

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -1,0 +1,37 @@
+name: "Unit Tests "
+description: "Run Unit Tests with Maven"
+
+runs:
+  using: "composite"
+  steps:
+  - name: Run Integration Tests 
+    shell: bash
+    run: mvn -B test '-Dtest=!org.eclipse.leshan.integration.tests.**' -DfailIfNoTests=false -Dskip.yarn
+
+  - name: Add comment
+    if: failure()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Unit Tests Failed
+      message: |
+        :x: **Unit Tests failed !** [(more details)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+        Ensure your code build locally using: 
+        ```
+        mvn clean install
+        ```
+        Or just launch tests : 
+        ```
+        mvn test -Dskip.yarn
+        ```
+        To launch unit tests only : 
+        ```
+        mvn test '-Dtest=!org.eclipse.leshan.integration.tests.**' -DfailIfNoTests=false -Dskip.yarn
+        ```
+
+  - name: Delete comment
+    if: success()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Unit Tests Failed
+      delete: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,69 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Maven
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build: 
+    name : Code Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'adopt'
+        cache: maven
+
+    - name: Build
+      id: build
+      uses: ./.github/actions/build
+
+    - name: Generate Javadoc
+      if: ${{ steps.build.conclusion == 'success' }}
+      uses: ./.github/actions/javadoc
+      
+    - name: Unit Tests
+      id: unit_tests
+      if: ${{ always() &&  steps.build.conclusion == 'success' }}
+      uses: ./.github/actions/unit-tests
+
+    - name: Integration Tests
+      id: integration_tests
+      if: ${{ always() && steps.build.conclusion == 'success' }}
+      uses: ./.github/actions/integration-tests
+
+    - name: Report Test Failure
+      uses: mikepenz/action-junit-report@v3
+      if: ${{ always() && (steps.unit_tests.conclusion == 'failure' || steps.integration_tests.conclusion == 'failure') }}
+      with:
+          check_name: Automatic Tests Report
+          report_paths: '**/target/surefire-reports/*.xml'
+          fail_on_failure: true
+
+    - name: Add Tips comment
+      if: failure()
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: Refine your PR
+        message: |
+          :information_source: Some tips : 
+           - Once you fix your issues locally, **do not create a new PR**, see [how to refine your PR](https://github.com/eclipse/leshan/wiki/How-to-contribute#refine-it).
+           - See [How to contribute](https://github.com/eclipse/leshan/wiki/How-to-contribute) guide and some [Code & design guidelines](https://github.com/eclipse/leshan/wiki/Code-&-design-guidelines). 
+
+          If documentation or those automatic comments are not clear enough, please [create a new issue](https://github.com/eclipse/leshan/issues/new) to discus about how to enhance it. 
+      
+    - name: Delete Tips comment
+      if: success()
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: Refine your PR
+        delete: true


### PR DESCRIPTION
This aims to partially implement #1265.

It will automatically check that : 
 - code compiles
 - javadoc can be generated
 - unit tests are OK
 - integrations tests are OK
 
 In case of failure some comments will be created, see some example of failure : 
  - see https://github.com/sbernard31/leshan/pull/8
  - see https://github.com/sbernard31/leshan/pull/9