### PR TITLE
Some API enhancement to create `CaliforniumServerEndpointsProvider`

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coap/CoapClientEndpointFactory.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coap/CoapClientEndpointFactory.java
@@ -60,7 +60,7 @@ public class CoapClientEndpointFactory implements CaliforniumClientEndpointFacto
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, uri);
         } else {
-            return String.format("[%s-%s]", uri);
+            return String.format("[%s]", uri);
         }
     }
 

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coaps/CoapsClientEndpointFactory.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coaps/CoapsClientEndpointFactory.java
@@ -103,7 +103,7 @@ public class CoapsClientEndpointFactory extends CoapClientEndpointFactory {
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, uri);
         } else {
-            return String.format("[%s-%s]", uri);
+            return String.format("[%s]", uri);
         }
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/endpoint/EndpointUriUtil.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/endpoint/EndpointUriUtil.java
@@ -55,15 +55,15 @@ public class EndpointUriUtil {
         Validate.notNull(uri);
 
         if (uri.getScheme() == null) {
-            throw new IllegalArgumentException("URI Scheme MUST NOT be null");
+            throw new IllegalArgumentException(String.format("Invalid URI[%s]: Scheme MUST NOT be null", uri));
         }
 
         if (uri.getHost() == null) {
-            throw new IllegalArgumentException("URI Host MUST NOT be null");
+            throw new IllegalArgumentException(String.format("Invalid URI[%s]: Host MUST NOT be null", uri));
         }
 
         if (uri.getPort() == -1) {
-            throw new IllegalArgumentException("URI Post MUST NOT be undefined");
+            throw new IllegalArgumentException(String.format("Invalid URI[%s]: Post MUST NOT be undefined", uri));
         }
     }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerEndpointFactory.java
@@ -61,7 +61,7 @@ public class CoapBootstrapServerEndpointFactory implements CaliforniumBootstrapS
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, getUri().toString());
         } else {
-            return String.format("[%s-%s]", getUri().toString());
+            return String.format("[%s]", getUri().toString());
         }
     }
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerEndpointFactoryBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerEndpointFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Sierra Wireless and others.
+ * Copyright (c) 2023 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -13,30 +13,28 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
-package org.eclipse.leshan.server.californium.endpoint.coap;
+package org.eclipse.leshan.server.californium.bootstrap.endpoint.coap;
 
-import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.List;
 
-import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
-import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
-import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointFactory;
-import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.californium.endpoint.AbstractEndpointFactoryBuilder;
+import org.eclipse.leshan.server.californium.endpoint.coap.CoapServerEndpointFactory;
 
