### PR TITLE
Experiment new design for integration tests.

### DIFF
--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -40,6 +40,11 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-server-redis</artifactId>
     </dependency>
     <dependency>

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisRegistrationTest2.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisRegistrationTest2.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.server.redis.RedisRegistrationStore;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.util.Pool;
+
+public class RedisRegistrationTest2 extends RegistrationTest2 {
+
+    @Override
+    protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+        LeshanTestServerBuilder builder = super.givenServerUsing(givenProtocol);
+
+        // Create redis store
+        Pool<Jedis> jedis = createJedisPool();
+        builder.setRegistrationStore(new RedisRegistrationStore(jedis));
+
+        return builder;
+    }
+
+    private Pool<Jedis> createJedisPool() {
+        String redisURI = System.getenv("REDIS_URI");
+        if (redisURI != null && !redisURI.isEmpty()) {
+            return new JedisPool(redisURI);
+        } else {
+            return new JedisPool();
+        }
+    }
+
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisRegistrationTest3.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisRegistrationTest3.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.server.redis.RedisRegistrationStore;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.util.Pool;
+
+public abstract class RedisRegistrationTest3 extends RegistrationTest3 {
+
+    public RedisRegistrationTest3(Protocol protocol, String serverProvider, String clientProvider) {
+        super(protocol, serverProvider, clientProvider);
+    }
+
+    public static class CoAPCaliforniumCalifornium extends RedisRegistrationTest3 {
+        public CoAPCaliforniumCalifornium() {
+            super(Protocol.COAP, "Californium", "Californium");
+        }
+    }
+
+    public static class CoAPCaliforniumJavaCoap extends RedisRegistrationTest3 {
+        public CoAPCaliforniumJavaCoap() {
+            super(Protocol.COAP, "Californium", "java-coap");
+        }
+    }
+
+    @Override
+    protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+        LeshanTestServerBuilder builder = super.givenServerUsing(givenProtocol);
+
+        // Create redis store
+        Pool<Jedis> jedis = createJedisPool();
+        builder.setRegistrationStore(new RedisRegistrationStore(jedis));
+
+        return builder;
+    }
+
+    private Pool<Jedis> createJedisPool() {
+        String redisURI = System.getenv("REDIS_URI");
+        if (redisURI != null && !redisURI.isEmpty()) {
+            return new JedisPool(redisURI);
+        } else {
+            return new JedisPool();
+        }
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisRegistrationTest4.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RedisRegistrationTest4.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.server.redis.RedisRegistrationStore;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.util.Pool;
+
+public abstract class RedisRegistrationTest4 extends RegistrationTest3 {
+
+    public RedisRegistrationTest4(Protocol protocol, String serverProvider, String clientProvider) {
+        super(protocol, serverProvider, clientProvider);
+    }
+
+    public static class CoAPCaliforniumCalifornium extends RedisRegistrationTest4 {
+        public CoAPCaliforniumCalifornium() {
+            super(Protocol.COAP, "Californium", "Californium");
+        }
+    }
+
+    public static class CoAPCaliforniumJavaCoap extends RedisRegistrationTest4 {
+        public CoAPCaliforniumJavaCoap() {
+            super(Protocol.COAP, "Californium", "java-coap");
+        }
+    }
+
+    @Override
+    protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+        LeshanTestServerBuilder builder = super.givenServerUsing(givenProtocol);
+
+        // Create redis store
+        Pool<Jedis> jedis = createJedisPool();
+        builder.setRegistrationStore(new RedisRegistrationStore(jedis));
+
+        return builder;
+    }
+
+    private Pool<Jedis> createJedisPool() {
+        String redisURI = System.getenv("REDIS_URI");
+        if (redisURI != null && !redisURI.isEmpty()) {
+            return new JedisPool(redisURI);
+        } else {
+            return new JedisPool();
+        }
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest2.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest2.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
+ *     Michał Wadowski (Orange) - Improved compliance with rfc6690
+ *******************************************************************************/
+
+package org.eclipse.leshan.integration.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.leshan.integration.tests.util.IntegrationTestHelper.LIFETIME;
+import static org.eclipse.leshan.integration.tests.util.IntegrationTestHelper.linkParser;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.LinkParseException;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.integration.tests.util.junit5.extensions.BeforeEachParameterizedResolver;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(BeforeEachParameterizedResolver.class)
+public class RegistrationTest2 {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    @ParameterizedTest(name = "{0} - Client using {1} - Server using {2}")
+    @MethodSource("transports")
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface TestAllTransportLayer {
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
+        return Stream.of(//
+                // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
+                arguments(Protocol.COAP, "Californium", "Californium"), //
+                arguments(Protocol.COAP, "Californium", "java-coap") //
+        );
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+
+    LeshanTestServer server;
+    LeshanTestClientBuilder givenClient;
+    LeshanTestClient client;
+
+    @BeforeEach
+    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+        server = givenServerUsing(givenProtocol).with(givenServerEndpointProvider).build();
+        server.start();
+        givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider).connectingTo(server);
+    }
+
+    @AfterEach
+    public void stop() throws InterruptedException {
+        if (client != null)
+            client.destroy(false);
+        if (server != null)
+            server.destroy();
+    }
+
+    protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+        return new LeshanTestServerBuilder(givenProtocol);
+    }
+
+    /*---------------------------------/
+     *  Tests
+     * -------------------------------*/
+    @TestAllTransportLayer
+    public void register_update_deregister(Protocol protocol, String clientEndpointProvider,
+            String serverEndpointProvider) throws LinkParseException {
+
+        // Check client is not registered
+        client = givenClient.build();
+        assertThat(client).isNotRegisteredAt(server);
+
+        // Start it and wait for registration
+        client.start();
+        server.waitForNewRegistrationOf(client);
+        client.waitForRegistrationTo(server);
+
+        // Check client is well registered
+        assertThat(client).isRegisteredAt(server);
+        Registration registration = server.getRegistrationFor(client);
+        assertThat(registration.getObjectLinks()) //
+                .isEqualTo(linkParser.parseCoreLinkFormat(
+                        "</>;rt=\"oma.lwm2m\";ct=\"60 110 112 1542 1543 11542 11543\",</1>;ver=1.1,</1/0>,</2>,</3>;ver=1.1,</3/0>,</3442/0>"
+                                .getBytes()));
+
+        // Check for update
+        client.waitForUpdateTo(server, LIFETIME, TimeUnit.SECONDS);
+        server.waitForUpdateOf(registration);
+        assertThat(client).isRegisteredAt(server);
+
+        // Check deregistration
+        client.stop(true);
+        server.waitForDeregistrationOf(registration);
+        assertThat(client).isNotRegisteredAt(server);
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest3.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest3.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
+ *     Michał Wadowski (Orange) - Improved compliance with rfc6690
+ *******************************************************************************/
+
+package org.eclipse.leshan.integration.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.leshan.integration.tests.util.IntegrationTestHelper.LIFETIME;
+import static org.eclipse.leshan.integration.tests.util.IntegrationTestHelper.linkParser;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.LinkParseException;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public abstract class RegistrationTest3 {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    public static class CoAPCaliforniumCalifornium extends RegistrationTest3 {
+        public CoAPCaliforniumCalifornium() {
+            super(Protocol.COAP, "Californium", "Californium");
+        }
+    }
+
+    public static class CoAPCaliforniumJavaCoap extends RegistrationTest3 {
+        public CoAPCaliforniumJavaCoap() {
+            super(Protocol.COAP, "Californium", "java-coap");
+        }
+    }
+
+    private final Protocol givenProtocol;
+    private final String givenServerEndpointProvider;
+    private final String givenClientEndpointProvider;
+
+    public RegistrationTest3(Protocol protocol, String clientProvider, String serverProvider) {
+        this.givenProtocol = protocol;
+        this.givenClientEndpointProvider = clientProvider;
+        this.givenServerEndpointProvider = serverProvider;
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+
+    LeshanTestServer server;
+    LeshanTestClientBuilder givenClient;
+    LeshanTestClient client;
+
+    @BeforeEach
+    public void start() {
+        server = givenServerUsing(givenProtocol).with(givenServerEndpointProvider).build();
+        server.start();
+        givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider).connectingTo(server);
+    }
+
+    @AfterEach
+    public void stop() throws InterruptedException {
+        if (client != null)
+            client.destroy(false);
+        if (server != null)
+            server.destroy();
+    }
+
+    protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+        return new LeshanTestServerBuilder(givenProtocol);
+    }
+
+    /*---------------------------------/
+     *  Tests
+     * -------------------------------*/
+    @Test
+    public void register_update_deregister() throws LinkParseException {
+
+        // Check client is not registered
+        client = givenClient.build();
+        assertThat(client).isNotRegisteredAt(server);
+
+        // Start it and wait for registration
+        client.start();
+        server.waitForNewRegistrationOf(client);
+        client.waitForRegistrationTo(server);
+
+        // Check client is well registered
+        assertThat(client).isRegisteredAt(server);
+        Registration registration = server.getRegistrationFor(client);
+        assertThat(registration.getObjectLinks()) //
+                .isEqualTo(linkParser.parseCoreLinkFormat(
+                        "</>;rt=\"oma.lwm2m\";ct=\"60 110 112 1542 1543 11542 11543\",</1>;ver=1.1,</1/0>,</2>,</3>;ver=1.1,</3/0>,</3442/0>"
+                                .getBytes()));
+
+        // Check for update
+        client.waitForUpdateTo(server, LIFETIME, TimeUnit.SECONDS);
+        server.waitForUpdateOf(registration);
+        assertThat(client).isRegisteredAt(server);
+
+        // Check deregistration
+        client.stop(true);
+        server.waitForDeregistrationOf(registration);
+        assertThat(client).isNotRegisteredAt(server);
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest4.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest4.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Zebra Technologies - initial API and implementation
+ *     Achim Kraus (Bosch Software Innovations GmbH) - replace close() with destroy()
+ *     Michał Wadowski (Orange) - Improved compliance with rfc6690
+ *******************************************************************************/
+
+package org.eclipse.leshan.integration.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.leshan.integration.tests.util.IntegrationTestHelper.LIFETIME;
+import static org.eclipse.leshan.integration.tests.util.IntegrationTestHelper.linkParser;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.LinkParseException;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.integration.tests.util.junit5.TestingUtils;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+public class RegistrationTest4 {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    @TestFactory
+    Stream<DynamicNode> testRegistrations() throws Exception {
+        return TestingUtils.parameterizedClassTester("protocol={0} clientProvider={1}, ServerProvider={1}",
+                InnerRegistrationTest4.class, transports());
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
+        return Stream.of(//
+                // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
+                arguments(Protocol.COAP, "Californium", "Californium"), //
+                arguments(Protocol.COAP, "Californium", "java-coap") //
+        );
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+    public static class InnerRegistrationTest4 {
+        private final Protocol givenProtocol;
+        private final String givenServerEndpointProvider;
+        private final String givenClientEndpointProvider;
+
+        public InnerRegistrationTest4(Protocol protocol, String clientProvider, String serverProvider) {
+            this.givenProtocol = protocol;
+            this.givenClientEndpointProvider = clientProvider;
+            this.givenServerEndpointProvider = serverProvider;
+        }
+
+        LeshanTestServer server;
+        LeshanTestClientBuilder givenClient;
+        LeshanTestClient client;
+
+        @BeforeEach
+        public void start() {
+            server = givenServerUsing(givenProtocol).with(givenServerEndpointProvider).build();
+            server.start();
+            givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider).connectingTo(server);
+        }
+
+        @AfterEach
+        public void stop() throws InterruptedException {
+            if (client != null)
+                client.destroy(false);
+            if (server != null)
+                server.destroy();
+        }
+
+        protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+            return new LeshanTestServerBuilder(givenProtocol);
+        }
+
+        @Test
+        public void register_update_deregister() throws LinkParseException {
+
+            // Check client is not registered
+            client = givenClient.build();
+            assertThat(client).isNotRegisteredAt(server);
+
+            // Start it and wait for registration
+            client.start();
+            server.waitForNewRegistrationOf(client);
+            client.waitForRegistrationTo(server);
+
+            // Check client is well registered
+            assertThat(client).isRegisteredAt(server);
+            Registration registration = server.getRegistrationFor(client);
+            assertThat(registration.getObjectLinks()) //
+                    .isEqualTo(linkParser.parseCoreLinkFormat(
+                            "</>;rt=\"oma.lwm2m\";ct=\"60 110 112 1542 1543 11542 11543\",</1>;ver=1.1,</1/0>,</2>,</3>;ver=1.1,</3/0>,</3442/0>"
+                                    .getBytes()));
+
+            // Check for update
+            client.waitForUpdateTo(server, LIFETIME, TimeUnit.SECONDS);
+            server.waitForUpdateOf(registration);
+            assertThat(client).isRegisteredAt(server);
+
+            // Check deregistration
+            client.stop(true);
+            server.waitForDeregistrationOf(registration);
+            assertThat(client).isNotRegisteredAt(server);
+        }
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertArg;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.security.cert.Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.client.LeshanClient;
+import org.eclipse.leshan.client.bootstrap.BootstrapConsistencyChecker;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.client.engine.RegistrationEngineFactory;
+import org.eclipse.leshan.client.observer.LwM2mClientObserver;
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.client.send.DataSender;
+import org.eclipse.leshan.core.link.LinkSerializer;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeParser;
+import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
+import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
+
+public class LeshanTestClient extends LeshanClient {
+
+    private final LwM2mClientObserver clientObserver = mock(LwM2mClientObserver.class);
+
+    private final String endpointName;
+
+    public LeshanTestClient(String endpoint, List<? extends LwM2mObjectEnabler> objectEnablers,
+            List<DataSender> dataSenders, List<Certificate> trustStore, RegistrationEngineFactory engineFactory,
+            BootstrapConsistencyChecker checker, Map<String, String> additionalAttributes,
+            Map<String, String> bsAdditionalAttributes, LwM2mEncoder encoder, LwM2mDecoder decoder,
+            ScheduledExecutorService sharedExecutor, LinkSerializer linkSerializer,
+            LwM2mAttributeParser attributeParser, LwM2mClientEndpointsProvider endpointsProvider) {
+        super(endpoint, objectEnablers, dataSenders, trustStore, engineFactory, checker, additionalAttributes,
+                bsAdditionalAttributes, encoder, decoder, sharedExecutor, linkSerializer, attributeParser,
+                endpointsProvider);
+
+        // Store some internal attribute
+        this.endpointName = endpoint;
+
+        // Add Mock Listener
+        this.addObserver(clientObserver);
+    }
+
+    public String getEndpointName() {
+        return endpointName;
+    }
+
+    public void waitForRegistrationTo(LeshanTestServer server) {
+        waitForRegistrationTo(server, 5, TimeUnit.SECONDS);
+    }
+
+    public void waitForRegistrationTo(LeshanTestServer server, long timeout, TimeUnit unit) {
+        verify(clientObserver, timeout(unit.toMillis(timeout)).times(1)).onRegistrationStarted(assertArg( //
+                s -> {
+                    assertThat(server.getEndpoints()) //
+                            .filteredOn(ep -> ep.getURI().toString().equals(s.getUri())) //
+                            .hasSize(1);
+
+                }), //
+                isNotNull());
+        verify(clientObserver, timeout(unit.toMillis(timeout)).times(1)).onRegistrationSuccess(assertArg( //
+                s -> assertThat(server.getEndpoints()) //
+                        .filteredOn(ep -> ep.getURI().toString().equals(s.getUri())) //
+                        .hasSize(1)), //
+                isNotNull(), isNotNull());
+        verifyNoMoreInteractions(clientObserver);
+    }
+
+    public void waitForUpdateTo(LeshanTestServer server, long timeout, TimeUnit unit) {
+        verify(clientObserver, timeout(unit.toMillis(timeout)).times(1)).onUpdateStarted(assertArg( //
+                s -> assertThat(server.getEndpoints()) //
+                        .filteredOn(ep -> ep.getURI().toString().equals(s.getUri())) //
+                        .hasSize(1)), //
+                notNull());
+        verify(clientObserver, timeout(unit.toMillis(timeout)).times(1)).onUpdateSuccess(assertArg( //
+                s -> assertThat(server.getEndpoints()) //
+                        .filteredOn(ep -> ep.getURI().toString().equals(s.getUri())) //
+                        .hasSize(1)), //
+                notNull());
+        verifyNoMoreInteractions(clientObserver);
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util;
+
+import java.net.URI;
+import java.security.cert.Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.leshan.client.LeshanClientBuilder;
+import org.eclipse.leshan.client.bootstrap.BootstrapConsistencyChecker;
+import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpointsProvider;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.client.engine.RegistrationEngineFactory;
+import org.eclipse.leshan.client.object.LwM2mTestObject;
+import org.eclipse.leshan.client.object.Security;
+import org.eclipse.leshan.client.object.Server;
+import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.client.resource.ObjectsInitializer;
+import org.eclipse.leshan.client.send.DataSender;
+import org.eclipse.leshan.client.send.ManualDataSender;
+import org.eclipse.leshan.core.LwM2mId;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.LinkSerializer;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeParser;
+import org.eclipse.leshan.core.model.StaticModel;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mDecoder;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
+import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
+import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
+import org.eclipse.leshan.core.util.TestLwM2mId;
+import org.eclipse.leshan.integration.tests.util.IntegrationTestHelper.TestDevice;
+import org.eclipse.leshan.server.LeshanServer;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpoint;
+
+public class LeshanTestClientBuilder extends LeshanClientBuilder {
+
+    public static final String MODEL_NUMBER = "IT-TEST-123";
+    public static final long LIFETIME = 2;
+
+    private static final Random r = new Random();
+
+    private final Protocol protocolToUse;
+    ObjectsInitializer initializer;
+
+    // server.getEndpoint(Protocol.COAP).getURI().toString()
+    public LeshanTestClientBuilder(Protocol protocolToUse) {
+        super("leshan_test_client_" + r.nextInt());
+        this.protocolToUse = protocolToUse;
+
+        // Create objects Enabler
+        initializer = new ObjectsInitializer(new StaticModel(TestObjectLoader.loadDefaultObject()));
+        initializer.setInstancesForObject(LwM2mId.DEVICE, new TestDevice("Eclipse Leshan", MODEL_NUMBER, "12345"));
+        initializer.setClassForObject(LwM2mId.ACCESS_CONTROL, DummyInstanceEnabler.class);
+        initializer.setInstancesForObject(TestLwM2mId.TEST_OBJECT, new LwM2mTestObject());
+
+        // Build Client
+        this.setDecoder(new DefaultLwM2mDecoder(true));
+        this.setEncoder(new DefaultLwM2mEncoder(true));
+        this.setDataSenders(new ManualDataSender());
+
+    }
+
+    @Override
+    public LeshanTestClient build() {
+        List<LwM2mObjectEnabler> objects = initializer.createAll();
+        this.setObjects(objects);
+        return (LeshanTestClient) super.build();
+    }
+
+    @Override
+    protected LeshanTestClient createLeshanClient(String endpoint, List<? extends LwM2mObjectEnabler> objectEnablers,
+            List<DataSender> dataSenders, List<Certificate> trustStore, RegistrationEngineFactory engineFactory,
+            BootstrapConsistencyChecker checker, Map<String, String> additionalAttributes,
+            Map<String, String> bsAdditionalAttributes, LwM2mEncoder encoder, LwM2mDecoder decoder,
+            ScheduledExecutorService sharedExecutor, LinkSerializer linkSerializer,
+            LwM2mAttributeParser attributeParser, LwM2mClientEndpointsProvider endpointsProvider) {
+        return new LeshanTestClient(endpoint, objectEnablers, dataSenders, trustStore, engineFactory, checker,
+                additionalAttributes, bsAdditionalAttributes, encoder, decoder, sharedExecutor, linkSerializer,
+                attributeParser, endpointsProvider);
+    }
+
+    public LeshanTestClientBuilder with(String endpointProvider) {
+        if (endpointProvider.equals("Californium")) {
+            this.setEndpointsProvider(new CaliforniumClientEndpointsProvider());
+        }
+        return this;
+    }
+
+    public LeshanTestClientBuilder connectingTo(LeshanServer server) {
+        LwM2mServerEndpoint endpoint = server.getEndpoint(protocolToUse);
+        URI uri = endpoint.getURI();
+        initializer.setInstancesForObject(LwM2mId.SECURITY, Security.noSec(uri.toString(), 12345));
+        initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, LIFETIME));
+        return this;
+    }
+
+    public static LeshanTestClientBuilder givenClientUsing(Protocol protocol) {
+        return new LeshanTestClientBuilder(protocol);
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServer.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServer.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.booleanThat;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.core.link.lwm2m.LwM2mLinkParser;
+import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
+import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
+import org.eclipse.leshan.server.LeshanServer;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+import org.eclipse.leshan.server.model.LwM2mModelProvider;
+import org.eclipse.leshan.server.queue.ClientAwakeTimeProvider;
+import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.server.registration.RegistrationIdProvider;
+import org.eclipse.leshan.server.registration.RegistrationListener;
+import org.eclipse.leshan.server.registration.RegistrationStore;
+import org.eclipse.leshan.server.security.Authorizer;
+import org.eclipse.leshan.server.security.SecurityStore;
+import org.eclipse.leshan.server.security.ServerSecurityInfo;
+
+public class LeshanTestServer extends LeshanServer {
+
+    private final RegistrationListener registrationListener = mock(RegistrationListener.class);
+
+    public LeshanTestServer(LwM2mServerEndpointsProvider endpointsProvider, RegistrationStore registrationStore,
+            SecurityStore securityStore, Authorizer authorizer, LwM2mModelProvider modelProvider, LwM2mEncoder encoder,
+            LwM2mDecoder decoder, boolean noQueueMode, ClientAwakeTimeProvider awakeTimeProvider,
+            RegistrationIdProvider registrationIdProvider, LwM2mLinkParser linkParser,
+            ServerSecurityInfo serverSecurityInfo, boolean updateRegistrationOnNotification) {
+        super(endpointsProvider, registrationStore, securityStore, authorizer, modelProvider, encoder, decoder,
+                noQueueMode, awakeTimeProvider, registrationIdProvider, updateRegistrationOnNotification, linkParser,
+                serverSecurityInfo);
+
+        // add mocked listener
+        this.getRegistrationService().addListener(registrationListener);
+    }
+
+    public Registration getRegistrationFor(LeshanTestClient client) {
+        return getRegistrationService().getByEndpoint(client.getEndpointName());
+    }
+
+    public void waitForNewRegistrationOf(LeshanTestClient client) {
+        waitForNewRegistrationOf(client, 1, TimeUnit.SECONDS);
+    }
+
+    public void waitForNewRegistrationOf(LeshanTestClient client, int timeout, TimeUnit unit) {
+        verify(registrationListener, timeout(unit.toMillis(timeout)).times(1)).registered(//
+                assertArg(reg -> assertThat(reg.getEndpoint()).isEqualTo(client.getEndpointName())), //
+                isNull(), //
+                isNull());
+        verifyNoMoreInteractions(registrationListener);
+    }
+
+    public void waitForUpdateOf(Registration expectedRegistration) {
+        waitForUpdateOf(expectedRegistration, 1, TimeUnit.SECONDS);
+    }
+
+    public void waitForUpdateOf(Registration expectedPreviousReg, int timeout, TimeUnit unit) {
+        verify(registrationListener, timeout(unit.toMillis(timeout)).times(1)).updated( //
+                any(), //
+                assertArg(updatedReg -> updatedReg.getId().equals(expectedPreviousReg.getId())), //
+                assertArg(previousReg -> previousReg.equals(expectedPreviousReg)));
+        verifyNoMoreInteractions(registrationListener);
+    }
+
+    public void waitForDeregistrationOf(Registration expectedRegistration) {
+        waitForDeregistrationOf(expectedRegistration, 1, TimeUnit.SECONDS);
+    }
+
+    public void waitForDeregistrationOf(Registration expectedRegistration, int timeout, TimeUnit unit) {
+        verify(registrationListener, timeout(unit.toMillis(timeout)).times(1)).unregistered(
+                assertArg(reg -> reg.getId().equals(expectedRegistration.getId())), //
+                assertArg(obs -> assertThat(obs).isEmpty()), //
+                booleanThat(expired -> expired == false), //
+                isNull());
+        verifyNoMoreInteractions(registrationListener);
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        // remove all registration on destroy
+        getRegistrationStore().getAllRegistrations()
+                .forEachRemaining(r -> getRegistrationStore().removeRegistration(r.getId()));
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServerBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServerBuilder.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.lwm2m.LwM2mLinkParser;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mDecoder;
+import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
+import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
+import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
+import org.eclipse.leshan.server.LeshanServerBuilder;
+import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointsProvider;
+import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointsProvider.Builder;
+import org.eclipse.leshan.server.californium.endpoint.coap.CoapServerProtocolProvider;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+import org.eclipse.leshan.server.model.LwM2mModelProvider;
+import org.eclipse.leshan.server.model.VersionedModelProvider;
+import org.eclipse.leshan.server.queue.ClientAwakeTimeProvider;
+import org.eclipse.leshan.server.registration.RegistrationIdProvider;
+import org.eclipse.leshan.server.registration.RegistrationStore;
+import org.eclipse.leshan.server.security.Authorizer;
+import org.eclipse.leshan.server.security.SecurityStore;
+import org.eclipse.leshan.server.security.ServerSecurityInfo;
+import org.eclipse.leshan.transport.javacoap.endpoint.JavaCoapServerEndpointsProvider;
+
+public class LeshanTestServerBuilder extends LeshanServerBuilder {
+
+    private final Protocol protocolToUse;
+
+    public LeshanTestServerBuilder(Protocol protocolToUse) {
+        this.protocolToUse = protocolToUse;
+        this.setDecoder(new DefaultLwM2mDecoder(true));
+        this.setEncoder(new DefaultLwM2mEncoder(true));
+        this.setObjectModelProvider(new VersionedModelProvider(TestObjectLoader.loadDefaultObject()));
+    }
+
+    @Override
+    public LeshanTestServer build() {
+        return (LeshanTestServer) super.build();
+    }
+
+    @Override
+    protected LeshanTestServer createServer(LwM2mServerEndpointsProvider endpointsProvider,
+            RegistrationStore registrationStore, SecurityStore securityStore, Authorizer authorizer,
+            LwM2mModelProvider modelProvider, LwM2mEncoder encoder, LwM2mDecoder decoder, boolean noQueueMode,
+            ClientAwakeTimeProvider awakeTimeProvider, RegistrationIdProvider registrationIdProvider,
+            LwM2mLinkParser linkParser, ServerSecurityInfo serverSecurityInfo,
+            boolean updateRegistrationOnNotification) {
+
+        return new LeshanTestServer(endpointsProvider, registrationStore, securityStore, authorizer, modelProvider,
+                encoder, decoder, noQueueMode, awakeTimeProvider, registrationIdProvider, linkParser,
+                serverSecurityInfo, updateRegistrationOnNotification);
+    }
+
+    public LeshanTestServerBuilder with(String endpointProvider) {
+        switch (endpointProvider) {
+        case "Californium":
+            Builder builder = new CaliforniumServerEndpointsProvider.Builder(new CoapServerProtocolProvider());
+            builder.addEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), protocolToUse);
+            this.setEndpointsProvider(builder.build());
+            return this;
+        case "java-coap":
+            this.setEndpointsProvider(
+                    new JavaCoapServerEndpointsProvider(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0)));
+            return this;
+        default:
+            throw new IllegalStateException(String.format("Unknown endpoint provider : [%s]", endpointProvider));
+        }
+    }
+
+    public static LeshanTestServerBuilder givenServerUsing(Protocol protocolToUse) {
+        return new LeshanTestServerBuilder(protocolToUse);
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/Assertions.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/Assertions.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util.assertion;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.matcher.AssertionMatcher;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.mockito.hamcrest.MockitoHamcrest;
+
+public class Assertions extends org.assertj.core.api.Assertions {
+    public static <T> T assertArg(Consumer<T> assertions) {
+        return MockitoHamcrest.argThat(new AssertionMatcher<T>() {
+            @Override
+            public void assertion(T actual) throws AssertionError {
+                assertions.accept(actual);
+            }
+        });
+    }
+
+    // give access to TolkienCharacter Race assertion
+    public static LeshanTestClientAssert assertThat(LeshanTestClient actual) {
+        return new LeshanTestClientAssert(actual);
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/LeshanTestClientAssert.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/LeshanTestClientAssert.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util.assertion;
+
+import org.assertj.core.api.AbstractAssert;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.server.LeshanServer;
+import org.eclipse.leshan.server.registration.Registration;
+
+public class LeshanTestClientAssert extends AbstractAssert<LeshanTestClientAssert, LeshanTestClient> {
+
+    public LeshanTestClientAssert(LeshanTestClient actual) {
+        super(actual, LeshanTestClientAssert.class);
+    }
+
+    public static LeshanTestClientAssert assertThat(LeshanTestClient actual) {
+        return new LeshanTestClientAssert(actual);
+    }
+
+    public LeshanTestClientAssert isRegisteredAt(LeshanServer server) {
+        isNotNull();
+        isNotNull(server);
+
+        Registration r = getRegistration(server);
+        if (r == null) {
+            failWithMessage("Expected Registration for <%s> client", actual.getEndpointName());
+        }
+        return this;
+    }
+
+    public LeshanTestClientAssert isNotRegisteredAt(LeshanServer server) {
+        isNotNull();
+        isNotNull(server);
+
+        Registration r = getRegistration(server);
+        if (r != null) {
+            failWithMessage("Expected No Registration for <%s> client but have <%>", actual.getEndpointName(), r);
+        }
+        return this;
+    }
+
+    private void isNotNull(LeshanServer server) {
+        if (server == null)
+            failWithMessage("server MUST NOT be null");
+    }
+
+    private Registration getRegistration(LeshanServer server) {
+        return server.getRegistrationService().getByEndpoint(actual.getEndpointName());
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/junit5/TestingUtils.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/junit5/TestingUtils.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *******************************************************************************/
+
+package org.eclipse.leshan.integration.tests.util.junit5;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.engine.discovery.predicates.IsTestMethod;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+public class TestingUtils {
+
+    private TestingUtils() {
+    }
+
+    private static interface TestInvoker {
+
+        void invoke(Method testMethod) throws Exception;
+
+    }
+
+    public static Stream<DynamicNode> parameterizedClassTester(String displayName, Class<?> clazz,
+            Stream<Arguments> streamOfArguments) {
+
+        final List<Method> testMethods = ReflectionUtils.findMethods(clazz, new IsTestMethod());
+        if (testMethods.isEmpty()) {
+            throw new IllegalStateException(clazz.getName() + " has no supported @Test methods");
+        }
+
+        List<Constructor<?>> candidateConstructors = Arrays.stream(clazz.getDeclaredConstructors())
+                .filter(ctor -> ctor.getParameterCount() != 0).collect(Collectors.toList());
+        if (candidateConstructors.size() != 1) {
+            if (candidateConstructors.isEmpty()) {
+                throw new IllegalStateException(clazz.getName() + " has no candiate constructors");
+            }
+            throw new IllegalStateException(clazz.getName() + " has more than one candiate constructors");
+        }
+
+        final MessageFormat displayNameFormatter = new MessageFormat(displayName);
+
+        final Constructor<?> constructor = candidateConstructors.get(0);
+        constructor.setAccessible(true);
+
+        final List<Method> beforeEachMethods = AnnotationUtils.findAnnotatedMethods(clazz, BeforeEach.class,
+                ReflectionUtils.HierarchyTraversalMode.TOP_DOWN);
+
+        final List<Method> afterEachMethods = AnnotationUtils.findAnnotatedMethods(clazz, AfterEach.class,
+                ReflectionUtils.HierarchyTraversalMode.BOTTOM_UP);
+
+        for (List<Method> methods : Arrays.asList(testMethods, beforeEachMethods, afterEachMethods)) {
+            for (Method method : methods) {
+                method.setAccessible(true);
+            }
+        }
+
+        return streamOfArguments.map(arguments -> {
+            final Object[] arrayOfArguments = arguments.get();
+
+            final TestInvoker testInvoker = new TestInvoker() {
+                private Object instance;
+
+                @Override
+                public void invoke(Method testMethod) throws Exception {
+                    if (instance == null) {
+                        instance = constructor.newInstance(arrayOfArguments);
+                    }
+
+                    try {
+                        for (Method method : beforeEachMethods) {
+                            method.invoke(instance);
+                        }
+
+                        testMethod.invoke(instance);
+
+                    } finally {
+                        for (Method method : afterEachMethods) {
+                            method.invoke(instance);
+                        }
+                    }
+                }
+            };
+
+            return DynamicContainer.dynamicContainer(displayNameFormatter.format(arrayOfArguments), testMethods.stream()
+                    .map(method -> DynamicTest.dynamicTest(method.getName() + "()", () -> testInvoker.invoke(method))));
+        });
+    }
+
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/junit5/extensions/BeforeEachParameterizedResolver.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/junit5/extensions/BeforeEachParameterizedResolver.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util.junit5.extensions;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
+
+/**
+ * Junit5 Extension to use parameter in BeforeEach. Largely inspired by :
+ * <ul>
+ * <li>https://code-case.hashnode.dev/how-to-pass-parameterized-test-parameters-to-beforeeachaftereach-method-in-junit5
+ * <li>https://stackoverflow.com/a/69265907/5088764
+ * </ul>
+ * See https://github.com/junit-team/junit5/issues/3157 about find a better way ?
+ */
+public class BeforeEachParameterizedResolver implements BeforeEachMethodAdapter, ParameterResolver {
+
+    private ParameterResolver parameterizedTestParameterResolver = null;
+
+    @Override
+    public void invokeBeforeEachMethod(ExtensionContext context, ExtensionRegistry registry) throws Throwable {
+        // get default ParameterResolver
+        Optional<ParameterResolver> parameterResolver = registry.getExtensions(ParameterResolver.class).stream()
+                .filter(resolver -> resolver.getClass().getName().contains("ParameterizedTestParameterResolver"))
+                .findFirst();
+
+        if (!parameterResolver.isPresent()) {
+            throw new IllegalStateException(
+                    "ParameterizedTestParameterResolver missed in the registry. Probably it's not a Parameterized Test");
+        } else {
+            parameterizedTestParameterResolver = parameterResolver.get();
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        if (isExecutedOnAfterOrBeforeMethod(parameterContext)) {
+            ParameterContext pContext = getMappedContext(parameterContext, extensionContext);
+            return parameterizedTestParameterResolver.supportsParameter(pContext, extensionContext);
+        }
+        return false;
+    }
+
+    private boolean isExecutedOnAfterOrBeforeMethod(ParameterContext parameterContext) {
+        return Arrays.stream(parameterContext.getDeclaringExecutable().getDeclaredAnnotations())
+                .anyMatch(this::isAfterEachOrBeforeEachAnnotation);
+    }
+
+    private boolean isAfterEachOrBeforeEachAnnotation(Annotation annotation) {
+        return annotation.annotationType() == BeforeEach.class || annotation.annotationType() == AfterEach.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        if (isExecutedOnAfterOrBeforeMethod(parameterContext)) {
+            ParameterContext pContext = getMappedContext(parameterContext, extensionContext);
+            return parameterizedTestParameterResolver.resolveParameter(pContext, extensionContext);
+        }
+        return null;
+    }
+
+    private MappedParameterContext getMappedContext(ParameterContext parameterContext,
+            ExtensionContext extensionContext) {
+        return new MappedParameterContext(parameterContext.getIndex(),
+                extensionContext.getRequiredTestMethod().getParameters()[parameterContext.getIndex()],
+                Optional.of(parameterContext.getTarget()));
+    }
+
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/junit5/extensions/MappedParameterContext.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/junit5/extensions/MappedParameterContext.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.util.junit5.extensions;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+public class MappedParameterContext implements ParameterContext {
+
+    private final int index;
+    private final Parameter parameter;
+    private final Optional<Object> target;
+
+    public MappedParameterContext(int index, Parameter parameter, Optional<Object> target) {
+        this.index = index;
+        this.parameter = parameter;
+        this.target = target;
+    }
+
+    @Override
+    public boolean isAnnotated(Class<? extends Annotation> annotationType) {
+        return AnnotationUtils.isAnnotated(parameter, annotationType);
+    }
+
+    @Override
+    public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
+        return null;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    public Parameter getParameter() {
+        return parameter;
+    }
+
+    @Override
+    public Optional<Object> getTarget() {
+        return target;
+    }
+}


### PR DESCRIPTION
This aims to propose new design for integration tests to allow us to launch tests with different transport layer implementation.

See `RegistrationTest2` to see what it looks like.
```java
// Check client is not registered
client = givenClient.build();
assertThat(client).isNotRegisteredAt(server);

// Start it and wait for registration
client.start();
server.waitForNewRegistrationOf(client);
client.waitForRegistrationTo(server);

// Check client is well registered
assertThat(client).isRegisteredAt(server);
Registration registration = server.getRegistrationFor(client);
assertThat(registration.getObjectLinks()) //
        .isEqualTo(linkParser.parseCoreLinkFormat(
                "</>;rt=\"oma.lwm2m\";ct=\"60 110 112 1542 1543 11542 11543\",</1>;ver=1.1,</1/0>,</2>,</3>;ver=1.1,</3/0>,</3442/0>"
                        .getBytes()));

// Check for update
client.waitForUpdateTo(server, LIFETIME, TimeUnit.SECONDS);
server.waitForUpdateOf(registration);
assertThat(client).isRegisteredAt(server);

// Check deregistration
client.stop(true);
server.waitForDeregistrationOf(registration);
assertThat(client).isNotRegisteredAt(server);
```


I used  : 
 - AssertJ : to write more elegant assertion (see `LeshanTestClientAssert`)
 - Mockito : to verify listener call (see `waitFor**` methods in `LeshanTestClient` and  `LeshanTestServer` 

I also use a kind of Junit5 HACK to be able to use parameter in **`@BeforeEach`**, See https://github.com/junit-team/junit5/issues/3157 for more details. 