### PR TITLE
Fixed wrongly assigned EXE buttons

### DIFF
--- a/leshan-server-demo/webapp/src/components/resources/ResourceControl.vue
+++ b/leshan-server-demo/webapp/src/components/resources/ResourceControl.vue
@@ -93,7 +93,7 @@ export default {
       return this.resourcedef.operations.includes("W");
     },
     executable() {
-      return this.resourcedef.operations.includes("E");
+      return this.resourcedef.operations == ("E");
     },
   },
   methods: {


### PR DESCRIPTION
Fixed wrong recognition of "NONE" operation as "E" (Execute) in web app, causing resources without operations to be assigned "EXE" buttons

Aims to implement [#1441](https://github.com/eclipse/leshan/issues/1441)