-public class CoapServerProtocolProvider implements ServerProtocolProvider {
+public class CoapBootstrapServerEndpointFactoryBuilder extends
+        AbstractEndpointFactoryBuilder<CoapBootstrapServerEndpointFactoryBuilder, CoapBootstrapServerEndpointFactory> {
 
     @Override
-    public Protocol getProtocol() {
+    protected Protocol getSupportedProtocol() {
         return CoapServerEndpointFactory.getSupportedProtocol();
     }
 
     @Override
     public void applyDefaultValue(Configuration configuration) {
         CoapServerEndpointFactory.applyDefaultValue(configuration);
+
     }
 
     @Override
@@ -45,13 +43,8 @@ public class CoapServerProtocolProvider implements ServerProtocolProvider {
     }
 
     @Override
-    public CaliforniumServerEndpointFactory createDefaultEndpointFactory(URI uri) {
-        return new CoapServerEndpointFactory(uri);
-    }
-
-    @Override
-    public URI getDefaultUri(Configuration configuration) {
-        return EndpointUriUtil.createUri(getProtocol().getUriScheme(),
-                new InetSocketAddress(configuration.get(CoapConfig.COAP_PORT)));
+    public CoapBootstrapServerEndpointFactory build() {
+        return new CoapBootstrapServerEndpointFactory(uri, loggingTagPrefix, configuration,
+                coapEndpointConfigInitializer);
     }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerProtocolProvider.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerProtocolProvider.java
@@ -17,15 +17,11 @@ package org.eclipse.leshan.server.californium.bootstrap.endpoint.coap;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.californium.core.config.CoapConfig;
-import org.eclipse.californium.core.config.CoapConfig.TrackerMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
-import org.eclipse.californium.elements.config.SystemConfig;
-import org.eclipse.californium.elements.config.UdpConfig;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.server.californium.bootstrap.endpoint.BootstrapServerProtocolProvider;
@@ -35,17 +31,17 @@ public class CoapBootstrapServerProtocolProvider implements BootstrapServerProto
 
     @Override
     public Protocol getProtocol() {
-        return Protocol.COAP;
+        return CoapBootstrapServerEndpointFactory.getSupportedProtocol();
     }
 
     @Override
     public void applyDefaultValue(Configuration configuration) {
-        configuration.set(CoapConfig.MID_TRACKER, TrackerMode.NULL);
+        CoapBootstrapServerEndpointFactory.applyDefaultValue(configuration);
     }
 
     @Override
     public List<ModuleDefinitionsProvider> getModuleDefinitionsProviders() {
-        return Arrays.asList(SystemConfig.DEFINITIONS, CoapConfig.DEFINITIONS, UdpConfig.DEFINITIONS);
+        return CoapBootstrapServerEndpointFactory.getModuleDefinitionsProviders();
     }
 
     @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerEndpointFactory.java
@@ -94,7 +94,7 @@ public class CoapsBootstrapServerEndpointFactory implements CaliforniumBootstrap
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, getUri().toString());
         } else {
-            return String.format("[%s-%s]", getUri().toString());
+            return String.format("[%s]", getUri().toString());
         }
     }
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerEndpointFactoryBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerEndpointFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Sierra Wireless and others.
+ * Copyright (c) 2023 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,28 +15,29 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.bootstrap.endpoint.coaps;
 
-import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.List;
+import java.util.function.Consumer;
 
-import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
-import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.leshan.core.endpoint.Protocol;
-import org.eclipse.leshan.server.californium.bootstrap.endpoint.BootstrapServerProtocolProvider;
-import org.eclipse.leshan.server.californium.bootstrap.endpoint.CaliforniumBootstrapServerEndpointFactory;
+import org.eclipse.leshan.server.californium.endpoint.AbstractEndpointFactoryBuilder;
 
-public class CoapsBootstrapServerProtocolProvider implements BootstrapServerProtocolProvider {
+public class CoapsBootstrapServerEndpointFactoryBuilder extends
+        AbstractEndpointFactoryBuilder<CoapsBootstrapServerEndpointFactoryBuilder, CoapsBootstrapServerEndpointFactory> {
+
+    protected Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer;
 
     @Override
-    public Protocol getProtocol() {
+    protected Protocol getSupportedProtocol() {
         return CoapsBootstrapServerEndpointFactory.getSupportedProtocol();
     }
 
     @Override
     public void applyDefaultValue(Configuration configuration) {
         CoapsBootstrapServerEndpointFactory.applyDefaultValue(configuration);
+
     }
 
     @Override
@@ -44,14 +45,15 @@ public class CoapsBootstrapServerProtocolProvider implements BootstrapServerProt
         return CoapsBootstrapServerEndpointFactory.getModuleDefinitionsProviders();
     }
 
-    @Override
-    public CaliforniumBootstrapServerEndpointFactory createDefaultEndpointFactory(URI uri) {
-        return new CoapsBootstrapServerEndpointFactory(uri);
+    public CoapsBootstrapServerEndpointFactoryBuilder setDtlsConnectorConfig(
+            Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer) {
+        this.dtlsConnectorConfigInitializer = dtlsConnectorConfigInitializer;
+        return this;
     }
 
     @Override
-    public URI getDefaultUri(Configuration configuration) {
-        return EndpointUriUtil.createUri(getProtocol().getUriScheme(),
-                new InetSocketAddress(configuration.get(CoapConfig.COAP_SECURE_PORT)));
+    public CoapsBootstrapServerEndpointFactory build() {
+        return new CoapsBootstrapServerEndpointFactory(uri, loggingTagPrefix, configuration,
+                dtlsConnectorConfigInitializer, coapEndpointConfigInitializer);
     }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerProtocolProvider.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerProtocolProvider.java
@@ -18,16 +18,27 @@ package org.eclipse.leshan.server.californium.bootstrap.endpoint.coaps;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.server.californium.bootstrap.endpoint.BootstrapServerProtocolProvider;
 import org.eclipse.leshan.server.californium.bootstrap.endpoint.CaliforniumBootstrapServerEndpointFactory;
 
 public class CoapsBootstrapServerProtocolProvider implements BootstrapServerProtocolProvider {
+
+    protected Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer;
+
+    public CoapsBootstrapServerProtocolProvider() {
+    }
+
+    public CoapsBootstrapServerProtocolProvider(Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer) {
+        this.dtlsConnectorConfigInitializer = dtlsConnectorConfigInitializer;
+    }
 
     @Override
     public Protocol getProtocol() {
@@ -46,7 +57,8 @@ public class CoapsBootstrapServerProtocolProvider implements BootstrapServerProt
 
     @Override
     public CaliforniumBootstrapServerEndpointFactory createDefaultEndpointFactory(URI uri) {
-        return new CoapsBootstrapServerEndpointFactory(uri);
+        return new CoapsBootstrapServerEndpointFactoryBuilder().setURI(uri)
+                .setDtlsConnectorConfig(dtlsConnectorConfigInitializer).build();
     }
 
     @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/AbstractEndpointFactoryBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/AbstractEndpointFactoryBuilder.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.californium.endpoint;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
+import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
+import org.eclipse.leshan.core.endpoint.Protocol;
+
+public abstract class AbstractEndpointFactoryBuilder<SELF extends AbstractEndpointFactoryBuilder<SELF, TTarget>, TTarget> {
+
+    protected URI uri;
+    protected String loggingTagPrefix;
+    protected Configuration configuration;
+    protected Consumer<CoapEndpoint.Builder> coapEndpointConfigInitializer;
+
+    @SuppressWarnings("unchecked")
+    private SELF self() {
+        return (SELF) this;
+    }
+
+    protected abstract Protocol getSupportedProtocol();
+
+    protected abstract void applyDefaultValue(Configuration configuration);
+
+    protected abstract List<ModuleDefinitionsProvider> getModuleDefinitionsProviders();
+
+    public abstract TTarget build();
+
+    public SELF setURI(URI uri) {
+        EndpointUriUtil.validateURI(uri);
+        this.uri = uri;
+        return self();
+    }
+
+    public SELF setURI(int port) {
+        return setURI(new InetSocketAddress(port));
+    }
+
+    public SELF setURI(InetSocketAddress addr) {
+        this.uri = EndpointUriUtil.createUri(getSupportedProtocol().getUriScheme(), addr);
+        return self();
+    }
+
+    public SELF setURI(String uriAsString) {
+        URI uri = EndpointUriUtil.createUri(uriAsString);
+        EndpointUriUtil.validateURI(uri);
+
+        if (!getSupportedProtocol().getUriScheme().equals(uri.getScheme())) {
+            throw new IllegalArgumentException(String.format("Invalid URI[%s]: Protocol Scheme MUST NOT be [%s]", uri,
+                    getSupportedProtocol().getUriScheme()));
+        }
+
+        return self();
+    }
+
+    public SELF setLoggingTagPrefix(String loggingTagPrefix) {
+        this.loggingTagPrefix = loggingTagPrefix;
+        return self();
+    }
+
+    public SELF setConfiguration(Consumer<Configuration> configurationInitializer) {
+        // Create Configuration
+        List<ModuleDefinitionsProvider> moduleDefinitions = getModuleDefinitionsProviders();
+        Configuration configuration = new Configuration(
+                moduleDefinitions.toArray(new ModuleDefinitionsProvider[moduleDefinitions.size()]));
+        // Apply default value
+        applyDefaultValue(configuration);
+
+        // Apply initializer
+        configurationInitializer.accept(configuration);
+
+        // if all OK, save configuration
+        this.configuration = configuration;
+        return self();
+    }
+
+    public SELF setCoapEndpointConfig(Consumer<CoapEndpoint.Builder> coapEndpointConfigInitializer) {
+        this.coapEndpointConfigInitializer = coapEndpointConfigInitializer;
+        return self();
+    }
+
+}

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapServerEndpointFactory.java
@@ -66,7 +66,7 @@ public class CoapServerEndpointFactory implements CaliforniumServerEndpointFacto
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, getUri().toString());
         } else {
-            return String.format("[%s-%s]", getUri().toString());
+            return String.format("[%s]", getUri().toString());
         }
     }
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapServerEndpointFactoryBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapServerEndpointFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Sierra Wireless and others.
+ * Copyright (c) 2023 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,28 +15,25 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.endpoint.coap;
 
-import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.List;
 
-import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
-import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
-import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointFactory;
-import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.californium.endpoint.AbstractEndpointFactoryBuilder;
 
-public class CoapServerProtocolProvider implements ServerProtocolProvider {
+public class CoapServerEndpointFactoryBuilder
+        extends AbstractEndpointFactoryBuilder<CoapServerEndpointFactoryBuilder, CoapServerEndpointFactory> {
 
     @Override
-    public Protocol getProtocol() {
+    protected Protocol getSupportedProtocol() {
         return CoapServerEndpointFactory.getSupportedProtocol();
     }
 
     @Override
     public void applyDefaultValue(Configuration configuration) {
         CoapServerEndpointFactory.applyDefaultValue(configuration);
+
     }
 
     @Override
@@ -45,13 +42,7 @@ public class CoapServerProtocolProvider implements ServerProtocolProvider {
     }
 
     @Override
-    public CaliforniumServerEndpointFactory createDefaultEndpointFactory(URI uri) {
-        return new CoapServerEndpointFactory(uri);
-    }
-
-    @Override
-    public URI getDefaultUri(Configuration configuration) {
-        return EndpointUriUtil.createUri(getProtocol().getUriScheme(),
-                new InetSocketAddress(configuration.get(CoapConfig.COAP_PORT)));
+    public CoapServerEndpointFactory build() {
+        return new CoapServerEndpointFactory(uri, loggingTagPrefix, configuration, coapEndpointConfigInitializer);
     }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerEndpointFactory.java
@@ -104,7 +104,7 @@ public class CoapsServerEndpointFactory implements CaliforniumServerEndpointFact
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, getUri().toString());
         } else {
-            return String.format("[%s-%s]", getUri().toString());
+            return String.format("[%s]", getUri().toString());
         }
     }
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerEndpointFactoryBuilder.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerEndpointFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Sierra Wireless and others.
+ * Copyright (c) 2023 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -15,28 +15,29 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.californium.endpoint.coaps;
 
-import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.List;
+import java.util.function.Consumer;
 
-import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
-import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.leshan.core.endpoint.Protocol;
-import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointFactory;
-import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.californium.endpoint.AbstractEndpointFactoryBuilder;
 
-public class CoapsServerProtocolProvider implements ServerProtocolProvider {
+public class CoapsServerEndpointFactoryBuilder
+        extends AbstractEndpointFactoryBuilder<CoapsServerEndpointFactoryBuilder, CoapsServerEndpointFactory> {
+
+    protected Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer;
 
     @Override
-    public Protocol getProtocol() {
+    protected Protocol getSupportedProtocol() {
         return CoapsServerEndpointFactory.getSupportedProtocol();
     }
 
     @Override
     public void applyDefaultValue(Configuration configuration) {
         CoapsServerEndpointFactory.applyDefaultValue(configuration);
+
     }
 
     @Override
@@ -44,14 +45,15 @@ public class CoapsServerProtocolProvider implements ServerProtocolProvider {
         return CoapsServerEndpointFactory.getModuleDefinitionsProviders();
     }
 
-    @Override
-    public CaliforniumServerEndpointFactory createDefaultEndpointFactory(URI uri) {
-        return new CoapsServerEndpointFactory(uri);
+    public CoapsServerEndpointFactoryBuilder setDtlsConnectorConfig(
+            Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer) {
+        this.dtlsConnectorConfigInitializer = dtlsConnectorConfigInitializer;
+        return this;
     }
 
     @Override
-    public URI getDefaultUri(Configuration configuration) {
-        return EndpointUriUtil.createUri(getProtocol().getUriScheme(),
-                new InetSocketAddress(configuration.get(CoapConfig.COAP_SECURE_PORT)));
+    public CoapsServerEndpointFactory build() {
+        return new CoapsServerEndpointFactory(uri, loggingTagPrefix, configuration, dtlsConnectorConfigInitializer,
+                coapEndpointConfigInitializer);
     }
 }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerProtocolProvider.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerProtocolProvider.java
@@ -18,16 +18,27 @@ package org.eclipse.leshan.server.californium.endpoint.coaps;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.ModuleDefinitionsProvider;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointFactory;
 import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
 
 public class CoapsServerProtocolProvider implements ServerProtocolProvider {
+
+    protected Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer;
+
+    public CoapsServerProtocolProvider() {
+    }
+
+    public CoapsServerProtocolProvider(Consumer<DtlsConnectorConfig.Builder> dtlsConnectorConfigInitializer) {
+        this.dtlsConnectorConfigInitializer = dtlsConnectorConfigInitializer;
+    }
 
     @Override
     public Protocol getProtocol() {
@@ -46,7 +57,8 @@ public class CoapsServerProtocolProvider implements ServerProtocolProvider {
 
     @Override
     public CaliforniumServerEndpointFactory createDefaultEndpointFactory(URI uri) {
-        return new CoapsServerEndpointFactory(uri);
+        return new CoapsServerEndpointFactoryBuilder().setURI(uri)
+                .setDtlsConnectorConfig(dtlsConnectorConfigInitializer).build();
     }
 
     @Override

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerBuilderTest.java
@@ -34,7 +34,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.KeySpec;
 
-import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.leshan.core.endpoint.Protocol;
@@ -140,9 +139,9 @@ public class LeshanServerBuilderTest {
     public void create_server_without_psk_cipher() {
         Builder endpointsBuilder = new CaliforniumServerEndpointsProvider.Builder(new CoapsServerProtocolProvider());
 
-        Configuration coapConfiguration = endpointsBuilder.createDefaultConfiguration();
-        coapConfiguration.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
-        endpointsBuilder.setConfiguration(coapConfiguration);
+        endpointsBuilder.setConfiguration(c -> {
+            c.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
+        });
 
         builder.setPrivateKey(privateKey);
         builder.setPublicKey(publicKey);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilderTest.java
@@ -35,7 +35,6 @@ import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.KeySpec;
 import java.util.Iterator;
 
-import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.leshan.core.endpoint.Protocol;
@@ -186,9 +185,9 @@ public class LeshanBootstrapServerBuilderTest {
     public void create_server_without_psk_cipher() {
         Builder endpointsBuilder = new CaliforniumBootstrapServerEndpointsProvider.Builder(
                 new CoapsBootstrapServerProtocolProvider());
-        Configuration coapConfiguration = endpointsBuilder.createDefaultConfiguration();
-        coapConfiguration.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
-        endpointsBuilder.setConfiguration(coapConfiguration);
+        endpointsBuilder.setConfiguration(c -> {
+            c.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
+        });
         builder.setEndpointsProvider(endpointsBuilder.build());
 
         builder.setPrivateKey(privateKey);


### PR DESCRIPTION
This aims to implements #1395.

I know that names are very long and I know that Builder of Factory sounds a bit heavy ... :disappointed:  but didn't find better name for now. 

API can be changed again if we find better idea/naming/design !

----------------------------------------------------

**1st Improvement :** shortcut to set `Configuration` at `CaliforniumServerEndpointsProvider` level

This allow to avoid to first create  config then set it.  It looks like : 

```java
endpointsBuilder.setConfiguration(c -> {
          c.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, true);
          c.set(CoapConfig.ACK_TIMEOUT , 1, TimeUnit.SECONDS);
      });
```
instead of 
```java
Configuration c = endpointsBuilder.createDefaultConfiguration();
c.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, true);
c.set(CoapConfig.ACK_TIMEOUT, 1, TimeUnit.SECONDS);
endpointsBuilder.setConfiguration(c);
```
(this :point_up:  API is not removed)

----------------------------------------------------------
**2nd Improvement :** Builder to create Endpoint Factory 

This allow to customize the factory easily. 

```java
endpointsBuilder.addEndpoint(new CoapsServerEndpointFactoryBuilder() //
        .setURI(5784) //
        .setConfiguration(c -> c.set(CoapConfig.ACK_TIMEOUT  , 1, TimeUnit.SECONDS)) //
        .setLoggingTagPrefix("Custom Coaps") //
        .setDtlsConnectorConfig(c -> c.setSessionStore(new CustomSessionStore())) //
        .setCoapEndpointConfig(c -> c.setTokenGenerator(new CustomTokenGenerator())) //
        .build());
```

----------------------------------------------------------

**3rd Improvement :**  Being able to set `DtlsConnectorConfig` at Protocol Provider level 

This aims to solve : https://github.com/eclipse/leshan/issues/1383

```java
LeshanServerBuilder serverBuilder = new LeshanServerBuilder();

CaliforniumServerEndpointsProvider.Builder endpointsBuilder = new CaliforniumServerEndpointsProvider.Builder(
        // add CoAP protocol Provider
        new CoapServerProtocolProvider(),

        // add CoAPS protocol Provider.
        new CoapsServerProtocolProvider(dtlsConfigBuilder -> {
            dtlsConfigBuilder.setSessionStore(new CustomSessionStore());
        }));

serverBuilder.setEndpointsProvider(endpointsBuilder.build());
```