### PR TITLE
Add Checkstyle Rule to ensure Java File has Header

### DIFF
--- a/eclipse/checkstyle.xml
+++ b/eclipse/checkstyle.xml
@@ -15,6 +15,12 @@
         <module name="UnusedLocalVariable"/>
     </module>
 
+    <module name="RegexpHeader">
+        <property name="headerFile" value="./eclipse/java.header"/>
+        <property name="multiLines" value="2, 3, 14"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
     <module name="RegexpSingleline">
         <property name="format" value="\s+$"/>
         <property name="message" value="No trailing white space allowed."/>

--- a/eclipse/java.header
+++ b/eclipse/java.header
@@ -1,0 +1,15 @@
+^/\*+$
+^ \* Copyright \(c\) \d\d\d\d(-\d\d\d\d)? .+\.$
+^ \*$
+^ \* All rights reserved\. This program and the accompanying materials$
+^ \* are made available under the terms of the Eclipse Public License v2\.0$
+^ \* and Eclipse Distribution License v1\.0 which accompany this distribution\.$
+^ \*$
+^ \* The Eclipse Public License is available at$
+^ \*    http://www\.eclipse\.org/legal/epl-v20\.html$
+^ \* and the Eclipse Distribution License is available at$
+^ \*    http://www\.eclipse\.org/org/documents/edl-v10\.html\.$
+^ \*$
+^ \* Contributors:$
+^ \*    .+$
+^ \*+/$

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/object/Oscore.java
@@ -2,18 +2,17 @@
  * Copyright (c) 2015 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    http://www.eclipse.org/legal/epl-v10.html
+ *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *     Rikard Höglund (RISE SICS) - Additions to support OSCORE
- *
  *******************************************************************************/
 package org.eclipse.leshan.client.object;
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverDispatcher.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/observer/LwM2mClientObserverDispatcher.java
@@ -1,13 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2016 Sierra Wireless and others.
+ * Copyright (c) 2016    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
- * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
- * Public License v1.0 and Eclipse Distribution License v1.0 which accompany this distribution.
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
  *
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v20.html and the Eclipse Distribution
- * License is available at http://www.eclipse.org/org/documents/edl-v10.html.
- *
- * Contributors: Sierra Wireless - initial API and implementation
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
 package org.eclipse.leshan.client.observer;
 
