### PR TITLE
Ensure there is no precision loss on Number conversion

### DIFF
--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/datatype/NumberUtilTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/datatype/NumberUtilTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.datatype;
 
 import static org.eclipse.leshan.core.util.datatype.NumberUtil.longToInt;
+import static org.eclipse.leshan.core.util.datatype.NumberUtil.numberToDouble;
 import static org.eclipse.leshan.core.util.datatype.NumberUtil.numberToLong;
 import static org.eclipse.leshan.core.util.datatype.NumberUtil.numberToULong;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -270,6 +271,79 @@ public class NumberUtilTest {
     public void too_long_to_int() {
         assertThrowsExactly(IllegalArgumentException.class, () -> {
             longToInt(2147483648l);
+        });
+    }
+
+    @Test
+    public void convert_number_to_double() {
+        assertEquals(-128d, numberToDouble(Byte.valueOf("-128"), true));
+        assertEquals(127d, numberToDouble(Byte.valueOf("127"), true));
+
+        assertEquals(-32768d, numberToDouble(Short.valueOf("-32768"), true));
+        assertEquals(32767d, numberToDouble(Short.valueOf("32767"), true));
+
+        assertEquals(-2147483648d, numberToDouble(Integer.valueOf("-2147483648"), true));
+        assertEquals(2147483647d, numberToDouble(Integer.valueOf("2147483647"), true));
+
+        // safe limit
+        assertEquals(-9007199254740991d, numberToDouble(Long.valueOf("-9007199254740991"), true));
+        assertEquals(9007199254740991d, numberToDouble(Long.valueOf("9007199254740991"), true));
+        // outside safe limit
+        // see for more details : https://observablehq.com/@benaubin/floating-point
+        assertEquals(9007199254740992d, numberToDouble(Long.valueOf("9007199254740992"), true));
+        assertEquals(9007199254740992d, numberToDouble(Long.valueOf("9007199254740992"), true));
+        assertEquals(9007199254740994d, numberToDouble(Long.valueOf("9007199254740994"), true));
+
+        // safe limit
+        assertEquals(-9007199254740991d, numberToDouble(new BigInteger("-9007199254740991"), true));
+        assertEquals(9007199254740991d, numberToDouble(new BigInteger("9007199254740991"), true));
+        // outside safe limit
+        // see for more details : https://observablehq.com/@benaubin/floating-point
+        assertEquals(-9007199254740992d, numberToDouble(new BigInteger("-9007199254740992"), true));
+        assertEquals(9007199254740992d, numberToDouble(new BigInteger("9007199254740992"), true));
+        assertEquals(9007199254740994d, numberToDouble(new BigInteger("9007199254740994"), true));
+
+        // floating point
+        assertEquals(-340282346638528859811704183484516925440d, numberToDouble(new Float(-Float.MAX_VALUE), true));
+        assertEquals(340282346638528859811704183484516925440d, numberToDouble(new Float(Float.MAX_VALUE), true));
+
+        assertEquals(
+                -179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368d,
+                numberToDouble(new Double(-Double.MAX_VALUE), true));
+        assertEquals(
+                179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368d,
+                numberToDouble(new Double(Double.MAX_VALUE), true));
+
+        assertEquals(
+                -179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368d,
+                numberToDouble(new BigDecimal(-Double.MAX_VALUE), true));
+        assertEquals(
+                179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368d,
+                numberToDouble(new BigDecimal(Double.MAX_VALUE), true));
+    }
+
+    @Test
+    public void long_does_not_fit_in_for_double() {
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            numberToDouble(Long.valueOf("9007199254740993"), true);
+        });
+    }
+
+    @Test
+    public void biginteger_does_not_fit_in_double() {
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            numberToDouble(new BigInteger("-9007199254740993"), true);
+        });
+    }
+
+    @Test
+    public void bigdecimal_does_not_fit_in_for_double() {
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            numberToDouble(new BigDecimal(Double.MAX_VALUE).add(new BigDecimal(Double.MAX_VALUE)), true);
+        });
+
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            numberToDouble(new BigDecimal(-Double.MAX_VALUE).add(new BigDecimal(-Double.MAX_VALUE)), true);
         });
     }
 }


### PR DESCRIPTION
When converting Integer number  (long/biginteger) or big decimal to double, ensure there is no precision loss. 