### PR TITLE
Timestamps in seconds instead of milliseconds in ManualDataSender.

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/send/ManualDataSender.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/send/ManualDataSender.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.client.send;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.node.LwM2mNode;
@@ -44,7 +45,7 @@ public class ManualDataSender implements DataSender {
     }
 
     public synchronized void collectData(List<LwM2mPath> paths) {
-        long currentTimestamp = System.currentTimeMillis();
+        long currentTimestamp = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
         Map<LwM2mPath, LwM2mNode> currentValues = dataSenderManager.getCurrentValues(ServerIdentity.SYSTEM, paths);
         synchronized (this) {
             builder.addNodes(currentTimestamp, currentValues);

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/send/ManualDataSenderTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/send/ManualDataSenderTest.java
@@ -73,11 +73,11 @@ public class ManualDataSenderTest {
         Map<LwM2mPath, LwM2mNode> firstValue = fakeDataSenderManager.getCurrentValues(givenServer, givenPaths);
         manualDataSender.collectData(givenPaths);
 
-        Thread.sleep(100);
+        Thread.sleep(1000);
         Map<LwM2mPath, LwM2mNode> secondValue = fakeDataSenderManager.changeCurrentValues(givenServer, givenPaths);
         manualDataSender.collectData(givenPaths);
 
-        Thread.sleep(100);
+        Thread.sleep(1000);
         Map<LwM2mPath, LwM2mNode> thirdValue = fakeDataSenderManager.changeCurrentValues(givenServer, givenPaths);
         manualDataSender.collectData(givenPaths);
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/SendTimestampedTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/SendTimestampedTest.java
@@ -79,7 +79,7 @@ public class SendTimestampedTest {
         ManualDataSender sender = helper.client.getSendService().getDataSender(ManualDataSender.DEFAULT_NAME,
                 ManualDataSender.class);
         sender.collectData(Arrays.asList(getExamplePath()));
-        Thread.sleep(100);
+        Thread.sleep(1000);
         sender.collectData(Arrays.asList(getExamplePath()));
         sender.sendCollectedData(server, ContentFormat.SENML_JSON, 1000, false);
         listener.waitForData(1, TimeUnit.SECONDS);


### PR DESCRIPTION
Timestamps in ManualDataSender correction mentioned in issue: [https://github.com/eclipse/leshan/issues/1304](https://github.com/eclipse/leshan/issues/1304)