### PR TITLE
ci: use actions/setup-java temurin distribution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
 
     # ------------- Begin of : Build Steps ------------- 


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates

See : https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
