### PR TITLE
Avoid to call registrationStore.removeObservation with null registration ID

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/endpoint/EndpointUriUtil.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/endpoint/EndpointUriUtil.java
@@ -19,6 +19,8 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.eclipse.leshan.core.util.Validate;
+
 public class EndpointUriUtil {
 
     public static URI createUri(String scheme, String host, int port) {
@@ -47,5 +49,21 @@ public class EndpointUriUtil {
 
     public static InetSocketAddress getSocketAddr(URI uri) {
         return new InetSocketAddress(uri.getHost(), uri.getPort());
+    }
+
+    public static void validateURI(URI uri) throws IllegalArgumentException {
+        Validate.notNull(uri);
+
+        if (uri.getScheme() == null) {
+            throw new IllegalArgumentException("URI Scheme MUST NOT be null");
+        }
+
+        if (uri.getHost() == null) {
+            throw new IllegalArgumentException("URI Host MUST NOT be null");
+        }
+
+        if (uri.getPort() == -1) {
+            throw new IllegalArgumentException("URI Post MUST NOT be undefined");
+        }
     }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.integration.tests.server.redis;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
@@ -157,6 +158,24 @@ public class RedisRegistrationStoreTest {
         assertTrue(leshanObservation instanceof CompositeObservation);
         CompositeObservation observation = (CompositeObservation) leshanObservation;
         assertEquals(examplePaths, observation.getPaths());
+    }
+
+    @Test
+    public void remove_observation() {
+        // given
+        givenASimpleRegistration(lifetime);
+        store.addRegistration(registration);
+
+        org.eclipse.californium.core.observe.Observation observationToStore = prepareCoapObservationOnSingle("/1/2/3");
+        observationStore.put(aToken, observationToStore);
+
+        // when
+        observationStore.remove(aToken);
+
+        // then
+        Observation leshanObservation = store.getObservation(registrationId,
+                new ObservationIdentifier(aToken.getBytes()));
+        assertNull(leshanObservation);
     }
 
     private void givenASimpleRegistration(Long lifetime) {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
@@ -35,6 +35,7 @@ import org.eclipse.californium.core.network.serialization.UdpDataParser;
 import org.eclipse.californium.core.network.serialization.UdpDataSerializer;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.leshan.core.californium.ObserveUtil;
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.observation.CompositeObservation;
@@ -162,7 +163,7 @@ public class RedisRegistrationStoreTest {
         Registration.Builder builder = new Registration.Builder(registrationId, ep, Identity.unsecure(address, port));
 
         registration = builder.lifeTimeInSec(lifetime).smsNumber(sms).bindingMode(binding).objectLinks(objectLinks)
-                .build();
+                .lastEndpointUsed(EndpointUriUtil.createUri("coap://localhost:5683")).build();
     }
 
     private org.eclipse.californium.core.observe.Observation prepareCoapObservationOnSingle(String path) {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
@@ -160,10 +160,11 @@ public class RedisRegistrationStoreTest {
     }
 
     private void givenASimpleRegistration(Long lifetime) {
-        Registration.Builder builder = new Registration.Builder(registrationId, ep, Identity.unsecure(address, port));
+        Registration.Builder builder = new Registration.Builder(registrationId, ep, Identity.unsecure(address, port),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
 
         registration = builder.lifeTimeInSec(lifetime).smsNumber(sms).bindingMode(binding).objectLinks(objectLinks)
-                .lastEndpointUsed(EndpointUriUtil.createUri("coap://localhost:5683")).build();
+                .build();
     }
 
     private org.eclipse.californium.core.observe.Observation prepareCoapObservationOnSingle(String path) {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStore.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStore.java
@@ -85,15 +85,24 @@ public class LwM2mObservationStore implements ObservationStore {
 
     @Override
     public void remove(Token token) {
-        org.eclipse.leshan.core.observation.Observation removedObservation = registrationStore.removeObservation(null,
-                new ObservationIdentifier(token.getBytes()));
-        notificationListener.cancelled(removedObservation);
+        // try to find observation for given token
+        org.eclipse.leshan.core.observation.Observation observation = registrationStore
+                .getObservation(new ObservationIdentifier(token.getBytes()));
+
+        if (observation != null) {
+            // try to remove observation
+            org.eclipse.leshan.core.observation.Observation removedObservation = registrationStore
+                    .removeObservation(observation.getRegistrationId(), new ObservationIdentifier(token.getBytes()));
+            if (removedObservation != null) {
+                notificationListener.cancelled(removedObservation);
+            }
+        }
     }
 
     @Override
     public Observation get(Token token) {
-        org.eclipse.leshan.core.observation.Observation observation = registrationStore.getObservation(null,
-                new ObservationIdentifier(token.getBytes()));
+        org.eclipse.leshan.core.observation.Observation observation = registrationStore
+                .getObservation(new ObservationIdentifier(token.getBytes()));
         if (observation == null) {
             return null;
         } else {

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerTest.java
@@ -118,9 +118,9 @@ public class LeshanServerTest {
     }
 
     private void forceThreadsCreation(LeshanServer server) {
-        Registration reg = new Registration.Builder("id", "endpoint", Identity.unsecure(new InetSocketAddress(5555)))
-                .bindingMode(EnumSet.of(BindingMode.U, BindingMode.Q))
-                .lastEndpointUsed(server.getEndpoint(Protocol.COAP).getURI()).build();
+        Registration reg = new Registration.Builder("id", "endpoint", Identity.unsecure(new InetSocketAddress(5555)),
+                server.getEndpoint(Protocol.COAP).getURI()).bindingMode(EnumSet.of(BindingMode.U, BindingMode.Q))
+                        .build();
         // Force timer thread creation of preference service.
         if (server.getPresenceService() != null) {
             ((PresenceServiceImpl) server.getPresenceService()).setAwake(reg);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStoreTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStoreTest.java
@@ -34,6 +34,7 @@ import org.eclipse.californium.core.network.serialization.UdpDataParser;
 import org.eclipse.californium.core.network.serialization.UdpDataSerializer;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.leshan.core.californium.ObserveUtil;
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.observation.CompositeObservation;
@@ -194,7 +195,8 @@ public class LwM2mObservationStoreTest {
 
     private void givenASimpleRegistration(Long lifetime) {
 
-        Registration.Builder builder = new Registration.Builder(registrationId, ep, Identity.unsecure(address, port));
+        Registration.Builder builder = new Registration.Builder(registrationId, ep, Identity.unsecure(address, port),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
 
         registration = builder.lifeTimeInSec(lifetime).smsNumber(sms).bindingMode(binding).objectLinks(objectLinks)
                 .build();

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStoreTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStoreTest.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.server.californium.observation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
@@ -157,6 +158,24 @@ public class LwM2mObservationStoreTest {
         assertTrue(leshanObservation instanceof CompositeObservation);
         CompositeObservation observation = (CompositeObservation) leshanObservation;
         assertEquals(examplePaths, observation.getPaths());
+    }
+
+    @Test
+    public void remove_observation() {
+        // given
+        givenASimpleRegistration(lifetime);
+        store.addRegistration(registration);
+
+        org.eclipse.californium.core.observe.Observation observationToStore = prepareCoapCompositeObservation();
+        observationStore.put(exampleToken, observationToStore);
+
+        // when
+        observationStore.remove(exampleToken);
+
+        // then
+        Observation leshanObservation = store.getObservation(registrationId,
+                new ObservationIdentifier(exampleToken.getBytes()));
+        assertNull(leshanObservation);
     }
 
     private org.eclipse.californium.core.observe.Observation prepareCoapObservation() {

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/ObservationServiceTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/ObservationServiceTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.node.LwM2mPath;
@@ -73,7 +74,8 @@ public class ObservationServiceTest {
 
     private Registration givenASimpleRegistration() throws UnknownHostException {
         Registration.Builder builder = new Registration.Builder("4711", "urn:endpoint",
-                Identity.unsecure(InetAddress.getLocalHost(), 23452));
+                Identity.unsecure(InetAddress.getLocalHost(), 23452),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
         return builder.lifeTimeInSec(10000L).bindingMode(EnumSet.of(BindingMode.U))
                 .objectLinks(new Link[] { new Link("/3") }).build();
     }
@@ -183,7 +185,8 @@ public class ObservationServiceTest {
         Registration.Builder builder;
         try {
             builder = new Registration.Builder(registrationId, registrationId + "_ep",
-                    Identity.unsecure(InetAddress.getLocalHost(), 10000));
+                    Identity.unsecure(InetAddress.getLocalHost(), 10000),
+                    EndpointUriUtil.createUri("coap://localhost:5683"));
             return builder.build();
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/request/CoapRequestBuilderTest.java
@@ -28,6 +28,7 @@ import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.leshan.core.californium.identity.DefaultCoapIdentityHandler;
 import org.eclipse.leshan.core.californium.identity.IdentityHandler;
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.link.attributes.ResourceTypeAttribute;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
@@ -81,7 +82,8 @@ public class CoapRequestBuilderTest {
 
     private Registration newRegistration(String rootpath) throws UnknownHostException {
         Builder b = new Registration.Builder("regid", "endpoint",
-                Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354));
+                Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
         b.extractDataFromObjectLink(true);
         if (rootpath != null) {
             b.objectLinks(new Link[] { new Link(rootpath, new ResourceTypeAttribute("oma.lwm2m")) });

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/InMemoryRegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/InMemoryRegistrationStore.java
@@ -297,8 +297,21 @@ public class InMemoryRegistrationStore implements RegistrationStore, Startable, 
         try {
             lock.readLock().lock();
             Observation observation = unsafeGetObservation(observationId);
-            if (observation != null
-                    && (registrationId == null || registrationId.equals(observation.getRegistrationId()))) {
+            if (observation != null && registrationId.equals(observation.getRegistrationId())) {
+                return observation;
+            }
+            return null;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Observation getObservation(ObservationIdentifier observationId) {
+        try {
+            lock.readLock().lock();
+            Observation observation = unsafeGetObservation(observationId);
+            if (observation != null) {
                 return observation;
             }
             return null;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/InMemoryRegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/InMemoryRegistrationStore.java
@@ -281,8 +281,7 @@ public class InMemoryRegistrationStore implements RegistrationStore, Startable, 
         try {
             lock.writeLock().lock();
             Observation observation = unsafeGetObservation(observationId);
-            if (observation != null
-                    && (registrationId == null || registrationId.equals(observation.getRegistrationId()))) {
+            if (observation != null && registrationId.equals(observation.getRegistrationId())) {
                 unsafeRemoveObservation(observationId);
                 return observation;
             }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -100,11 +100,6 @@ public class Registration {
 
     protected Registration(Builder builder) {
 
-        Validate.notNull(builder.registrationId);
-        Validate.notEmpty(builder.endpoint);
-        Validate.notNull(builder.identity);
-        EndpointUriUtil.validateURI(builder.lastEndpointUsed);
-
         // mandatory params
         id = builder.registrationId;
         identity = builder.identity;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -33,6 +33,7 @@ import java.util.TreeSet;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.link.attributes.Attributes;
 import org.eclipse.leshan.core.link.attributes.ContentFormatAttribute;
@@ -102,7 +103,7 @@ public class Registration {
         Validate.notNull(builder.registrationId);
         Validate.notEmpty(builder.endpoint);
         Validate.notNull(builder.identity);
-        Validate.notNull(builder.lastEndpointUsed);
+        EndpointUriUtil.validateURI(builder.lastEndpointUsed);
 
         // mandatory params
         id = builder.registrationId;
@@ -537,8 +538,7 @@ public class Registration {
             Validate.notNull(registrationId);
             Validate.notEmpty(endpoint);
             Validate.notNull(identity);
-            Validate.notNull(lastEndpointUsed);
-            // TODO we should maybe do some validation on URI
+            EndpointUriUtil.validateURI(lastEndpointUsed);
 
             this.registrationId = registrationId;
             this.endpoint = endpoint;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -102,11 +102,13 @@ public class Registration {
         Validate.notNull(builder.registrationId);
         Validate.notEmpty(builder.endpoint);
         Validate.notNull(builder.identity);
+        Validate.notNull(builder.lastEndpointUsed);
 
         // mandatory params
         id = builder.registrationId;
         identity = builder.identity;
         endpoint = builder.endpoint;
+        lastEndpointUsed = builder.lastEndpointUsed;
 
         // object links related params
         objectLinks = builder.objectLinks;
@@ -126,8 +128,6 @@ public class Registration {
         additionalRegistrationAttributes = builder.additionalRegistrationAttributes;
 
         applicationData = builder.applicationData;
-
-        lastEndpointUsed = builder.lastEndpointUsed;
     }
 
     public String getId() {
@@ -484,6 +484,7 @@ public class Registration {
         private final String registrationId;
         private final String endpoint;
         private final Identity identity;
+        private final URI lastEndpointUsed;
 
         private Date registrationDate;
         private Date lastUpdate;
@@ -499,7 +500,6 @@ public class Registration {
         private Set<LwM2mPath> availableInstances;
         private Map<String, String> additionalRegistrationAttributes;
         private Map<String, String> applicationData;
-        private URI lastEndpointUsed;
 
         // builder setting
         private boolean extractData; // if true extract data from objectLinks
@@ -510,6 +510,7 @@ public class Registration {
             registrationId = registration.id;
             identity = registration.identity;
             endpoint = registration.endpoint;
+            lastEndpointUsed = registration.lastEndpointUsed;
 
             // object links related params
             objectLinks = registration.objectLinks;
@@ -529,17 +530,20 @@ public class Registration {
             additionalRegistrationAttributes = registration.additionalRegistrationAttributes;
 
             applicationData = registration.applicationData;
-            lastEndpointUsed = registration.lastEndpointUsed;
         }
 
-        public Builder(String registrationId, String endpoint, Identity identity) {
+        public Builder(String registrationId, String endpoint, Identity identity, URI lastEndpointUsed) {
 
             Validate.notNull(registrationId);
             Validate.notEmpty(endpoint);
             Validate.notNull(identity);
+            Validate.notNull(lastEndpointUsed);
+            // TODO we should maybe do some validation on URI
+
             this.registrationId = registrationId;
             this.endpoint = endpoint;
             this.identity = identity;
+            this.lastEndpointUsed = lastEndpointUsed;
         }
 
         public Builder extractDataFromObjectLink(boolean extract) {
@@ -622,11 +626,6 @@ public class Registration {
 
         public Builder applicationData(Map<String, String> applicationData) {
             this.applicationData = applicationData;
-            return this;
-        }
-
-        public Builder lastEndpointUsed(URI lastEndpointUsed) {
-            this.lastEndpointUsed = lastEndpointUsed;
             return this;
         }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationHandler.java
@@ -58,15 +58,15 @@ public class RegistrationHandler {
 
         // Create Registration from RegisterRequest
         Registration.Builder builder = new Registration.Builder(
-                registrationIdProvider.getRegistrationId(registerRequest), registerRequest.getEndpointName(), sender);
+                registrationIdProvider.getRegistrationId(registerRequest), registerRequest.getEndpointName(), sender,
+                endpointUsed);
         builder.extractDataFromObjectLink(true);
 
         builder.lwM2mVersion(LwM2mVersion.get(registerRequest.getLwVersion()))
                 .lifeTimeInSec(registerRequest.getLifetime()).bindingMode(registerRequest.getBindingMode())
                 .queueMode(registerRequest.getQueueMode()).objectLinks(registerRequest.getObjectLinks())
                 .smsNumber(registerRequest.getSmsNumber()).registrationDate(new Date()).lastUpdate(new Date())
-                .additionalRegistrationAttributes(registerRequest.getAdditionalAttributes())
-                .lastEndpointUsed(endpointUsed);
+                .additionalRegistrationAttributes(registerRequest.getAdditionalAttributes());
 
         Registration registrationToApproved = builder.build();
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -114,6 +114,11 @@ public interface RegistrationStore {
     Observation getObservation(String registrationId, ObservationIdentifier observationId);
 
     /**
+     * Get the observation for the given observationId
+     */
+    Observation getObservation(ObservationIdentifier observationId);
+
+    /**
      * Remove the observation for the given registration with the given observationId
      */
     Observation removeObservation(String registrationId, ObservationIdentifier observationId);

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
@@ -92,7 +92,7 @@ public class RegistrationUpdate {
         Date lastUpdate = new Date();
 
         Registration.Builder builder = new Registration.Builder(registration.getId(), registration.getEndpoint(),
-                identity);
+                identity, registration.getLastEndpointUsed());
         builder.extractDataFromObjectLink(this.objectLinks != null); // we parse object link only if there was updated.
 
         builder.lwM2mVersion(registration.getLwM2mVersion()).lifeTimeInSec(lifeTimeInSec).smsNumber(smsNumber)
@@ -101,8 +101,7 @@ public class RegistrationUpdate {
                 .additionalRegistrationAttributes(additionalAttributes).rootPath(registration.getRootPath())
                 .supportedContentFormats(registration.getSupportedContentFormats())
                 .supportedObjects(registration.getSupportedObject())
-                .availableInstances(registration.getAvailableInstances()).applicationData(applicationData)
-                .lastEndpointUsed(registration.getLastEndpointUsed());
+                .availableInstances(registration.getAvailableInstances()).applicationData(applicationData);
 
         return builder.build();
     }

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/PresenceServiceTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/queue/PresenceServiceTest.java
@@ -23,6 +23,7 @@ import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.util.EnumSet;
 
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.server.registration.Registration;
@@ -33,8 +34,8 @@ import org.junit.Test;
  *
  */
 public class PresenceServiceTest {
-    private ClientAwakeTimeProvider awakeTimeProvider = new StaticClientAwakeTimeProvider();
-    private PresenceServiceImpl presenceService = new PresenceServiceImpl(awakeTimeProvider);
+    private final ClientAwakeTimeProvider awakeTimeProvider = new StaticClientAwakeTimeProvider();
+    private final PresenceServiceImpl presenceService = new PresenceServiceImpl(awakeTimeProvider);
 
     @Test
     public void testSetOnlineForNonQueueMode() throws Exception {
@@ -65,7 +66,8 @@ public class PresenceServiceTest {
 
     private Registration givenASimpleClient() throws UnknownHostException {
         Registration.Builder builder = new Registration.Builder("ID", "urn:client",
-                Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354));
+                Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
 
         Registration reg = builder.build();
         presenceService.setAwake(reg);
@@ -75,7 +77,8 @@ public class PresenceServiceTest {
     private Registration givenASimpleClientWithQueueMode() throws UnknownHostException {
 
         Registration.Builder builder = new Registration.Builder("ID", "urn:client",
-                Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354));
+                Identity.unsecure(Inet4Address.getLoopbackAddress(), 12354),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
 
         Registration reg = builder.bindingMode(EnumSet.of(BindingMode.U, BindingMode.Q)).build();
         presenceService.setAwake(reg);

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/InMemoryRegistrationStoreTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/InMemoryRegistrationStoreTest.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.EnumSet;
 
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.Identity;
@@ -94,7 +95,8 @@ public class InMemoryRegistrationStoreTest {
 
     private void givenASimpleRegistration(Long lifetime) {
 
-        Registration.Builder builder = new Registration.Builder(registrationId, ep, Identity.unsecure(address, port));
+        Registration.Builder builder = new Registration.Builder(registrationId, ep, Identity.unsecure(address, port),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
 
         registration = builder.lifeTimeInSec(lifetime).smsNumber(sms).bindingMode(binding).objectLinks(objectLinks)
                 .build();

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationSortObjectLinksTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationSortObjectLinksTest.java
@@ -20,6 +20,7 @@ package org.eclipse.leshan.server.registration;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.request.Identity;
 import org.junit.Assert;
@@ -35,7 +36,8 @@ public class RegistrationSortObjectLinksTest {
         objs[2] = null;
 
         Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",
-                Identity.unsecure(Inet4Address.getLocalHost(), 1)).objectLinks(objs);
+                Identity.unsecure(Inet4Address.getLocalHost(), 1), EndpointUriUtil.createUri("coap://localhost:5683"))
+                        .objectLinks(objs);
 
         Registration r = builder.build();
 

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.leshan.core.LwM2m.Version;
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.LinkParseException;
 import org.eclipse.leshan.core.link.LinkParser;
 import org.eclipse.leshan.core.link.lwm2m.DefaultLwM2mLinkParser;
@@ -241,7 +242,8 @@ public class RegistrationTest {
 
     private Registration given_a_registration_with_object_link_like(String objectLinks) throws LinkParseException {
         Builder builder = new Registration.Builder("id", "endpoint",
-                Identity.unsecure(InetSocketAddress.createUnresolved("localhost", 0)));
+                Identity.unsecure(InetSocketAddress.createUnresolved("localhost", 0)),
+                EndpointUriUtil.createUri("coap://localhost:5683"));
         builder.extractDataFromObjectLink(true);
         builder.objectLinks(linkParser.parseCoreLinkFormat(objectLinks.getBytes()));
         return builder.build();

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
@@ -19,6 +19,7 @@ import java.net.Inet4Address;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.server.queue.PresenceService;
 import org.junit.Assert;
@@ -33,7 +34,7 @@ public class RegistrationUpdateTest {
     @Test
     public void testAdditionalAttributesUpdate() throws Exception {
         Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",
-                Identity.unsecure(Inet4Address.getLocalHost(), 1));
+                Identity.unsecure(Inet4Address.getLocalHost(), 1), EndpointUriUtil.createUri("coap://localhost:5683"));
 
         Map<String, String> additionalAttributes = new HashMap<String, String>();
         additionalAttributes.put("x", "1");
@@ -67,7 +68,7 @@ public class RegistrationUpdateTest {
     public void testApplicationDataUpdate() throws Exception {
 
         Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",
-                Identity.unsecure(Inet4Address.getLocalHost(), 1));
+                Identity.unsecure(Inet4Address.getLocalHost(), 1), EndpointUriUtil.createUri("coap://localhost:5683"));
         Map<String, String> appData = new HashMap<String, String>();
         appData.put("x", "1");
         appData.put("y", "10");

--- a/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/RedisRegistrationStore.java
+++ b/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/RedisRegistrationStore.java
@@ -587,11 +587,17 @@ public class RedisRegistrationStore implements RegistrationStore, Startable, Sto
     public Observation getObservation(String registrationId, ObservationIdentifier observationId) {
         try (Jedis j = pool.getResource()) {
             Observation observation = unsafeGetObservation(j, observationId);
-            if (observation != null
-                    && (registrationId == null || registrationId.equals(observation.getRegistrationId()))) {
+            if (observation != null && registrationId.equals(observation.getRegistrationId())) {
                 return observation;
             }
             return null;
+        }
+    }
+
+    @Override
+    public Observation getObservation(ObservationIdentifier observationId) {
+        try (Jedis j = pool.getResource()) {
+            return unsafeGetObservation(j, observationId);
         }
     }
 

--- a/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
+++ b/leshan-server-redis/src/main/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDes.java
@@ -155,16 +155,17 @@ public class RegistrationSerDes {
     }
 
     public Registration deserialize(JsonNode jObj) {
-        Registration.Builder b = new Registration.Builder(jObj.get("regId").asText(), jObj.get("ep").asText(),
-                IdentitySerDes.deserialize(jObj.get("identity")));
-
+        URI lastEndpointUsed;
         try {
-            b.lastEndpointUsed(new URI(jObj.get("epUri").asText()));
+            lastEndpointUsed = new URI(jObj.get("epUri").asText());
         } catch (URISyntaxException e1) {
             throw new IllegalStateException(
                     String.format("Unable to deserialize last endpoint used URI %s of registration %s/%s",
                             jObj.get("epUri").asText(), jObj.get("regId").asText(), jObj.get("ep").asText()));
         }
+
+        Registration.Builder b = new Registration.Builder(jObj.get("regId").asText(), jObj.get("ep").asText(),
+                IdentitySerDes.deserialize(jObj.get("identity")), lastEndpointUsed);
 
         b.bindingMode(BindingMode.parse(jObj.get("bnd").asText()));
         if (jObj.get("qm") != null)

--- a/leshan-server-redis/src/test/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDesTest.java
+++ b/leshan-server-redis/src/test/java/org/eclipse/leshan/server/redis/serialization/RegistrationSerDesTest.java
@@ -19,12 +19,11 @@ package org.eclipse.leshan.server.redis.serialization;
 import static org.junit.Assert.assertEquals;
 
 import java.net.Inet4Address;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.link.attributes.AttributeSet;
 import org.eclipse.leshan.core.link.attributes.ContentFormatAttribute;
@@ -42,7 +41,7 @@ public class RegistrationSerDesTest {
     private final RegistrationSerDes registrationSerDes = new RegistrationSerDes();
 
     @Test
-    public void ser_and_des_are_equals() throws URISyntaxException {
+    public void ser_and_des_are_equals() {
         Link[] objs = new Link[2];
         AttributeSet attrs = new AttributeSet( //
                 new UnquotedStringAttribute("us", "12"), //
@@ -54,9 +53,9 @@ public class RegistrationSerDesTest {
         objs[1] = new Link("/0/2");
 
         Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",
-                Identity.unsecure(Inet4Address.getLoopbackAddress(), 1)).objectLinks(objs).rootPath("/")
+                Identity.unsecure(Inet4Address.getLoopbackAddress(), 1),
+                EndpointUriUtil.createUri("coap://localhost:5683")).objectLinks(objs).rootPath("/")
                         .supportedContentFormats(ContentFormat.TLV, ContentFormat.TEXT);
-        builder.lastEndpointUsed(new URI("coap://localhost:5683"));
         builder.registrationDate(new Date(100L));
         builder.extractDataFromObjectLink(true);
         builder.lastUpdate(new Date(101L));
@@ -69,7 +68,7 @@ public class RegistrationSerDesTest {
     }
 
     @Test
-    public void ser_and_des_are_equals_with_app_data() throws URISyntaxException {
+    public void ser_and_des_are_equals_with_app_data() {
         Link[] objs = new Link[2];
         AttributeSet attrs = new AttributeSet( //
                 new UnquotedStringAttribute("us", "12"), //
@@ -85,10 +84,10 @@ public class RegistrationSerDesTest {
         appData.put("null", null);
 
         Registration.Builder builder = new Registration.Builder("registrationId", "endpoint",
-                Identity.unsecure(Inet4Address.getLoopbackAddress(), 1)).objectLinks(objs).rootPath("/")
+                Identity.unsecure(Inet4Address.getLoopbackAddress(), 1),
+                EndpointUriUtil.createUri("coap://localhost:5683")).objectLinks(objs).rootPath("/")
                         .supportedContentFormats(ContentFormat.TLV, ContentFormat.TEXT).applicationData(appData);
 
-        builder.lastEndpointUsed(new URI("coap://localhost:5683"));
         builder.registrationDate(new Date(100L));
         builder.lastUpdate(new Date(101L));
         builder.extractDataFromObjectLink(true);


### PR DESCRIPTION
This aims to fix #1384

But working on this, I also polish some details which sounds not so good to me : 
- NPE in RedisRegistrationStoreTest
- lastEndpointUsed in Registration should be mandatory
- add validation on lastEndpointUsed 
- Remove redundant validation in Registration Constructor
- Avoid any Registration call with `null` value for registration ID. 

