### PR TITLE
Timestamp calculation in SenMLResolver class correction

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/senml/SenMLResolver.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/senml/SenMLResolver.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.senml;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Utility class used to resolve SenML record.
  *
@@ -49,7 +51,7 @@ public abstract class SenMLResolver<T extends ResolvedSenMLRecord> {
             // A negative value indicates seconds in the past from roughly "now".
             // Positive values up to 2**28 indicate seconds in the future from "now".
             if (resolvedTimestamp < 268_435_456) {
-                resolvedTimestamp = currentTimestamp + resolvedTimestamp;
+                resolvedTimestamp =  TimeUnit.MILLISECONDS.toSeconds(currentTimestamp) + resolvedTimestamp;
             }
             // else
             // Values greater than or equal to 2**28 represent an absolute time relative to the Unix epoch


### PR DESCRIPTION
Please find in commit [https://github.com/eclipse/leshan/commit/4db7b871bd1bc752af334cf2ee268b06c6d9db5f](https://github.com/eclipse/leshan/commit/4db7b871bd1bc752af334cf2ee268b06c6d9db5f)  changes fixing bug described in [https://github.com/eclipse/leshan/issues/1301](https://github.com/eclipse/leshan/issues/1301)