### PR TITLE
Fix Invalid datatype for DTLS/TLS Ciphersuite resource (/0/?/16) in BootstrapConfig

### DIFF
--- a/leshan-server-core/pom.xml
+++ b/leshan-server-core/pom.xml
@@ -43,6 +43,11 @@ Contributors:
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -71,27 +71,35 @@ public class BootstrapConfig {
      */
     public ContentFormat contentFormat = null;
 
-    /** List of LWM2M path to delete. */
+    /**
+     * List of LWM2M path to delete.
+     */
     public List<String> toDelete = new ArrayList<>();
 
-    /** Map indexed by Server Instance Id. Key is the Server Instance to write. */
+    /**
+     * Map indexed by Server Instance Id. Key is the Server Instance to write.
+     */
     public Map<Integer, ServerConfig> servers = new HashMap<>();
 
-    /** Map indexed by Security Instance Id. Key is the Server Instance to write. */
+    /**
+     * Map indexed by Security Instance Id. Key is the Server Instance to write.
+     */
     public Map<Integer, ServerSecurity> security = new HashMap<>();
 
-    /** Map indexed by ACL Instance Id. Key is the ACL Instance to write. */
+    /**
+     * Map indexed by ACL Instance Id. Key is the ACL Instance to write.
+     */
     public Map<Integer, ACLConfig> acls = new HashMap<>();
 
-    /** Map indexed by OSCORE Object Instance Id. Key is the OSCORE Object Instance to write. */
+    /**
+     * Map indexed by OSCORE Object Instance Id. Key is the OSCORE Object Instance to write.
+     */
     public Map<Integer, OscoreObject> oscore = new HashMap<>();
 
     /** Server Configuration (object 1) as defined in LWM2M 1.0.x TS. */
     public static class ServerConfig {
 
-        /**
-         * Used as link to associate server Object Instance.
-         */
+        /** Used as link to associate server Object Instance. */
         public int shortId;
         /** Specify the lifetime of the registration in seconds (see Section 5.3 Registration). */
         public int lifetime = 86400;

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -509,7 +509,7 @@ public class BootstrapConfig {
          */
         @Override
         public String toString() {
-            return String.format("%02x,%02x", firstByte, secondByte);
+            return String.format("0x%02X,0x%02X", firstByte, secondByte);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -495,7 +495,7 @@ public class BootstrapConfig {
          */
         public CipherSuiteId(ULong valueFromSecurityObject) {
             if (valueFromSecurityObject.intValue() < 0 || valueFromSecurityObject.intValue() > 65535)
-                throw new IllegalArgumentException("ULong value have to be between <0, 65535>");
+                throw new IllegalArgumentException("ULong value MUST be a 16-bit unsigned integer (max value : 65535)");
             this.firstByte = (byte) ((valueFromSecurityObject.intValue() >> 8) & 0xFF);
             this.secondByte = (byte) ((valueFromSecurityObject.intValue()) & 0xFF);
         }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -509,7 +509,7 @@ public class BootstrapConfig {
          */
         @Override
         public String toString() {
-            return String.format("%x,%x", firstByte, secondByte);
+            return String.format("%02x,%02x", firstByte, secondByte);
         }
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapConfig.java
@@ -470,11 +470,15 @@ public class BootstrapConfig {
         private final byte secondByte;
 
         /**
-         * Ciphersuite is created with 2 bytes. Possible values are described in the
+         * Create {@link CipherSuiteId} from Cipher Suite value defined at IANA.
+         * <p>
+         * Possible values are described in the
          * <a href="https://iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4"> registry</a>.
+         * <p>
+         * This doesn't mean that Leshan supports all IANA registered Cipher Suites.
          *
-         * @param firstByte first byte of ciphersuite (for example 0xC0)
-         * @param secondByte second byte of ciphersuite (for example 0xA8)
+         * @param firstByte of Cipher Suite (e.g. {@code 0xC0} for {@code TLS_PSK_WITH_AES_128_CCM_8})
+         * @param secondByte of Cipher Suite (e.g. {@code 0xA8} for {@code TLS_PSK_WITH_AES_128_CCM_8})
          */
         public CipherSuiteId(byte firstByte, byte secondByte) {
             this.firstByte = firstByte;
@@ -482,10 +486,12 @@ public class BootstrapConfig {
         }
 
         /**
-         * Integer is split into 2 bytes for example 49320 (0xc0a8 in hex) will be split into "0xC0,0xA8". This format
-         * is used by Security Object, resource 16.
-         *
-         * @param valueFromSecurityObject Integer representing ciphersuite id
+         * Create {@link CipherSuiteId} from ULong value of "DTLS/TLS Ciphersuite" resource (Id:16) from "Security"
+         * Object (Id:0).
+         * <p>
+         * As an example, the {@code TLS_PSK_WITH_AES_128_CCM_8} Cipher Suite is represented with the following string
+         * "{@code 0xC0,0xA8}". To form an integer value the two values are concatenated. In this example, the value is
+         * {@code 0xc0a8} for {@code 49320}.
          */
         public CipherSuiteId(ULong valueFromSecurityObject) {
             if (valueFromSecurityObject.intValue() < 0 || valueFromSecurityObject.intValue() > 65535)
@@ -495,17 +501,18 @@ public class BootstrapConfig {
         }
 
         /**
-         * Two bytes of ciphersuite id are concatenated into integer value. As an example bytes "0xC0,0xA8" will be
-         * concatenated into 0xc0a8 which in decimal notation is 49320.
-         *
-         * @return Integer number concatenated from 2 bytes.
+         * @return Value used in "DTLS/TLS Ciphersuite" resource (Id:16) from "Security" Object (Id:0).
+         *         <p>
+         *         The two bytes from Cipher Suite id are concatenated into integer value. As an example bytes
+         *         "{@code 0xC0,0xA8}" will be concatenated into {@code 0xc0a8} which in decimal notation is
+         *         {@code 49320}.
          */
         public ULong getValueForSecurityObject() {
             return ULong.valueOf((Byte.toUnsignedInt(firstByte) << 8) | Byte.toUnsignedInt(secondByte));
         }
 
         /**
-         * @return String representing hex value of concatenated two bytes.
+         * @return String representing IANA Cipher Suite Value.
          */
         @Override
         public String toString() {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/BootstrapUtil.java
@@ -18,7 +18,9 @@ package org.eclipse.leshan.server.bootstrap;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
@@ -36,6 +38,7 @@ import org.eclipse.leshan.core.request.BootstrapDownlinkRequest;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.util.datatype.ULong;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ACLConfig;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.OscoreObject;
 import org.eclipse.leshan.server.bootstrap.BootstrapConfig.ServerConfig;
@@ -79,8 +82,14 @@ public class BootstrapUtil {
             resources.add(LwM2mSingleResource.newStringResource(14, securityConfig.sni));
         if (securityConfig.certificateUsage != null)
             resources.add(LwM2mSingleResource.newUnsignedIntegerResource(15, securityConfig.certificateUsage.code));
-        if (securityConfig.cipherSuite != null)
-            resources.add(LwM2mSingleResource.newUnsignedIntegerResource(16, securityConfig.cipherSuite));
+        if (securityConfig.cipherSuite != null) {
+            Map<Integer, ULong> ciperSuiteULong = new HashMap<>();
+            int i = 0;
+            for (BootstrapConfig.CipherSuiteId cipherSuiteId : securityConfig.cipherSuite) {
+                ciperSuiteULong.put(i++, cipherSuiteId.getValueForSecurityObject());
+            }
+            resources.add(LwM2mMultipleResource.newUnsignedIntegerResource(16, ciperSuiteULong));
+        }
         if (securityConfig.oscoreSecurityMode != null) {
             resources.add(LwM2mSingleResource.newObjectLinkResource(17,
                     new ObjectLink(21, securityConfig.oscoreSecurityMode)));

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.datatype.ULong;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -44,19 +43,31 @@ class BootstrapConfigTest {
         assertEquals(expectedResult, cipherSuiteId.toString());
     }
 
-    @Test
-    public void test_create_new_CipherSuiteId_from_ULong() {
+    @ParameterizedTest
+    @CsvSource(value = { // given ulong, expected ToString()
+            "49320 | 0xC0,0xA8", // TLS_PSK_WITH_AES_128_CCM_8
+            "    0 | 0x00,0x00", // test to lower limit
+            "65535 | 0xFF,0xFF", // test to upper limit
+
+    }, delimiter = '|')
+
+    public void test_create_new_CipherSuiteId_from_ULong(String input, String expectedResult) {
         // Create CipherSuiteId with ULong
-        BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(ULong.valueOf(49320));
+        BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(ULong.valueOf(input));
 
         // Assert if ULong was correctly phrased
-        assertEquals("0xC0,0xA8", cipherSuiteId.toString());
+        assertEquals(expectedResult, cipherSuiteId.toString());
     }
 
-    @Test
-    public void test_getValueForSecurityObject() {
+    @ParameterizedTest
+    @ValueSource(strings = { //
+            "49320", // TLS_PSK_WITH_AES_128_CCM_8
+            "0", // test to lower limit
+            "65535", // test to upper limit
+    })
+    public void test_getValueForSecurityObject(String input) {
         // Create example ULong
-        ULong testValue = ULong.valueOf(49320);
+        ULong testValue = ULong.valueOf(input);
 
         // Create cipherSuiteId from ULong
         BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(testValue);

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
@@ -30,8 +30,8 @@ class BootstrapConfigTest {
 
     @ParameterizedTest
     @CsvSource(value = { // given 2 bytes, expected ToString()
-            "C0A8 | c0,a8", // TLS_PSK_WITH_AES_128_CCM_8
-            "0003 | 00,03", // TLS_RSA_EXPORT_WITH_RC4_40_MD5
+            "C0A8 | 0xC0,0xA8", // TLS_PSK_WITH_AES_128_CCM_8
+            "0003 | 0x00,0x03", // TLS_RSA_EXPORT_WITH_RC4_40_MD5
     }, delimiter = '|')
     public void test_toString(String input, String expectedResult) {
         // Given 2 bytes
@@ -50,7 +50,7 @@ class BootstrapConfigTest {
         BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(ULong.valueOf(49320));
 
         // Assert if ULong was correctly phrased
-        assertEquals("c0,a8", cipherSuiteId.toString());
+        assertEquals("0xC0,0xA8", cipherSuiteId.toString());
     }
 
     @Test

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
@@ -23,20 +23,25 @@ import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.datatype.ULong;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class BootstrapConfigTest {
 
-    @Test
-    public void test_toString() {
+    @ParameterizedTest
+    @CsvSource(value = { // given 2 bytes, expected ToString()
+            "C0A8 | c0,a8", // TLS_PSK_WITH_AES_128_CCM_8
+            "0003 | 00,03", // TLS_RSA_EXPORT_WITH_RC4_40_MD5
+    }, delimiter = '|')
+    public void test_toString(String input, String expectedResult) {
         // Given 2 bytes
-        byte[] decoded = Hex.decodeHex("C0A8".toCharArray());
+        byte[] decoded = Hex.decodeHex(input.toCharArray());
 
         // Create CipherSuiteId
         BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(decoded[0], decoded[1]);
 
         // Assert if bytes were correctly phrased
-        assertEquals("c0,a8", cipherSuiteId.toString());
+        assertEquals(expectedResult, cipherSuiteId.toString());
     }
 
     @Test

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.datatype.ULong;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class BootstrapConfigTest {
 
@@ -58,10 +60,15 @@ class BootstrapConfigTest {
         assertEquals(testValue, cipherSuiteId.getValueForSecurityObject());
     }
 
-    @Test
-    public void test_error_thrown_for_invalid_ulong() {
+    @ParameterizedTest
+    @ValueSource(strings = { //
+            "2147483647", // max 32-bit signed Integer
+            "2147483648", // max 32-bit signed Integer + 1
+            "65536"// max 16-bit signed Integer +1
+    })
+    public void test_error_thrown_for_invalid_ulong(String invalidULong) {
         // Create ULong from String
-        ULong testValue = ULong.valueOf(65536);
+        ULong testValue = ULong.valueOf(invalidULong);
 
         // Try to create CipherSuiteId with ULong outside of range
         assertThrowsExactly(IllegalArgumentException.class, () -> new BootstrapConfig.CipherSuiteId(testValue));

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
@@ -17,6 +17,7 @@
 package org.eclipse.leshan.server.bootstrap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.datatype.ULong;
@@ -25,21 +26,19 @@ import org.junit.jupiter.api.Test;
 class BootstrapConfigTest {
 
     @Test
-    public void CipherSuiteId_encode_from_two_bytes() {
-        // Create 2 bytes
+    public void test_toString() {
+        // Given 2 bytes
         byte[] decoded = Hex.decodeHex("C0A8".toCharArray());
-        Byte firstByte = decoded[0];
-        Byte secoundByte = decoded[1];
 
-        // Create CipherSuiteId with two bytes
-        BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(firstByte, secoundByte);
+        // Create CipherSuiteId
+        BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(decoded[0], decoded[1]);
 
         // Assert if bytes were correctly phrased
         assertEquals("c0,a8", cipherSuiteId.toString());
     }
 
     @Test
-    public void CipherSuiteId_encode_from_ULong() {
+    public void test_create_new_CipherSuiteId_from_ULong() {
         // Create CipherSuiteId with ULong
         BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(ULong.valueOf(49320));
 
@@ -48,7 +47,7 @@ class BootstrapConfigTest {
     }
 
     @Test
-    public void getValueForSecurityObject() {
+    public void test_getValueForSecurityObject() {
         // Create example ULong
         ULong testValue = ULong.valueOf(49320);
 
@@ -60,17 +59,11 @@ class BootstrapConfigTest {
     }
 
     @Test
-    public void is_error_thrown_for_too_big_values() {
-        // Create ULong with value bigger than 65535
+    public void test_error_thrown_for_invalid_ulong() {
+        // Create ULong from String
         ULong testValue = ULong.valueOf(65536);
 
         // Try to create CipherSuiteId with ULong outside of range
-        try {
-            new BootstrapConfig.CipherSuiteId(testValue);
-            assert (false);
-        } catch (IllegalArgumentException e) {
-            // If IllegalArgumentException is caught pass the test
-            assert (true);
-        }
+        assertThrowsExactly(IllegalArgumentException.class, () -> new BootstrapConfig.CipherSuiteId(testValue));
     }
 }

--- a/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
+++ b/leshan-server-core/src/test/java/org/eclipse/leshan/server/bootstrap/BootstrapConfigTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Bartosz Stolarczyk
+ *     Orange Polska S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.leshan.core.util.Hex;
+import org.eclipse.leshan.core.util.datatype.ULong;
+import org.junit.jupiter.api.Test;
+
+class BootstrapConfigTest {
+
+    @Test
+    public void CipherSuiteId_encode_from_two_bytes() {
+        // Create 2 bytes
+        byte[] decoded = Hex.decodeHex("C0A8".toCharArray());
+        Byte firstByte = decoded[0];
+        Byte secoundByte = decoded[1];
+
+        // Create CipherSuiteId with two bytes
+        BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(firstByte, secoundByte);
+
+        // Assert if bytes were correctly phrased
+        assertEquals("c0,a8", cipherSuiteId.toString());
+    }
+
+    @Test
+    public void CipherSuiteId_encode_from_ULong() {
+        // Create CipherSuiteId with ULong
+        BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(ULong.valueOf(49320));
+
+        // Assert if ULong was correctly phrased
+        assertEquals("c0,a8", cipherSuiteId.toString());
+    }
+
+    @Test
+    public void getValueForSecurityObject() {
+        // Create example ULong
+        ULong testValue = ULong.valueOf(49320);
+
+        // Create cipherSuiteId from ULong
+        BootstrapConfig.CipherSuiteId cipherSuiteId = new BootstrapConfig.CipherSuiteId(testValue);
+
+        // Check if getValueForSecurityObject() returns input ULong
+        assertEquals(testValue, cipherSuiteId.getValueForSecurityObject());
+    }
+
+    @Test
+    public void is_error_thrown_for_too_big_values() {
+        // Create ULong with value bigger than 65535
+        ULong testValue = ULong.valueOf(65536);
+
+        // Try to create CipherSuiteId with ULong outside of range
+        try {
+            new BootstrapConfig.CipherSuiteId(testValue);
+            assert (false);
+        } catch (IllegalArgumentException e) {
+            // If IllegalArgumentException is caught pass the test
+            assert (true);
+        }
+    }
+}


### PR DESCRIPTION
This aims to fix #1402.
This is work is based on PR #1404 