### PR TITLE
Add `transport` command to leshan-client-demo

### DIFF
--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -37,6 +37,10 @@ Contributors:
       <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-core-demo</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-client</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -31,23 +31,15 @@ import static org.eclipse.leshan.core.LwM2mId.OSCORE;
 import static org.eclipse.leshan.core.LwM2mId.SECURITY;
 import static org.eclipse.leshan.core.LwM2mId.SERVER;
 
-import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
 
-import org.eclipse.californium.elements.config.Configuration;
-import org.eclipse.californium.scandium.config.DtlsConfig;
-import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
-import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.leshan.client.LeshanClient;
 import org.eclipse.leshan.client.LeshanClientBuilder;
-import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpointFactory;
-import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpointsProvider;
-import org.eclipse.leshan.client.californium.endpoint.coap.CoapOscoreProtocolProvider;
-import org.eclipse.leshan.client.californium.endpoint.coaps.CoapsClientEndpointFactory;
-import org.eclipse.leshan.client.californium.endpoint.coaps.CoapsClientProtocolProvider;
 import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
 import org.eclipse.leshan.client.demo.cli.interactive.InteractiveCommands;
+import org.eclipse.leshan.client.demo.cli.transport.TransportCommand;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.LwM2mTestObject;
 import org.eclipse.leshan.client.object.Oscore;
@@ -56,8 +48,8 @@ import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;
 import org.eclipse.leshan.client.send.ManualDataSender;
-import org.eclipse.leshan.core.californium.PrincipalMdcConnectionListener;
 import org.eclipse.leshan.core.demo.LwM2mDemoConstant;
+import org.eclipse.leshan.core.demo.cli.PicocliUtil;
 import org.eclipse.leshan.core.demo.cli.ShortErrorMessageHandler;
 import org.eclipse.leshan.core.demo.cli.interactive.InteractiveCLI;
 import org.eclipse.leshan.core.model.LwM2mModelRepository;