@@ -25,7 +28,7 @@ import org.eclipse.leshan.core.request.UpdateRequest;
  *
  */
 public class LwM2mClientObserverDispatcher implements LwM2mClientObserver {
-    private CopyOnWriteArrayList<LwM2mClientObserver> observers = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<LwM2mClientObserver> observers = new CopyOnWriteArrayList<>();
 
     public void addObserver(LwM2mClientObserver observer) {
         observers.add(observer);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/send/DataSender.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/send/DataSender.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.send;
 
 /**

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/send/DataSenderManager.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/send/DataSenderManager.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.send;
 
 import java.util.HashMap;

--- a/leshan-client-core/src/test/java/org/eclipse/leshan/client/send/ManualDataSenderTest.java
+++ b/leshan-client-core/src/test/java/org/eclipse/leshan/client/send/ManualDataSenderTest.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.send;
 
 import java.time.Instant;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.demo;
 
 import java.text.SimpleDateFormat;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyLocation.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyLocation.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.demo;
 
 import java.util.Arrays;
@@ -21,7 +35,7 @@ public class MyLocation extends BaseInstanceEnabler {
 
     private float latitude;
     private float longitude;
-    private float scaleFactor;
+    private final float scaleFactor;
     private Date timestamp;
 
     public MyLocation() {

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/RandomTemperatureSensor.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.demo;
 
 import java.math.BigDecimal;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/interactive/InteractiveCommands.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/interactive/InteractiveCommands.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.demo.cli.interactive;
 
 import java.util.List;
@@ -63,8 +77,8 @@ public class InteractiveCommands extends JLineInteractiveCommands implements Run
 
     private static final Logger LOG = LoggerFactory.getLogger(InteractiveCommands.class);
 
-    private LeshanClient client;
-    private LwM2mModelRepository repository;
+    private final LeshanClient client;
+    private final LwM2mModelRepository repository;
 
     public InteractiveCommands(LeshanClient client, LwM2mModelRepository repository) {
         this.client = client;

--- a/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/CoapAsyncRequestObserver.java
+++ b/leshan-core-cf/src/main/java/org/eclipse/leshan/core/californium/CoapAsyncRequestObserver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Sierra Wireless and others.
+ * Copyright (c) 2016-2021 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -55,14 +55,14 @@ public class CoapAsyncRequestObserver extends AbstractRequestObserver {
     private final long timeoutInMs;
     private ScheduledFuture<?> cleaningTask;
     private boolean cancelled = false;
-    private ScheduledExecutorService executor;
+    private final ScheduledExecutorService executor;
 
     // The Californium API does not ensure that message callback are exclusive
     // meaning that you can get a onReponse call and a onCancel one.
     // The CoapAsyncRequestObserver ensure that you will receive only one event.
     // You get either 1 response or 1 error.
     // This boolean is used to ensure this.
-    private AtomicBoolean eventRaised = new AtomicBoolean(false);
+    private final AtomicBoolean eventRaised = new AtomicBoolean(false);
 
     private final AtomicBoolean responseTimedOut = new AtomicBoolean(false);
 

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/ShortErrorMessageHandler.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/ShortErrorMessageHandler.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.demo.cli;
 
 import java.io.PrintWriter;

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/LwM2mPathConverter.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/LwM2mPathConverter.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.demo.cli.converters;
 
 import org.eclipse.leshan.core.node.InvalidLwM2mPathException;

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/interactive/TerminalAppender.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/interactive/TerminalAppender.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.demo.cli.interactive;
 
 import java.io.IOException;

--- a/leshan-core/pom.xml
+++ b/leshan-core/pom.xml
@@ -61,6 +61,12 @@ Contributors:
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <excludes>org/eclipse/leshan/core/util/Base64.java,org/eclipse/leshan/core/util/BaseNCodec.java,org/eclipse/leshan/core/util/Hex.java,org/eclipse/leshan/core/util/RandomStringUtils.java,org/eclipse/leshan/core/util/StringUtils.java,org/eclipse/leshan/core/util/Validate.java,org/eclipse/leshan/core/util/datatype/ULong.java</excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <!-- Create test-jar to reuse it in integration-tests -->
         <artifactId>maven-jar-plugin</artifactId>
         <executions>

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/LinkParseException.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/LinkParseException.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.link;
 
 /**

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/oscore/AeadAlgorithm.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/oscore/AeadAlgorithm.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.oscore;
 
 import java.io.Serializable;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/oscore/HkdfAlgorithm.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/oscore/HkdfAlgorithm.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.oscore;
 
 import java.io.Serializable;

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/util/X509CertUtil.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/util/X509CertUtil.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.util;
 
 import java.net.InetAddress;

--- a/leshan-core/src/main/java/org/eclipse/leshan/senml/SenMLPack.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/senml/SenMLPack.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    http://www.eclipse.org/legal/epl-v10.html
+ *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *

--- a/leshan-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    http://www.eclipse.org/legal/epl-v10.html
+ *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *

--- a/leshan-core/src/main/java/org/eclipse/leshan/senml/json/jackson/SenMLJsonJacksonEncoderDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/senml/json/jackson/SenMLJsonJacksonEncoderDecoder.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    http://www.eclipse.org/legal/epl-v10.html
+ *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *

--- a/leshan-core/src/main/java/org/eclipse/leshan/senml/json/jackson/SenMLJsonRecordSerDes.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/senml/json/jackson/SenMLJsonRecordSerDes.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License v2.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
  *
  * The Eclipse Public License is available at
- *    http://www.eclipse.org/legal/epl-v10.html
+ *    http://www.eclipse.org/legal/epl-v20.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class SenMLJsonRecordSerDes extends JacksonJsonSerDes<SenMLRecord> {
-    private boolean allowNoValue;
+    private final boolean allowNoValue;
 
     public SenMLJsonRecordSerDes() {
         this(false);

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.link.attributes;
 
 import static org.junit.Assert.assertEquals;

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/util/TimestampUtilTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/util/TimestampUtilTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.util;
 
 import static org.junit.Assert.assertEquals;

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/util/X509CertUtilTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/util/X509CertUtilTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.util;
 
 import java.io.FileInputStream;

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/TestObservationListener.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/TestObservationListener.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.integration.tests.observe;
 
 import java.util.concurrent.CountDownLatch;

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/OscoreBootstrapListener.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/OscoreBootstrapListener.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.server.californium.bootstrap;
 
 import java.net.InetSocketAddress;

--- a/leshan-server-core-demo/src/main/java/org/eclipse/leshan/server/core/demo/cli/GeneralSection.java
+++ b/leshan-server-core-demo/src/main/java/org/eclipse/leshan/server/core/demo/cli/GeneralSection.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.server.core.demo.cli;
 
 import java.io.File;

--- a/leshan-server-core-demo/src/main/java/org/eclipse/leshan/server/core/demo/cli/converters/ServerCIDConverter.java
+++ b/leshan-server-core-demo/src/main/java/org/eclipse/leshan/server/core/demo/cli/converters/ServerCIDConverter.java
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2022    Sierra Wireless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.leshan.server.core.demo.cli.converters;
 
 import org.eclipse.leshan.core.demo.cli.converters.CIDConverter;


### PR DESCRIPTION
Following https://github.com/eclipse/leshan/pull/1313#discussion_r986657878, I find a way to check Java file header with Checkstyle using [**RegexpHeader** rule](https://checkstyle.org/config_header.html#RegexpHeader).  

Seeing the number of bad/missing header in current code base :scream:, I think we really need it :sweat_smile:. 

Note that, we currently don't check xml or javascript header but I guess could.

There is other maven plugins which could help and also provides goal to add header automatically. Not totally sure I feel the eclipse dual licenses could make their use not so easy : 
- https://www.mojohaus.org/license-maven-plugin/
- https://mycila.carbou.me/license-maven-plugin/