### PR TITLE
SenMLDecoder should raise CodecException instead of IllegalArgumentException

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLDecoder.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLDecoder.java
@@ -209,7 +209,7 @@ public class LwM2mNodeSenMLDecoder implements TimestampedNodeDecoder, MultiNodeD
             }
 
             return nodes.build();
-        } catch (SenMLException e) {
+        } catch (SenMLException | IllegalArgumentException e) {
             String hexValue = content != null ? Hex.encodeHexString(content) : "";
             throw new CodecException(e, "Unable to decode nodes : %s", hexValue, e);
         }


### PR DESCRIPTION
Re-throw IllegalArgumentException as CodecException

It aims to implement #1376 