### PR TITLE
Check Object Enabler Consistency at Client Creation

### DIFF
--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
@@ -89,10 +89,16 @@ public class LeshanClient implements LwM2mClient {
 
         Validate.notNull(endpoint);
         Validate.notEmpty(objectEnablers);
-
-        this.endpointsProvider = endpointsProvider;
+        Validate.notNull(checker);
 
         objectTree = createObjectTree(objectEnablers);
+        List<String> errors = checker.checkconfig(objectTree.getObjectEnablers());
+        if (errors != null) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid 'ObjectEnabler' Setting : \n - %s", String.join("\n - ", errors)));
+        }
+
+        this.endpointsProvider = endpointsProvider;
         rootEnabler = createRootEnabler(objectTree);
         observers = createClientObserverDispatcher();
         bootstrapHandler = createBoostrapHandler(objectTree, checker);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdateHandler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/RegistrationUpdateHandler.java
@@ -35,8 +35,8 @@ import org.eclipse.leshan.core.request.BindingMode;
  */
 public class RegistrationUpdateHandler {
 
-    private RegistrationEngine engine;
-    private BootstrapHandler bsHandler;
+    private final RegistrationEngine engine;
+    private final BootstrapHandler bsHandler;
 
     public RegistrationUpdateHandler(RegistrationEngine engine, BootstrapHandler bsHandler) {
         this.engine = engine;
@@ -104,7 +104,7 @@ public class RegistrationUpdateHandler {
                                 // handle supported binding changes
                                 EnumSet<BindingMode> bindingMode = null;
                                 if (path.getResourceId() == LwM2mId.DVC_SUPPORTED_BINDING) {
-                                    LwM2mObjectEnabler enabler = objecTree.getObjectEnabler(LwM2mId.SERVER);
+                                    LwM2mObjectEnabler enabler = objecTree.getObjectEnabler(LwM2mId.DEVICE);
                                     if (enabler != null) {
                                         bindingMode = ServersInfoExtractor.getDeviceSupportedBindingMode(enabler,
                                                 path.getObjectInstanceId());

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BaseBootstrapConsistencyChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/bootstrap/BaseBootstrapConsistencyChecker.java
@@ -15,8 +15,13 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.bootstrap;
 
+import static org.eclipse.leshan.core.LwM2mId.DEVICE;
+import static org.eclipse.leshan.core.LwM2mId.DVC_SUPPORTED_BINDING;
+import static org.eclipse.leshan.core.LwM2mId.SECURITY;
+import static org.eclipse.leshan.core.LwM2mId.SERVER;
+
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -25,6 +30,7 @@ import org.eclipse.leshan.client.servers.DmServerInfo;
 import org.eclipse.leshan.client.servers.ServerInfo;
 import org.eclipse.leshan.client.servers.ServersInfo;
 import org.eclipse.leshan.client.servers.ServersInfoExtractor;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,24 +43,83 @@ public abstract class BaseBootstrapConsistencyChecker implements BootstrapConsis
 
     @Override
     public List<String> checkconfig(Map<Integer, LwM2mObjectEnabler> objectEnablers) {
+        List<String> errors = new ArrayList<>();
+
+        // validate if mandatory object enabler are present.
+        checkMandatoryObjectEnabler(objectEnablers, errors);
+
+        // validate device object
+        if (errors.isEmpty()) {
+            checkDeviceObjectEnabler(objectEnablers, errors);
+        }
+
+        // validate bootstrap config.
+        if (errors.isEmpty()) {
+            checkBootstrapConfig(objectEnablers, errors);
+        }
+
+        if (!errors.isEmpty()) {
+            return errors;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Check mandatory object enabler are present
+     */
+    protected void checkMandatoryObjectEnabler(Map<Integer, LwM2mObjectEnabler> objectEnablers, List<String> errors) {
+        // Maybe it could make sense to use LwM2mModel and search for mandatory Object.
+        // But there is some issue with current LeshanClient design :
+        // See : https://github.com/eclipse/leshan/pull/1378#discussion_r1071426343
+
+        if (!objectEnablers.containsKey(SECURITY)) {
+            errors.add("Client MUST have ObjectEnabler for 'Security' Object (ID:0)");
+        }
+        if (!objectEnablers.containsKey(SERVER)) {
+            errors.add("Client MUST have ObjectEnabler for 'Server' Object (ID:1)");
+        }
+        if (!objectEnablers.containsKey(DEVICE)) {
+            errors.add("Client MUST have ObjectEnabler for 'Device' Object (ID:3)");
+        }
+    }
+
+    /**
+     * Check device object is valid
+     */
+    protected void checkDeviceObjectEnabler(Map<Integer, LwM2mObjectEnabler> objectEnablers, List<String> errors) {
+        LwM2mObjectEnabler deviceObjectEnabler = objectEnablers.get(DEVICE);
+        if (deviceObjectEnabler.getAvailableInstanceIds().size() != 1
+                || !deviceObjectEnabler.getAvailableInstanceIds().contains(0)) {
+            errors.add("'Device' object MUST have 1 object instance with instance ID : 0");
+        } else if (!deviceObjectEnabler.getAvailableResourceIds(0).contains(DVC_SUPPORTED_BINDING)) {
+            errors.add("'Device' object MUST support mandatory ressource 'Supported Binding' (ID:16)");
+        } else {
+            EnumSet<BindingMode> deviceSupportedBindingMode = ServersInfoExtractor
+                    .getDeviceSupportedBindingMode(deviceObjectEnabler, 0);
+            if (deviceSupportedBindingMode == null) {
+                errors.add("'Supported Binding' (ID:16) resource from 'Device' object (ID:3) MUST have value");
+            }
+        }
+    }
+
+    /**
+     * Check if config is valid enough to bootstrap the client
+     */
+    protected void checkBootstrapConfig(Map<Integer, LwM2mObjectEnabler> objectEnablers, List<String> errors) {
         try {
             ServersInfo info = ServersInfoExtractor.getInfo(objectEnablers, true);
 
-            List<String> errors = new ArrayList<>();
             if (info.bootstrap != null) {
                 checkBootstrapServerInfo(info.bootstrap, errors);
             }
             for (DmServerInfo server : info.deviceManagements.values()) {
                 checkDeviceMangementServerInfo(server, errors);
             }
-            if (!errors.isEmpty()) {
-                return errors;
-            }
         } catch (RuntimeException e) {
             LOG.debug(e.getMessage(), e);
-            return Arrays.asList(e.getMessage());
+            errors.add(e.getMessage());
         }
-        return null;
     }
 
     /**


### PR DESCRIPTION
The idea is to provide better feedback to user, if they try to create client without valid Object Enablers.

This idea was triggered by https://github.com/sbernard31/benchmark-clients/issues/8

The is implemented in this PR by reusing BootstrapConsistencyChecker which is mainly responsible to check the consistency state of the client after at the end of a bootstrap session. I guess it could also make sense to check it at creation ?

E.g. of error you can get at creation : 
```
Exception in thread "main" java.lang.IllegalArgumentException: Invalid 'ObjectEnabler' Setting : 
 - Client MUST have ObjectEnabler for 'Server' Object (ID:1)
 - Client MUST have ObjectEnabler for 'Device' Object (ID:3)
	at org.eclipse.leshan.client.LeshanClient.<init>(LeshanClient.java:97)
	at org.eclipse.leshan.client.LeshanClientBuilder.createLeshanClient(LeshanClientBuilder.java:329)
	at org.eclipse.leshan.client.LeshanClientBuilder.build(LeshanClientBuilder.java:294)
	at TestClient.main(TestClient.java:32)
```