### PR TITLE
Add CI to ensure PR does not contain merge commit.

### DIFF
--- a/.github/actions/no_merge/action.yml
+++ b/.github/actions/no_merge/action.yml
@@ -1,0 +1,25 @@
+name: "Check No Merge commit"
+description: "Check PR does not contains any merge commit"
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Check For Merge Commit
+    id: no_merge
+    uses: voxie-actions/no-merge-commits@v1.0.0
+
+  - name: Add comment
+    if: failure()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Merge Commit Detected
+      message: |
+        :x: **PR should not contain "Merge Commit"**, so please use `git rebase` instead.
+
+  - name: Delete comment
+    if: success()
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: Merge Commit Detected
+      delete: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,16 @@ jobs:
         distribution: 'adopt'
         cache: maven
 
+    - name: Check No Merge Commit
+      uses: ./.github/actions/no_merge
+
     - name: Build
+      if: always()
       id: build
       uses: ./.github/actions/build
 
     - name: Generate Javadoc
-      if: ${{ steps.build.conclusion == 'success' }}
+      if: ${{ always() && steps.build.conclusion == 'success' }}
       uses: ./.github/actions/javadoc
       
     - name: Unit Tests


### PR DESCRIPTION
This aims to implement some part of #1265.

This adds check to ensure PR does not contain any merge commit.

In case of failure some comments will be created, see some example of failure :
- https://github.com/sbernard31/leshan/pull/6