@@ -69,6 +61,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
+import picocli.CommandLine.RunAll;
 
 public class LeshanClientDemo {
 
@@ -83,26 +76,27 @@ public class LeshanClientDemo {
     private static final Logger LOG = LoggerFactory.getLogger(LeshanClientDemo.class);
     private static final int OBJECT_ID_TEMPERATURE_SENSOR = 3303;
     private static final int OBJECT_ID_LWM2M_TEST_OBJECT = 3442;
-    private static final String CF_CONFIGURATION_FILENAME = "Californium3.client.properties";
-    private static final String CF_CONFIGURATION_HEADER = "Leshan Client Demo - " + Configuration.DEFAULT_HEADER;
 
     public static void main(String[] args) {
 
         // Parse command line
         LeshanClientDemoCLI cli = new LeshanClientDemoCLI();
-        CommandLine command = new CommandLine(cli).setParameterExceptionHandler(new ShortErrorMessageHandler());
+        CommandLine command = new CommandLine(cli) //
+                .setExecutionStrategy(new RunAll()).setParameterExceptionHandler(new ShortErrorMessageHandler());
+
         // Handle exit code error
         int exitCode = command.execute(args);
         if (exitCode != 0)
             System.exit(exitCode);
         // Handle help or version command
-        if (command.isUsageHelpRequested() || command.isVersionHelpRequested())
+        if (command.isUsageHelpRequested() || command.isVersionHelpRequested() || PicocliUtil.isHelpRequested(command))
             System.exit(0);
 
         try {
             // Create Client
             LwM2mModelRepository repository = createModel(cli);
-            final LeshanClient client = createClient(cli, repository);
+            List<LwM2mClientEndpointsProvider> endpointProviders = createEndpointsProviders(cli, command);
+            final LeshanClient client = createClient(cli, repository, endpointProviders);
 
             // Print commands help
             InteractiveCLI console = new InteractiveCLI(new InteractiveCommands(client, repository));
@@ -145,7 +139,18 @@ public class LeshanClientDemo {
         return new LwM2mModelRepository(models);
     }
 
-    public static LeshanClient createClient(LeshanClientDemoCLI cli, LwM2mModelRepository repository) throws Exception {
+    private static List<LwM2mClientEndpointsProvider> createEndpointsProviders(LeshanClientDemoCLI cli,
+            CommandLine commandLine) {
+        // Get transport command
+        CommandLine transportCommand = commandLine.getSubcommands().get("transport");
+        List<LwM2mClientEndpointsProvider> providers = ((TransportCommand) transportCommand.getCommandSpec()
+                .userObject()).createEndpointsProviders(cli, transportCommand);
+
+        return providers;
+    }
+
+    public static LeshanClient createClient(LeshanClientDemoCLI cli, LwM2mModelRepository repository,
+            List<LwM2mClientEndpointsProvider> endpointProviders) throws Exception {
         // create Leshan client from command line option
         final MyLocation locationInstance = new MyLocation(cli.location.position.latitude,
                 cli.location.position.longitude, cli.location.scaleFactor);
@@ -233,65 +238,10 @@ public class LeshanClientDemo {
         engineFactory.setResumeOnConnect(!cli.dtls.forceFullhandshake);
         engineFactory.setQueueMode(cli.main.queueMode);
 
-        // Create Californium Endpoints Provider:
-        // --------------------------------------
-        // Define Custom CoAPS protocol provider
-        CoapsClientProtocolProvider customCoapsProtocolProvider = new CoapsClientProtocolProvider() {
-            @Override
-            public CaliforniumClientEndpointFactory createDefaultEndpointFactory() {
-                return new CoapsClientEndpointFactory() {
-
-                    @Override
-                    protected DtlsConnectorConfig.Builder createRootDtlsConnectorConfigBuilder(
-                            Configuration configuration) {
-                        Builder builder = super.createRootDtlsConnectorConfigBuilder(configuration);
-
-                        // Add DTLS Session lifecycle logger
-                        builder.setSessionListener(new DtlsSessionLogger());
-
-                        // Add MDC for connection logs
-                        if (cli.helpsOptions.getVerboseLevel() > 0)
-                            builder.setConnectionListener(new PrincipalMdcConnectionListener());
-                        return builder;
-                    };
-                };
-            }
-        };
-
-        // Create client endpoints Provider
-        CaliforniumClientEndpointsProvider.Builder endpointsBuilder = new CaliforniumClientEndpointsProvider.Builder(
-                new CoapOscoreProtocolProvider(), customCoapsProtocolProvider);
-
-        // Create Californium Configuration
-        Configuration clientCoapConfig = endpointsBuilder.createDefaultConfiguration();
-
-        // Set some DTLS stuff
-        // These configuration values are always overwritten by CLI therefore set them to transient.
-        clientCoapConfig.setTransient(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY);
-        clientCoapConfig.setTransient(DtlsConfig.DTLS_CONNECTION_ID_LENGTH);
-        clientCoapConfig.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, !cli.dtls.supportDeprecatedCiphers);
-        clientCoapConfig.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, cli.dtls.cid);
-        if (cli.dtls.ciphers != null) {
-            clientCoapConfig.set(DtlsConfig.DTLS_CIPHER_SUITES, cli.dtls.ciphers);
-        }
-
-        // Persist configuration
-        File configFile = new File(CF_CONFIGURATION_FILENAME);
-        if (configFile.isFile()) {
-            clientCoapConfig.load(configFile);
-        } else {
-            clientCoapConfig.store(configFile, CF_CONFIGURATION_HEADER);
-        }
-
-        // Set Californium Configuration
-        endpointsBuilder.setConfiguration(clientCoapConfig);
-
-        endpointsBuilder.setClientAddress(cli.main.localAddress);
-
         // Create client
         LeshanClientBuilder builder = new LeshanClientBuilder(cli.main.endpoint);
         builder.setObjects(enablers);
-        builder.setEndpointsProviders(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointProviders);
         builder.setDataSenders(new ManualDataSender());
         if (cli.identity.isx509())
             builder.setTrustStore(cli.identity.getX509().trustStore);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
+import org.eclipse.leshan.client.demo.cli.transport.TransportCommand;
+import org.eclipse.leshan.client.demo.cli.transport.californium.CaliforniumCommand;
 import org.eclipse.leshan.core.CertificateUsage;
 import org.eclipse.leshan.core.demo.cli.MultiParameterException;
 import org.eclipse.leshan.core.demo.cli.StandardHelpOptions;
@@ -34,6 +36,7 @@ import org.eclipse.leshan.core.util.StringUtils;
 
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.ITypeConverter;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
@@ -49,11 +52,16 @@ import picocli.CommandLine.Spec;
                  + "@|italic " //
                  + "This is a LWM2M client demo implemented with Leshan library.%n" //
                  + "You can launch it without any option and it will try to register to a LWM2M server at " + "coap://"
-                 + LeshanClientDemoCLI.DEFAULT_COAP_URL + ".%n" //
+                 + LeshanClientDemoCLI.DEFAULT_COAP_URL + ".|@%n" //
                  + "%n" //
-                 + "Californium is used as CoAP library and some CoAP parameters can be tweaked in 'Californium.properties' file." //
-                 + "|@%n%n",
-         versionProvider = VersionProvider.class)
+                 + CaliforniumCommand.DEFAULT_DESCRIPTION //
+                 + "%n" //
+                 + "You can use @|bold transport|@ command to use different transport layer.%n"
+                 + "Launch @|bold transport -h|@ for more details.%n" //
+                 + "%n",
+         versionProvider = VersionProvider.class,
+         subcommands = { HelpCommand.class, TransportCommand.class })
+
 public class LeshanClientDemoCLI implements Runnable {
 
     public static final String DEFAULT_COAP_URL = "localhost:" + CoAP.DEFAULT_COAP_PORT;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/DefaultEndpointProviderFactory.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/DefaultEndpointProviderFactory.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport;
+
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+
+import picocli.CommandLine;
+
+public interface DefaultEndpointProviderFactory {
+    LwM2mClientEndpointsProvider createDefault(LeshanClientDemoCLI cli, CommandLine commandLine);
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/EndpointProviderFactory.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/EndpointProviderFactory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport;
+
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+
+import picocli.CommandLine.ParseResult;
+
+public interface EndpointProviderFactory {
+
+    LwM2mClientEndpointsProvider create(LeshanClientDemoCLI cli, ParseResult result);
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/TransportCommand.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/TransportCommand.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+import org.eclipse.leshan.client.demo.cli.transport.californium.CaliforniumCommand;
+import org.eclipse.leshan.client.demo.cli.transport.javacoap.JavaCoapCommand;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.core.demo.cli.PicocliUtil;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "transport",
+         description = {
+                 "Configure Leshan transport layer. Can be used to add, remove or use different implementation of supported LWM2M transport.", //
+                 "%n"//
+                         + CaliforniumCommand.DEFAULT_DESCRIPTION //
+                         + CaliforniumCommand.DEFAULT_COMMAND_DESCRIPTION //
+                         + "%n" //
+                         + "@|italic More examples :|@%n" //
+                         + CaliforniumCommand.COMMON_USAGE //
+                         + "%n" //
+                         + JavaCoapCommand.COMMON_USAGE //
+                         + "%n" //
+                         + "coaps support based on Californium library and coap support based java-coap library: %n" //
+                         + "@|bold transport californium coaps java-coap coap|@%n"//
+                         + "%n" //
+                         + "Launch @|bold transport [californium|java-coap] -h|@ for more details.%n" //
+         },
+         subcommandsRepeatable = true,
+         subcommands = { CaliforniumCommand.class, JavaCoapCommand.class })
+public class TransportCommand implements Runnable {
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+    }
+
+    public List<LwM2mClientEndpointsProvider> createEndpointsProviders(LeshanClientDemoCLI cli,
+            CommandLine commandLine) {
+
+        // if transport sub-command is called
+        if (commandLine.getParseResult() != null && commandLine.getParseResult().hasSubcommand()) {
+            List<LwM2mClientEndpointsProvider> providers = new ArrayList<>();
+
+            // add provider from call sub-commands
+            PicocliUtil.applyTo(commandLine.getParseResult(), EndpointProviderFactory.class, //
+                    (parseResult, endpointProviderFactory) -> {
+                        providers.add(endpointProviderFactory.create(cli, parseResult));
+                    });
+            return providers;
+        }
+        // else create default providers
+        else {
+            List<LwM2mClientEndpointsProvider> providers = new ArrayList<>();
+            PicocliUtil.applyTo(commandLine, DefaultEndpointProviderFactory.class, //
+                    (cmd, endpointProviderFactory) -> {
+                        providers.add(endpointProviderFactory.createDefault(cli, cmd));
+                    });
+            return providers;
+        }
+    }
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/CaliforniumCommand.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/CaliforniumCommand.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport.californium;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpointsProvider;
+import org.eclipse.leshan.client.californium.endpoint.ClientProtocolProvider;
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+import org.eclipse.leshan.client.demo.cli.transport.DefaultEndpointProviderFactory;
+import org.eclipse.leshan.client.demo.cli.transport.EndpointProviderFactory;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.core.demo.cli.PicocliUtil;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+@Command(name = "californium",
+         description = { "Configure transport based on Californium.", //
+                 "%n"//
+                         + CaliforniumCommand.DEFAULT_DESCRIPTION //
+                         + CaliforniumCommand.DEFAULT_COMMAND_DESCRIPTION //
+                         + "%n" //
+                         + "@|italic More examples :|@%n" //
+                         + CaliforniumCommand.COMMON_USAGE //
+         },
+         subcommandsRepeatable = true,
+         subcommands = { //
+                 CoapCommand.class, //
+                 CoapsCommand.class })
+public class CaliforniumCommand implements Runnable, EndpointProviderFactory, DefaultEndpointProviderFactory {
+
+    // Configuration file constant
+    private static final String CF_CONFIGURATION_FILENAME = "Californium3.client.properties";
+    private static final String CF_CONFIGURATION_HEADER = "Leshan Client Demo - " + Configuration.DEFAULT_HEADER;
+
+    // Description constant
+    public static final String DEFAULT_DESCRIPTION = "By default, Californium library is used for coap/coaps. Some Californium parameters can be tweaked in " //
+            + CF_CONFIGURATION_FILENAME + " file." + "%n";
+    public static final String DEFAULT_COMMAND = "transport californium coap coaps";
+    public static final String DEFAULT_COMMAND_DESCRIPTION = "Default behavior is like using : %n@|bold "
+            + DEFAULT_COMMAND + "|@%n";
+    public static final String COMMON_USAGE = "coaps support only based on Californium library : %n" //
+            + "@|bold transport californium coaps|@%n";
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public LwM2mClientEndpointsProvider create(LeshanClientDemoCLI cli, ParseResult parseResult) {
+
+        // if sub command was called
+        if (parseResult.hasSubcommand()) {
+            // Get Protocols providers
+            List<ClientProtocolProvider> protocolProviders = new ArrayList<>();
+            PicocliUtil.applyTo(parseResult, ProtocolProviderFactory.class, (result, protocolProviderFactory) -> {
+                protocolProviders.add(protocolProviderFactory.create(cli, result));
+            });
+
+            return create(cli, protocolProviders);
+        }
+        // else create default provider
+        else {
+            return createDefault(cli, parseResult.commandSpec().commandLine());
+        }
+    }
+
+    @Override
+    public LwM2mClientEndpointsProvider createDefault(LeshanClientDemoCLI cli, CommandLine commandLine) {
+        // Create default protocols providers
+        List<ClientProtocolProvider> protocolProviders = new ArrayList<>();
+        PicocliUtil.applyTo(commandLine, DefaultProtocolProviderFactory.class, (cmdLine, protocolProviderFactory) -> {
+            protocolProviders.add(protocolProviderFactory.create(cli, cmdLine));
+        });
+
+        return create(cli, protocolProviders);
+    }
+
+    private LwM2mClientEndpointsProvider create(LeshanClientDemoCLI cli,
+            List<ClientProtocolProvider> protocolProvider) {
+        // Create client endpoints Provider
+        CaliforniumClientEndpointsProvider.Builder endpointsBuilder = new CaliforniumClientEndpointsProvider.Builder(
+                protocolProvider.toArray(new ClientProtocolProvider[protocolProvider.size()]));
+
+        // Create Californium Configuration
+        Configuration clientCoapConfig = endpointsBuilder.createDefaultConfiguration();
+        // Persist configuration
+        File configFile = new File(CF_CONFIGURATION_FILENAME);
+        if (configFile.isFile()) {
+            clientCoapConfig.load(configFile);
+        } else {
+            clientCoapConfig.store(configFile, CF_CONFIGURATION_HEADER);
+        }
+        // Set Californium Configuration
+        endpointsBuilder.setConfiguration(clientCoapConfig);
+
+        // define local address
+        endpointsBuilder.setClientAddress(cli.main.localAddress);
+        return endpointsBuilder.build();
+    }
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/CoapCommand.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/CoapCommand.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.leshan.client.demo.cli.transport.californium;
+
+import org.eclipse.leshan.client.californium.endpoint.ClientProtocolProvider;
+import org.eclipse.leshan.client.californium.endpoint.coap.CoapOscoreProtocolProvider;
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+/**
+ * To add coap support.
+ */
+@Command(name = "coap", description = "Activate coap support.")
+public class CoapCommand implements Runnable, ProtocolProviderFactory, DefaultProtocolProviderFactory {
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public ClientProtocolProvider create(LeshanClientDemoCLI cli, ParseResult result) {
+        return new CoapOscoreProtocolProvider();
+    }
+
+    @Override
+    public ClientProtocolProvider create(LeshanClientDemoCLI cli, CommandLine cmdLine) {
+        return new CoapOscoreProtocolProvider();
+    }
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/CoapsCommand.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/CoapsCommand.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.leshan.client.demo.cli.transport.californium;
+
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.scandium.config.DtlsConfig;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
+import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpointFactory;
+import org.eclipse.leshan.client.californium.endpoint.ClientProtocolProvider;
+import org.eclipse.leshan.client.californium.endpoint.coaps.CoapsClientEndpointFactory;
+import org.eclipse.leshan.client.californium.endpoint.coaps.CoapsClientProtocolProvider;
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+import org.eclipse.leshan.core.californium.PrincipalMdcConnectionListener;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+/**
+ * To add coap support.
+ */
+@Command(name = "coaps", description = "Activate coaps support.")
+public class CoapsCommand implements Runnable, ProtocolProviderFactory, DefaultProtocolProviderFactory {
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public ClientProtocolProvider create(LeshanClientDemoCLI cli, ParseResult result) {
+        return create(cli);
+    }
+
+    @Override
+    public ClientProtocolProvider create(LeshanClientDemoCLI cli, CommandLine cmdLine) {
+        return create(cli);
+    }
+
+    private ClientProtocolProvider create(LeshanClientDemoCLI cli) {
+        return new CoapsClientProtocolProvider() {
+
+            @Override
+            public void applyDefaultValue(Configuration configuration) {
+                super.applyDefaultValue(configuration);
+                // These configuration values are always overwritten by CLI therefore set them to transient.
+                configuration.setTransient(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY);
+                configuration.setTransient(DtlsConfig.DTLS_CONNECTION_ID_LENGTH);
+                configuration.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, !cli.dtls.supportDeprecatedCiphers);
+                configuration.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, cli.dtls.cid);
+                if (cli.dtls.ciphers != null) {
+                    configuration.set(DtlsConfig.DTLS_CIPHER_SUITES, cli.dtls.ciphers);
+                }
+            }
+
+            @Override
+            public CaliforniumClientEndpointFactory createDefaultEndpointFactory() {
+                return new CoapsClientEndpointFactory() {
+
+                    @Override
+                    protected DtlsConnectorConfig.Builder createRootDtlsConnectorConfigBuilder(
+                            Configuration configuration) {
+                        Builder builder = super.createRootDtlsConnectorConfigBuilder(configuration);
+
+                        // Add DTLS Session lifecycle logger
+                        builder.setSessionListener(new DtlsSessionLogger());
+
+                        // Add MDC for connection logs
+                        if (cli.helpsOptions.getVerboseLevel() > 0)
+                            builder.setConnectionListener(new PrincipalMdcConnectionListener());
+                        return builder;
+                    };
+                };
+            };
+        };
+    }
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/DefaultProtocolProviderFactory.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/DefaultProtocolProviderFactory.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport.californium;
+
+import org.eclipse.leshan.client.californium.endpoint.ClientProtocolProvider;
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+
+import picocli.CommandLine;
+
+public interface DefaultProtocolProviderFactory {
+    ClientProtocolProvider create(LeshanClientDemoCLI cli, CommandLine cmdLine);
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/DtlsSessionLogger.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/DtlsSessionLogger.java
@@ -13,7 +13,7 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
-package org.eclipse.leshan.client.demo;
+package org.eclipse.leshan.client.demo.cli.transport.californium;
 
 import org.eclipse.californium.scandium.dtls.ClientHandshaker;
 import org.eclipse.californium.scandium.dtls.DTLSContext;

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/ProtocolProviderFactory.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/californium/ProtocolProviderFactory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport.californium;
+
+import org.eclipse.leshan.client.californium.endpoint.ClientProtocolProvider;
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+
+import picocli.CommandLine.ParseResult;
+
+public interface ProtocolProviderFactory {
+
+    ClientProtocolProvider create(LeshanClientDemoCLI cli, ParseResult result);
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/javacoap/CoapCommand.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/javacoap/CoapCommand.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport.javacoap;
+
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+import org.eclipse.leshan.client.demo.cli.transport.DefaultEndpointProviderFactory;
+import org.eclipse.leshan.client.demo.cli.transport.EndpointProviderFactory;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.transport.javacoap.client.endpoint.JavaCoapClientEndpointsProvider;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+/**
+ * To add coap support.
+ */
+@Command(name = "coap", description = "Activate coap support.")
+public class CoapCommand implements Runnable, EndpointProviderFactory, DefaultEndpointProviderFactory {
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public LwM2mClientEndpointsProvider create(LeshanClientDemoCLI cli, ParseResult result) {
+        return new JavaCoapClientEndpointsProvider();
+    }
+
+    @Override
+    public LwM2mClientEndpointsProvider createDefault(LeshanClientDemoCLI cli, CommandLine commandLine) {
+        return new JavaCoapClientEndpointsProvider();
+    }
+}

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/javacoap/JavaCoapCommand.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/transport/javacoap/JavaCoapCommand.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.demo.cli.transport.javacoap;
+
+import org.eclipse.leshan.client.demo.cli.LeshanClientDemoCLI;
+import org.eclipse.leshan.client.demo.cli.transport.DefaultEndpointProviderFactory;
+import org.eclipse.leshan.client.demo.cli.transport.EndpointProviderFactory;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.core.demo.cli.PicocliUtil;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+@Command(name = "java-coap",
+         description = { "Configure transport based on java-coap.", //
+                 "%n"//
+                         + "@|italic Example :|@%n" //
+                         + JavaCoapCommand.COMMON_USAGE //
+         },
+         subcommands = { CoapCommand.class })
+public class JavaCoapCommand implements Runnable, EndpointProviderFactory {
+
+    public static final String COMMON_USAGE = "coap support based on java-coap library : %n" //
+            + "@|bold transport java-coap coap|@%n";
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public LwM2mClientEndpointsProvider create(LeshanClientDemoCLI cli, ParseResult result) {
+        // if one sub-command is called
+        if (result.hasSubcommand()) {
+            // java-coap command support only 1 sub-command call (subcommandsRepeatable = false)
+            EndpointProviderFactory providerFactory = (EndpointProviderFactory) result.subcommand().commandSpec()
+                    .userObject();
+            return providerFactory.create(cli, result.subcommand());
+        } else {
+            // no sub-command is called we just create default one provider for java coap.
+            return PicocliUtil.reduceTo(result.commandSpec().commandLine(), DefaultEndpointProviderFactory.class, //
+                    (cmd, endpointProviderFactory) -> endpointProviderFactory.createDefault(cli, cmd));
+        }
+    }
+}

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/PicocliUtil.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/PicocliUtil.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.demo.cli;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+import picocli.CommandLine;
+import picocli.CommandLine.HelpCommand;
+import picocli.CommandLine.ParseResult;
+
+public class PicocliUtil {
+
+    /**
+     * Apply given function to any <strong>called</strong> sub-command which implement given type.
+     * <p>
+     * (This is direct sub-command, not recursive search here)
+     */
+    public static <T> void applyTo(ParseResult result, Class<T> searchedType,
+            BiConsumer<ParseResult, T> functionToApply) {
+
+        if (result.hasSubcommand()) {
+            for (ParseResult subResult : result.subcommands()) {
+                Object userDefinedCommand = subResult.commandSpec().userObject();
+                if (searchedType.isInstance(userDefinedCommand)) {
+                    functionToApply.accept(subResult, searchedType.cast(userDefinedCommand));
+                }
+            }
+        }
+    }
+
+    /**
+     * Apply given function to any <strong>registered</strong> (not necessarily called) sub-command which implement
+     * given type.
+     * <p>
+     * (This is direct sub-command, not recursive search here)
+     */
+    public static <T> void applyTo(CommandLine cmdline, Class<T> searchedType,
+            BiConsumer<CommandLine, T> functionToApply) {
+
+        Collection<CommandLine> subcommands = cmdline.getSubcommands().values();
+        if (!subcommands.isEmpty()) {
+            for (CommandLine subCommandLine : subcommands) {
+                Object userDefinedCommand = subCommandLine.getCommandSpec().userObject();
+                if (searchedType.isInstance(userDefinedCommand)) {
+                    functionToApply.accept(subCommandLine, searchedType.cast(userDefinedCommand));
+                }
+            }
+        }
+    }
+
+    /**
+     * Search in <strong>registered</strong> (not necessarily called) sub-command the first one which implement given
+     * type, then apply the given function to it which will create returned result.
+     * <p>
+     * (This is direct sub-command, not recursive search here)
+     */
+    public static <T, R> R reduceTo(CommandLine cmdline, Class<T> searchedType,
+            BiFunction<CommandLine, T, R> functionToApply) {
+
+        Collection<CommandLine> subcommands = cmdline.getSubcommands().values();
+        if (!subcommands.isEmpty()) {
+            for (CommandLine subCommandLine : subcommands) {
+                Object userDefinedCommand = subCommandLine.getCommandSpec().userObject();
+                if (searchedType.isInstance(userDefinedCommand)) {
+                    return functionToApply.apply(subCommandLine, searchedType.cast(userDefinedCommand));
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return true if help is requested
+     */
+    public static <T> boolean isHelpRequested(CommandLine cmdline) {
+        List<CommandLine> calledCommands = cmdline.getParseResult().asCommandLineList();
+
+        for (CommandLine calledCommand : calledCommands) {
+            if (calledCommand.isUsageHelpRequested()
+                    || calledCommand.getCommandSpec().userObject() instanceof HelpCommand) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/PicocliUtil.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/PicocliUtil.java
@@ -29,6 +29,24 @@ public class PicocliUtil {
     /**
      * Apply given function to any <strong>called</strong> sub-command which implement given type.
      * <p>
+     * (This is apply to whole direct and indirect children)
+     */
+    public static <T> void applyRecursivelyTo(ParseResult result, Class<T> searchedType,
+            BiConsumer<ParseResult, T> functionToApply) {
+
+        if (result.hasSubcommand()) {
+            for (CommandLine cmd : result.asCommandLineList()) {
+                Object userDefinedCommand = cmd.getCommandSpec().userObject();
+                if (searchedType.isInstance(userDefinedCommand)) {
+                    functionToApply.accept(cmd.getParseResult(), searchedType.cast(userDefinedCommand));
+                }
+            }
+        }
+    }
+
+    /**
+     * Apply given function to any <strong>called</strong> sub-command which implement given type.
+     * <p>
      * (This is direct sub-command, not recursive search here)
      */
     public static <T> void applyTo(ParseResult result, Class<T> searchedType,

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/cli/LeshanServerDemoCLI.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/cli/LeshanServerDemoCLI.java
@@ -19,10 +19,11 @@ import java.net.URI;
 
 import org.eclipse.leshan.core.demo.cli.StandardHelpOptions;
 import org.eclipse.leshan.core.demo.cli.VersionProvider;
-import org.eclipse.leshan.core.demo.cli.converters.PortConverter;
 import org.eclipse.leshan.server.core.demo.cli.DtlsSection;
 import org.eclipse.leshan.server.core.demo.cli.GeneralSection;
 import org.eclipse.leshan.server.core.demo.cli.IdentitySection;
+import org.eclipse.leshan.server.demo.transport.TransportCommand;
+import org.eclipse.leshan.server.demo.transport.californium.CaliforniumCommand;
 
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
@@ -41,11 +42,15 @@ import redis.clients.jedis.JedisPool;
          description = "%n"//
                  + "@|italic " //
                  + "This is a LWM2M Server demo implemented with Leshan library.%n" //
-                 + "You can launch it without any option.%n" //
+                 + "You can launch it without any option.|@%n" //
                  + "%n" //
-                 + "Californium is used as CoAP library and some CoAP parameters can be tweaked in 'Californium.properties' file." //
-                 + "|@%n%n",
-         versionProvider = VersionProvider.class)
+                 + CaliforniumCommand.DEFAULT_DESCRIPTION //
+                 + "%n" //
+                 + "You can use @|bold transport|@ command to configure available endpoints.%n"
+                 + "Launch @|bold transport -h|@ for more details.%n" //
+                 + "%n",
+         versionProvider = VersionProvider.class,
+         subcommands = { TransportCommand.class })
 public class LeshanServerDemoCLI implements Runnable {
 
     @Mixin
@@ -56,18 +61,6 @@ public class LeshanServerDemoCLI implements Runnable {
     public ServerGeneralSection main = new ServerGeneralSection();
 
     public static class ServerGeneralSection extends GeneralSection {
-        @Option(names = { "-jh", "--java-coap-host" },
-                description = { //
-                        "Set the local CoAP address of endpoint based on java-coap library.", //
-                        "Default: any local address." })
-        public String jlocalAddress;
-
-        @Option(names = { "-jp", "--java-coap-port" },
-                description = { //
-                        "Set the local CoAP port of endpoint based on java-coap library.", //
-                        "Default: ${DEFAULT-VALUE}" },
-                converter = PortConverter.class)
-        public Integer jlocalPort = 5685;
 
         @Option(names = { "-r", "--redis" },
                 description = { //

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/DefaultEndpointProviderFactory.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/DefaultEndpointProviderFactory.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport;
+
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+
+import picocli.CommandLine;
+
+public interface DefaultEndpointProviderFactory {
+    LwM2mServerEndpointsProvider createDefault(LeshanServerDemoCLI cli, CommandLine commandLine);
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/EndpointProviderFactory.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/EndpointProviderFactory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport;
+
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+
+import picocli.CommandLine.ParseResult;
+
+public interface EndpointProviderFactory {
+
+    LwM2mServerEndpointsProvider create(LeshanServerDemoCLI cli, ParseResult result);
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/TransportCommand.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/TransportCommand.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.leshan.core.demo.cli.PicocliUtil;
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+import org.eclipse.leshan.server.demo.transport.californium.CaliforniumCommand;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "transport",
+         description = { "Configure Leshan transport layer. Can be used to define available server endpoints.", //
+                 "%n"//
+                         + CaliforniumCommand.DEFAULT_DESCRIPTION //
+                         + CaliforniumCommand.DEFAULT_COMMAND_DESCRIPTION //
+                         + "%n" //
+                         + "@|italic More examples :|@%n" //
+                         + CaliforniumCommand.COMMON_USAGE //
+                         + "%n" //
+                         + "coaps support based on Californium library and coap support based java-coap library: %n" //
+                         + "@|bold transport californium coaps java-coap coap|@%n"//
+                         + "%n" //
+                         + "Launch @|bold transport [californium|java-coap] -h|@ for more details.%n" //
+         },
+         subcommandsRepeatable = true,
+         subcommands = { CaliforniumCommand.class })
+public class TransportCommand implements Runnable {
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+    }
+
+    public List<LwM2mServerEndpointsProvider> createEndpointsProviders(LeshanServerDemoCLI cli,
+            CommandLine commandLine) {
+
+        // if transport sub-command is called
+        if (commandLine.getParseResult() != null && commandLine.getParseResult().hasSubcommand()) {
+            List<LwM2mServerEndpointsProvider> providers = new ArrayList<>();
+
+            // add provider from call sub-commands
+            PicocliUtil.applyTo(commandLine.getParseResult(), EndpointProviderFactory.class, //
+                    (parseResult, endpointProviderFactory) -> {
+                        providers.add(endpointProviderFactory.create(cli, parseResult));
+                    });
+            return providers;
+        }
+        // else create default providers
+        else {
+            List<LwM2mServerEndpointsProvider> providers = new ArrayList<>();
+            PicocliUtil.applyTo(commandLine, DefaultEndpointProviderFactory.class, //
+                    (cmd, endpointProviderFactory) -> {
+                        providers.add(endpointProviderFactory.createDefault(cli, cmd));
+                    });
+            return providers;
+        }
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/AbstractAddCommand.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/AbstractAddCommand.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.leshan.core.demo.cli.converters.PortConverter;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointsProvider;
+
+import picocli.CommandLine.Option;
+
+public abstract class AbstractAddCommand implements Runnable, EndpointAdder {
+
+    @Option(names = { "-lh", "--address" },
+            description = { //
+                    "Set the local address of the endpoint.", //
+                    "Default: any local address." })
+    public String localAddress;
+
+    @Option(names = { "-lp", "--port" },
+            description = { //
+                    "Set the local port of the endpoint.", //
+                    "Default: Port value from 'Californium.properties' file or ${DEFAULT-VALUE} if absent" },
+            converter = PortConverter.class)
+    public Integer localPort;
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    public AbstractAddCommand(Integer defaultPort) {
+        this.localPort = defaultPort;
+    }
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public void addEndpointTo(CaliforniumServerEndpointsProvider.Builder provider) {
+        // int coapPort = cli.main.localPort == null ? serverCoapConfig.get(CoapConfig.COAP_PORT) : cli.main.localPort;
+
+        InetSocketAddress addr = localAddress == null ? new InetSocketAddress(localPort)
+                : new InetSocketAddress(localAddress, localPort);
+//        if (cli.main.disableOscore) {
+//            endpointsBuilder.addEndpoint(coapAddr, Protocol.COAP);
+//        } else {
+//            endpointsBuilder.addEndpoint(new CoapOscoreServerEndpointFactory(
+//                    EndpointUriUtil.createUri(Protocol.COAP.getUriScheme(), coapAddr)));
+//        }
+
+        provider.addEndpoint(addr, getProtocol());
+    }
+
+    protected abstract Protocol getProtocol();
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CaliforniumCommand.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CaliforniumCommand.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.leshan.core.demo.cli.PicocliUtil;
+import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointsProvider;
+import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+import org.eclipse.leshan.server.demo.transport.DefaultEndpointProviderFactory;
+import org.eclipse.leshan.server.demo.transport.EndpointProviderFactory;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+@Command(name = "californium",
+         description = { "Configure transport based on Californium.", //
+                 "%n"//
+                         + CaliforniumCommand.DEFAULT_DESCRIPTION //
+                         + CaliforniumCommand.DEFAULT_COMMAND_DESCRIPTION //
+                         + "%n" //
+                         + "@|italic More examples :|@%n" //
+                         + CaliforniumCommand.COMMON_USAGE //
+         },
+         subcommandsRepeatable = true,
+         subcommands = { //
+                 CoapCommand.class, //
+                 CoapsCommand.class })
+public class CaliforniumCommand implements Runnable, EndpointProviderFactory, DefaultEndpointProviderFactory {
+
+    // Configuration file constant
+    private static final String CF_CONFIGURATION_FILENAME = "Californium3.client.properties";
+    private static final String CF_CONFIGURATION_HEADER = "Leshan Client Demo - " + Configuration.DEFAULT_HEADER;
+
+    // Description constant
+    public static final String DEFAULT_DESCRIPTION = "By default, Californium library is used to create coap and coaps endpoints. Some Californium parameters can be tweaked in " //
+            + CF_CONFIGURATION_FILENAME + " file." + "%n";
+    public static final String DEFAULT_COMMAND = "transport californium coap coaps";
+    public static final String DEFAULT_COMMAND_DESCRIPTION = "Default behavior is like using : %n@|bold "
+            + DEFAULT_COMMAND + "|@%n";
+    public static final String COMMON_USAGE = "coaps support only based on Californium library : %n" //
+            + "@|bold transport californium coaps|@%n";
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public LwM2mServerEndpointsProvider create(LeshanServerDemoCLI cli, ParseResult parseResult) {
+
+        // if sub command was called
+        if (parseResult.hasSubcommand()) {
+            // Get Protocols providers
+            List<ServerProtocolProvider> protocolProviders = new ArrayList<>();
+            PicocliUtil.applyTo(parseResult, ProtocolProviderFactory.class, (result, protocolProviderFactory) -> {
+                protocolProviders.add(protocolProviderFactory.create(cli, result));
+            });
+
+            CaliforniumServerEndpointsProvider.Builder provider = create(cli, protocolProviders);
+
+            // create endpoints if needed :
+            PicocliUtil.applyRecursivelyTo(parseResult, EndpointAdder.class, (result, endpointAdder) -> {
+                endpointAdder.addEndpointTo(provider);
+            });
+            return provider.build();
+        }
+        // else create default provider
+        else {
+            return createDefault(cli, parseResult.commandSpec().commandLine());
+        }
+    }
+
+    @Override
+    public LwM2mServerEndpointsProvider createDefault(LeshanServerDemoCLI cli, CommandLine commandLine) {
+        // Create default protocols providers
+        List<ServerProtocolProvider> protocolProviders = new ArrayList<>();
+        PicocliUtil.applyTo(commandLine, DefaultProtocolProviderFactory.class, (cmdLine, protocolProviderFactory) -> {
+            protocolProviders.add(protocolProviderFactory.create(cli, cmdLine));
+        });
+
+        return create(cli, protocolProviders).build();
+    }
+
+    private CaliforniumServerEndpointsProvider.Builder create(LeshanServerDemoCLI cli,
+            List<ServerProtocolProvider> protocolProvider) {
+        // Create client endpoints Provider
+        CaliforniumServerEndpointsProvider.Builder endpointsBuilder = new CaliforniumServerEndpointsProvider.Builder(
+                protocolProvider.toArray(new ServerProtocolProvider[protocolProvider.size()]));
+
+        // Create Californium Configuration
+        Configuration clientCoapConfig = endpointsBuilder.createDefaultConfiguration();
+        // Persist configuration
+        File configFile = new File(CF_CONFIGURATION_FILENAME);
+        if (configFile.isFile()) {
+            clientCoapConfig.load(configFile);
+        } else {
+            clientCoapConfig.store(configFile, CF_CONFIGURATION_HEADER);
+        }
+        // Set Californium Configuration
+        endpointsBuilder.setConfiguration(clientCoapConfig);
+
+        return endpointsBuilder;
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapAddCommand.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapAddCommand.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import org.eclipse.leshan.core.LwM2m;
+import org.eclipse.leshan.core.endpoint.Protocol;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "add", description = "add endpoint.")
+
+public class CoapAddCommand extends AbstractAddCommand {
+
+    public CoapAddCommand() {
+        super(LwM2m.DEFAULT_COAP_PORT);
+    }
+
+    @Override
+    protected Protocol getProtocol() {
+        return Protocol.COAP;
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapCommand.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapCommand.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.californium.endpoint.coap.CoapServerProtocolProvider;
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+/**
+ * To add coap support.
+ */
+@Command(name = "coap",
+         description = "Activate coap support.",
+         subcommandsRepeatable = true,
+         subcommands = { CoapAddCommand.class })
+public class CoapCommand implements Runnable, ProtocolProviderFactory, DefaultProtocolProviderFactory {
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public ServerProtocolProvider create(LeshanServerDemoCLI cli, ParseResult result) {
+        return new CoapServerProtocolProvider();
+    }
+
+    @Override
+    public ServerProtocolProvider create(LeshanServerDemoCLI cli, CommandLine cmdLine) {
+        return new CoapServerProtocolProvider();
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapsAddCommand.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapsAddCommand.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import org.eclipse.leshan.core.LwM2m;
+import org.eclipse.leshan.core.endpoint.Protocol;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "add", description = "add endpoint.")
+public class CoapsAddCommand extends AbstractAddCommand {
+
+    public CoapsAddCommand() {
+        super(LwM2m.DEFAULT_COAP_SECURE_PORT);
+    }
+
+    @Override
+    protected Protocol getProtocol() {
+        return Protocol.COAPS;
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapsCommand.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/CoapsCommand.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import java.net.URI;
+
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.scandium.config.DtlsConfig;
+import org.eclipse.leshan.core.californium.PrincipalMdcConnectionListener;
+import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointFactory;
+import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.californium.endpoint.coaps.CoapsServerEndpointFactoryBuilder;
+import org.eclipse.leshan.server.californium.endpoint.coaps.CoapsServerProtocolProvider;
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParseResult;
+
+/**
+ * To add coap support.
+ */
+@Command(name = "coaps",
+         description = "Activate coaps support.",
+         subcommandsRepeatable = true,
+         subcommands = { CoapAddCommand.class })
+public class CoapsCommand implements Runnable, ProtocolProviderFactory, DefaultProtocolProviderFactory {
+
+    @Option(names = { "-h", "--help" }, description = "Display help information.", usageHelp = true)
+    private boolean help;
+
+    @Override
+    public void run() {
+        // nothing todo, some validation could be added here if needed.
+    }
+
+    @Override
+    public ServerProtocolProvider create(LeshanServerDemoCLI cli, ParseResult result) {
+        return create(cli);
+    }
+
+    @Override
+    public ServerProtocolProvider create(LeshanServerDemoCLI cli, CommandLine cmdLine) {
+        return create(cli);
+    }
+
+    private ServerProtocolProvider create(LeshanServerDemoCLI cli) {
+        return new CoapsServerProtocolProvider() {
+
+            @Override
+            public void applyDefaultValue(Configuration configuration) {
+                super.applyDefaultValue(configuration);
+                // These configuration values are always overwritten by CLI therefore set them to transient.
+                configuration.setTransient(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY);
+                configuration.setTransient(DtlsConfig.DTLS_CONNECTION_ID_LENGTH);
+                configuration.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, !cli.dtls.supportDeprecatedCiphers);
+                configuration.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, cli.dtls.cid);
+            }
+
+            @Override
+            public CaliforniumServerEndpointFactory createDefaultEndpointFactory(URI uri) {
+                return new CoapsServerEndpointFactoryBuilder().setURI(uri).setDtlsConnectorConfig(b -> {
+                    // Add MDC for connection logs
+                    if (cli.helpsOptions.getVerboseLevel() > 0)
+                        b.setConnectionListener(new PrincipalMdcConnectionListener());
+                }).build();
+            }
+        };
+    }
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/DefaultProtocolProviderFactory.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/DefaultProtocolProviderFactory.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+
+import picocli.CommandLine;
+
+public interface DefaultProtocolProviderFactory {
+    ServerProtocolProvider create(LeshanServerDemoCLI cli, CommandLine cmdLine);
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/EndpointAdder.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/EndpointAdder.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpointsProvider;
+
+public interface EndpointAdder {
+    void addEndpointTo(CaliforniumServerEndpointsProvider.Builder provider);
+}

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/ProtocolProviderFactory.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/transport/californium/ProtocolProviderFactory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.demo.transport.californium;
+
+import org.eclipse.leshan.server.californium.endpoint.ServerProtocolProvider;
+import org.eclipse.leshan.server.demo.cli.LeshanServerDemoCLI;
+
+import picocli.CommandLine.ParseResult;
+
+public interface ProtocolProviderFactory {
+
+    ServerProtocolProvider create(LeshanServerDemoCLI cli, ParseResult result);
+}

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
@@ -29,6 +29,7 @@ import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.client.servers.ServerInfo;
 import org.eclipse.leshan.core.SecurityMode;
+import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.peer.IpPeer;
 import org.eclipse.leshan.core.peer.OscoreIdentity;
@@ -131,6 +132,10 @@ public class JavaCoapClientEndpointsProvider implements LwM2mClientEndpointsProv
     @Override
     public synchronized LwM2mServer createEndpoint(ServerInfo serverInfo, boolean clientInitiatedOnly,
             List<Certificate> trustStore, ClientEndpointToolbox toolbox) {
+        if (!Protocol.COAP.getUriScheme().equals(serverInfo.getFullUri().getScheme())) {
+            return null;
+        }
+
         // As we support only 1 server destroy previous one first
         destroyEndpoints();
 


### PR DESCRIPTION
This is experimentation about adding a `transport` command to **leshan-client-demo** to be able to configure transport layer. 

This looks like : 
```
Usage: leshan-client-demo transport [-h] [COMMAND]
Configure Leshan transport layer. Can be used to add, remove or use different
implementation of supported LWM2M transport.

By default, Californium library is used for coap/coaps. Some Californium
parameters can be tweaked in Californium3.client.properties file.
Default behavior is like using :
transport californium coap coaps

More examples :
coaps support only based on Californium library :
transport californium coaps

coap support based on java-coap library :
transport java-coap coap

coaps support based on Californium library and coap support based java-coap
library:
transport californium coaps java-coap coap

Launch transport [californium|java-coap] -h for more details.

  -h, --help   Display help information.
Commands:
  californium  Configure transport based on Californium.
  java-coap    Configure transport based on java-coap.

```


This could sound a bit overkill but this will allow to have specific option for each transport.
E.g. connection id option should probably be moved have a `transport californium coaps` option
