### PR TITLE
Add coaps support based on java-coap and bouncy castle at client side

### DIFF
--- a/leshan-demo-client/pom.xml
+++ b/leshan-demo-client/pom.xml
@@ -43,6 +43,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-client-coaps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-client-coaptcp</artifactId>
     </dependency>
     <dependency>

--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -72,6 +72,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-client-coaps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-client-coaptcp</artifactId>
     </dependency>
     <dependency>

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
@@ -62,7 +62,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class PskTest {
+class PskTest {
 
     private static final long SHORT_LIFETIME = 2; // seconds
 
@@ -91,13 +91,13 @@ public class PskTest {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -307,7 +307,7 @@ public class PskTest {
 
     @TestAllTransportLayer
     public void server_initiates_dtls_handshake_timeout(Protocol givenProtocol, String givenClientEndpointProvider,
-            String givenServerEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
+            String givenServerEndpointProvider) throws NonUniqueSecurityInfoException {
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
         server.start();
@@ -355,7 +355,7 @@ public class PskTest {
     @TestAllTransportLayer
     public void server_does_not_initiate_dtls_handshake_with_queue_mode(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
 
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
@@ -471,7 +471,7 @@ public class PskTest {
     @TestAllTransportLayer
     public void registered_device_with_psk_identity_to_server_with_psk_then_remove_security_info(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
         server.start();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
@@ -25,6 +25,7 @@ import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertArg;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -77,7 +78,8 @@ public class PskTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAPS, "Californium", "Californium"));
+                arguments(Protocol.COAPS, "Californium", "Californium"),
+                arguments(Protocol.COAPS, "java-coap", "Californium"));
     }
 
     /*---------------------------------/
@@ -268,6 +270,10 @@ public class PskTest {
     @TestAllTransportLayer
     public void server_initiates_dtls_handshake(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
+
+        // java-coap use bouncy castle which doesn't support server initiated (for now?)
+        assumeTrue(!givenClientEndpointProvider.equals("java-coap"));
+
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
         server.start();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
@@ -66,7 +66,8 @@ public class RpkTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAPS, "Californium", "Californium"));
+                arguments(Protocol.COAPS, "Californium", "Californium"), //
+                arguments(Protocol.COAPS, "java-coap", "Californium"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class RpkTest {
+class RpkTest {
 
     /*---------------------------------/
     *  Parameterized Tests
@@ -79,13 +79,13 @@ public class RpkTest {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -134,7 +134,7 @@ public class RpkTest {
     @TestAllTransportLayer
     public void registered_device_with_rpk_to_server_with_rpk_without_endpointname(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
         // Create RPK server & start it
         server = givenServer.using(serverPublicKey, serverPrivateKey).build();
         server.start();
@@ -175,9 +175,8 @@ public class RpkTest {
                 .trusting(serverPublicKey).build();
 
         // We use the server public key as bad client public key
-        PublicKey bad_client_public_key = serverPublicKey;
-        server.getSecurityStore()
-                .add(SecurityInfo.newRawPublicKeyInfo(client.getEndpointName(), bad_client_public_key));
+        PublicKey badClientPublicKey = serverPublicKey;
+        server.getSecurityStore().add(SecurityInfo.newRawPublicKeyInfo(client.getEndpointName(), badClientPublicKey));
 
         // Check client is not registered
         assertThat(client).isNotRegisteredAt(server);

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.security.cert.CertificateEncodingException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -52,7 +51,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class RpkX509Test {
+class RpkX509Test {
     /*---------------------------------/
      *  Parameterized Tests
      * -------------------------------*/
@@ -78,13 +77,13 @@ public class RpkX509Test {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -101,7 +100,7 @@ public class RpkX509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_rpk(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer.using(serverX509CertSignedByRoot.getPublicKey(), serverPrivateKeyFromCert).build();
         server.start();
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
@@ -65,7 +65,8 @@ public class RpkX509Test {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAPS, "Californium", "Californium"));
+                arguments(Protocol.COAPS, "Californium", "Californium"), //
+                arguments(Protocol.COAPS, "java-coap", "Californium"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.security.cert.CertificateEncodingException;
 import java.util.stream.Stream;
 
 import org.eclipse.leshan.core.CertificateUsage;
@@ -60,7 +59,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class SniTest {
+class SniTest {
 
     /*---------------------------------/
      *  Parameterized Tests
@@ -86,7 +85,7 @@ public class SniTest {
     LeshanTestClient client;
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -112,7 +111,7 @@ public class SniTest {
      * -------------------------------*/
     @TestAllTransportLayer
     public void registered_device_with_rpk(Protocol givenProtocol, String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -151,8 +150,7 @@ public class SniTest {
 
     @TestAllTransportLayer
     public void registered_device_with_x509_using_domain_issuer_certificate_usage(Protocol givenProtocol,
-            String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            String givenClientEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -192,8 +190,7 @@ public class SniTest {
 
     @TestAllTransportLayer
     public void registered_device_with_x509_using_trust_anchor_assertion_certificate_usage(Protocol givenProtocol,
-            String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            String givenClientEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -233,7 +230,7 @@ public class SniTest {
     @TestAllTransportLayer
     public void registered_device_with_x509_using_service_certificate_constraint_certificate_usage(
             Protocol givenProtocol, String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -272,8 +269,7 @@ public class SniTest {
 
     @TestAllTransportLayer
     public void registered_device_with_x509_using_ca_constraint_certificate_usage(Protocol givenProtocol,
-            String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            String givenClientEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
@@ -74,7 +74,8 @@ public class SniTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider
-                arguments(Protocol.COAPS, "Californium"));
+                arguments(Protocol.COAPS, "Californium"), //
+                arguments(Protocol.COAPS, "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
@@ -40,7 +40,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.security.PrivateKey;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -65,7 +64,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class X509Test {
+class X509Test {
 
     /*---------------------------------/
     *  Parameterized Tests
@@ -93,13 +92,13 @@ public class X509Test {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -113,10 +112,11 @@ public class X509Test {
     /*---------------------------------/
      *  Tests
      * -------------------------------*/
+    @SuppressWarnings("java:S2925")
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_x509cert_then_remove_security_info(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -163,7 +163,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -199,7 +199,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_x509cert_without_endpointname(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -236,7 +236,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_self_signed_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         // Create X509 server & start it
         server = givenServer //
                 .actingAsServerOnly()//
@@ -271,7 +271,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_and_bad_endpoint_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -299,7 +299,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_and_bad_cn_certificate_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         // Create X509 server & start it
         server = givenServer //
                 .actingAsServerOnly()//
@@ -327,7 +327,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_and_bad_private_key_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -357,7 +357,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_untrusted_x509cert_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -385,7 +385,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_selfsigned_x509cert_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         // Create X509 server & start it
         server = givenServer //
                 .actingAsServerOnly()//
@@ -427,7 +427,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_ca_constraint_with_direct_trust(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -461,7 +461,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_intermediate_ca_as_ca_contraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         server = givenServer //
                 .actingAsServerOnly()//
@@ -501,7 +501,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_ca_constraint_like_trust_anchor(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -541,7 +541,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_root_as_ca_contraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -580,7 +580,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_self_signed_certificate_as_ca_contraint_which_is_not_in_certhchain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -614,7 +614,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_self_signed_certificate_as_ca_contraint(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -650,7 +650,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_service_certificate_constraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -690,7 +690,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_root_ca_as_service_certificate_constraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -724,7 +724,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_another_certificate_as_service_certificate_constraint(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -758,7 +758,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_server_self_signed_cert_as_service_certificate_constraint_which_is_not_in_certhchain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -792,7 +792,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_server_self_signed_cert_as_service_certificate_constraint(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -826,7 +826,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_service_certificate_constraint_with_missing_intermediate_certificate_in_chain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa[0])//
@@ -864,7 +864,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_trust_anchor_assertion_with_direct_trust(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -898,7 +898,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_intermediate_cert_as_trust_anchor_assertion(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -937,7 +937,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_root_ca_cert_as_trust_anchor_assertion(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -976,7 +976,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_trust_anchor_assertion_which_is_not_in_certchain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1010,7 +1010,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_self_signed__cert_as_trust_anchor_assertion(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1044,7 +1044,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_direct_trust_with_self_signed_certificate_as_trust_anchor_assertion(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -1078,7 +1078,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_direct_trust_with_certificate_signed_by_ca_as_trust_anchor_assertion(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa[0])//
@@ -1114,7 +1114,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_certificate_signed_by_ca_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1153,7 +1153,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_no_end_entity_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1187,7 +1187,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_another_end_entity_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1221,7 +1221,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_unexpected_self_signed_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1255,7 +1255,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_expected_self_signed_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -1294,7 +1294,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_server_certificate_signed_by_ca_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa[0])//

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
@@ -80,6 +80,7 @@ public class X509Test {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
                 arguments(Protocol.COAPS, "Californium", "Californium"),
+                arguments(Protocol.COAPS, "java-coap", "Californium"),
                 arguments(Protocol.COAPS_TCP, "java-coap", "java-coap"));
     }
 
@@ -157,7 +158,6 @@ public class X509Test {
         // try to update
         client.triggerRegistrationUpdate();
         client.waitForUpdateFailureTo(server, 2, TimeUnit.SECONDS);
-
     }
 
     @TestAllTransportLayer

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
@@ -86,6 +86,7 @@ import org.eclipse.leshan.transport.californium.client.endpoint.ClientProtocolPr
 import org.eclipse.leshan.transport.californium.client.endpoint.coap.CoapClientProtocolProvider;
 import org.eclipse.leshan.transport.californium.client.endpoint.coap.CoapOscoreProtocolProvider;
 import org.eclipse.leshan.transport.californium.client.endpoint.coaps.CoapsClientProtocolProvider;
+import org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.JavaCoapsClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.coaptcp.endpoint.JavaCoapTcpClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.coaptcp.endpoint.JavaCoapsTcpClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.endpoint.JavaCoapClientEndpointsProvider;
@@ -311,6 +312,8 @@ public class LeshanTestClientBuilder extends LeshanClientBuilder {
     protected LwM2mClientEndpointsProvider getJavaCoapProtocolProvider(Protocol protocol) {
         if (protocolToUse.equals(Protocol.COAP)) {
             return new JavaCoapClientEndpointsProvider();
+        } else if (protocolToUse.equals(Protocol.COAPS)) {
+            return new JavaCoapsClientEndpointsProvider();
         } else if (protocolToUse.equals(Protocol.COAP_TCP)) {
             return new JavaCoapTcpClientEndpointsProvider();
         } else if (protocolToUse.equals(Protocol.COAPS_TCP)) {

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
@@ -26,6 +26,7 @@ import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.CoapResponse;
 import com.mbed.coap.server.CoapServer;
 import com.mbed.coap.server.filter.TokenGeneratorFilter;
+import com.mbed.coap.transport.CoapTransport;
 import com.mbed.coap.transport.udp.DatagramSocketTransport;
 import com.mbed.coap.utils.Service;
 
@@ -36,9 +37,20 @@ public class JavaCoapClientEndpointsProvider extends AbstractJavaCoapClientEndpo
     }
 
     @Override
-    protected CoapServer createCoapServer(ServerInfo serverInfo, Service<CoapRequest, CoapResponse> router,
-            List<Certificate> trustStore) {
-        return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM)
-                .transport(new DatagramSocketTransport(0)).route(router).build();
+    protected CoapTransport createCoapTransport(ServerInfo serverInfo, List<Certificate> trustStore) {
+        return new DatagramSocketTransport(0);
+    }
+
+    @Override
+    protected JavaCoapConnectionController createConnectionController(CoapTransport transport) {
+        return (server, resume) -> {
+            // nothing to do in coap
+        };
+    }
+
+    @Override
+    protected CoapServer createCoapServer(CoapTransport transport, Service<CoapRequest, CoapResponse> router) {
+        return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM).transport(transport).route(router)
+                .build();
     }
 }

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapConnectionController.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapConnectionController.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.endpoint;
+
+import org.eclipse.leshan.client.servers.LwM2mServer;
+
+public interface JavaCoapConnectionController {
+    void forceReconnection(LwM2mServer server, boolean resume);
+}

--- a/leshan-tl-jc-client-coaps/pom.xml
+++ b/leshan-tl-jc-client-coaps/pom.xml
@@ -14,7 +14,6 @@ and the Eclipse Distribution License is available at
 
 Contributors:
     Sierra Wireless - initial API and implementation
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -24,26 +23,23 @@ Contributors:
     <version>2.0.0-SNAPSHOT</version>
     <relativePath>../build-config/lib-build-config/pom.xml</relativePath>
   </parent>
-  <artifactId>leshan-tl-jc-shared</artifactId>
+  <artifactId>leshan-tl-jc-client-coaps</artifactId>
   <packaging>bundle</packaging>
-  <name>Leshan transport javacoap shared</name>
-  <description>Shared classes used for transport based on java-coap</description>
+  <name>Leshan transport javacoap client coaps</name>
+  <description>A transport implementation for leshan client based on java-coap and Bouncy Castle for CoAP over DTLS protocol</description>
 
   <dependencies>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
-      <artifactId>leshan-lwm2m-core</artifactId>
+      <artifactId>leshan-lwm2m-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.github.open-coap</groupId>
-      <artifactId>coap-core</artifactId>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-client-coap</artifactId>
     </dependency>
-
-    <!-- test dependencies -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-debug-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
@@ -51,9 +47,10 @@ Contributors:
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
 </project>

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+
+import org.bouncycastle.tls.DTLSClientProtocol;
+import org.bouncycastle.tls.DTLSTransport;
+import org.bouncycastle.tls.TlsClient;
+import org.bouncycastle.tls.UDPTransport;
+
+import com.mbed.coap.exception.CoapException;
+import com.mbed.coap.packet.CoapPacket;
+import com.mbed.coap.packet.CoapSerializer;
+import com.mbed.coap.transport.CoapTransport;
+import com.mbed.coap.utils.ExecutorHelpers;
+
+public class BouncyCastleDtlsTransport implements CoapTransport {
+
+    private final InetSocketAddress destination;
+    private final TlsClient client;
+    private final ExecutorService readingWorker;
+    private final boolean internalReadingWorker;
+    private final ExecutorService sendingWorker;
+    private final boolean internalSendingWorker;
+
+    // all this field can be accessed by different thread
+    private volatile boolean isRunning = false;
+    private CompletableFuture<DTLSTransport> whenConnected;
+    private DatagramSocket socket;
+    private DTLSTransport dtlsTransport;
+
+    public BouncyCastleDtlsTransport(TlsClient client, InetSocketAddress destination, ExecutorService readingWorker,
+            ExecutorService sendingWorker) {
+        this.destination = destination;
+        this.client = client;
+        if (readingWorker != null) {
+            this.readingWorker = readingWorker;
+            this.internalReadingWorker = false;
+        } else {
+            this.readingWorker = ExecutorHelpers.newSingleThreadExecutor("dtls-reader");
+            this.internalReadingWorker = true;
+        }
+        if (sendingWorker != null) {
+            this.sendingWorker = sendingWorker;
+            this.internalSendingWorker = false;
+        } else {
+            this.sendingWorker = ExecutorHelpers.newSingleThreadExecutor("dtls-sender");
+            this.internalSendingWorker = false;
+        }
+    }
+
+    @Override
+    public synchronized void start() throws IOException {
+        isRunning = true;
+        // Create local socket
+        socket = new DatagramSocket();
+        socket.connect(destination.getAddress(), destination.getPort());
+    }
+
+    @Override
+    public synchronized InetSocketAddress getLocalSocketAddress() {
+        return (InetSocketAddress) socket.getLocalSocketAddress();
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (isRunning) {
+            if (dtlsTransport != null)
+                try {
+                    dtlsTransport.close();
+                } catch (IOException e) {
+                    throw new IllegalStateException("unable to close dtls transport", e);
+                }
+            socket.close();
+            if (internalReadingWorker)
+                readingWorker.shutdown();
+            if (internalSendingWorker)
+                sendingWorker.shutdown();
+        }
+        isRunning = false;
+    }
+
+    protected synchronized CompletableFuture<DTLSTransport> connectIfNeeded() {
+
+        if (whenConnected == null || whenConnected.isCompletedExceptionally()) {
+
+            // create connecting future
+            whenConnected = CompletableFuture.supplyAsync(() -> {
+
+                // connect to foreign peer
+                DTLSTransport newTransport;
+                try {
+                    newTransport = new DTLSClientProtocol().connect(client, new UDPTransport(socket, 1500));
+                } catch (IOException e) {
+                    throw new CompletionException(String.format("unable to connect to %s", destination), e);
+                }
+
+                // store current transport
+                synchronized (this) {
+                    dtlsTransport = newTransport;
+                }
+                return newTransport;
+            }, readingWorker);
+        }
+        return whenConnected;
+    }
+
+    @Override
+    public CompletableFuture<CoapPacket> receive() {
+        return connectIfNeeded() //
+                .thenApplyAsync(this::blockingReceive, readingWorker) //
+                .thenCompose(it -> (it == null) ? receive() : CompletableFuture.completedFuture(it));
+    }
+
+    private CoapPacket blockingReceive(DTLSTransport transport) {
+        byte[] readBuffer = new byte[2048];
+        CoapPacket packet = null;
+        try {
+            // wait to receive new data
+            int receive = transport.receive(readBuffer, 0, readBuffer.length, 100);
+            if (receive > 0) {
+                packet = CoapSerializer.deserialize(destination, readBuffer, receive);
+                LOGGER.trace("coap packet received {}", packet);
+
+            }
+        } catch (CoapException e) {
+            LOGGER.warn(e.toString(), e);
+        } catch (IOException e) {
+            throw new CompletionException(e);
+        }
+        return packet;
+    }
+
+    @Override
+    public final CompletableFuture<Boolean> sendPacket(CoapPacket coapPacket) {
+        return connectIfNeeded() //
+                .thenApplyAsync(transport -> sendData(transport, coapPacket), sendingWorker);
+    }
+
+    public synchronized boolean sendData(DTLSTransport transport, CoapPacket coapPacket) {
+        try {
+            InetSocketAddress adr = coapPacket.getRemoteAddress();
+            if (!adr.equals(this.destination)) {
+                throw new IllegalStateException("No connection with: " + adr);
+            }
+            byte[] bytes = CoapSerializer.serialize(coapPacket);
+            LOGGER.trace("Try to send coap packet {} ...", coapPacket);
+            transport.send(bytes, 0, bytes.length);
+            LOGGER.trace("... coap packet {} sent ", coapPacket.getMessageId());
+            return true;
+        } catch (IOException e) {
+            throw new CompletionException(String.format("unable to send data to %s", destination), e);
+        }
+    }
+
+    public synchronized void forceReconnection() {
+        whenConnected = null;
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/LwM2mTlsClient.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/LwM2mTlsClient.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Vector;
+
+import org.bouncycastle.tls.AlertDescription;
+import org.bouncycastle.tls.BasicTlsPSKIdentity;
+import org.bouncycastle.tls.CertificateType;
+import org.bouncycastle.tls.CipherSuite;
+import org.bouncycastle.tls.DefaultTlsClient;
+import org.bouncycastle.tls.NameType;
+import org.bouncycastle.tls.ProtocolVersion;
+import org.bouncycastle.tls.ServerName;
+import org.bouncycastle.tls.TlsAuthentication;
+import org.bouncycastle.tls.TlsFatalAlert;
+import org.bouncycastle.tls.TlsPSKIdentity;
+import org.bouncycastle.tls.TlsUtils;
+import org.bouncycastle.tls.crypto.TlsCrypto;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+import org.eclipse.leshan.client.security.CertificateVerifierFactory;
+import org.eclipse.leshan.client.servers.ServerInfo;
+import org.eclipse.leshan.core.SecurityMode;
+import org.eclipse.leshan.core.security.certificate.verifier.X509CertificateVerifier;
+import org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication.RpkAuthentication;
+import org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication.X509Authentication;
+
+public class LwM2mTlsClient extends DefaultTlsClient {
+
+    private final CertificateVerifierFactory certificateVerifierFactory = new CertificateVerifierFactory();
+    private final ServerInfo serverInfo;
+    private final List<Certificate> trustStore;
+
+    public LwM2mTlsClient(TlsCrypto crypto, ServerInfo serverInfo, List<Certificate> trustStore) {
+        super(crypto);
+        this.serverInfo = serverInfo;
+        this.trustStore = trustStore;
+    }
+
+    @Override
+    public ProtocolVersion[] getProtocolVersions() {
+        return ProtocolVersion.DTLSv12.only();
+    }
+
+    @Override
+    public int getHandshakeTimeoutMillis() {
+        // limit global handshake time to 15s
+        return 15000;
+    }
+
+    @SuppressWarnings({ "rawtypes", "java:S1168" })
+    @Override
+    protected Vector getSNIServerNames() {
+        if (serverInfo.sni != null) {
+            Vector<ServerName> serverNames = new Vector<>();
+            serverNames.add(new ServerName(NameType.host_name, serverInfo.sni.getBytes()));
+            return serverNames;
+        }
+        return null;
+    }
+
+    @SuppressWarnings("java:S1168")
+    @Override
+    protected short[] getAllowedClientCertificateTypes() {
+        switch (serverInfo.secureMode) {
+        case RPK:
+            return new short[] { CertificateType.RawPublicKey };
+        case X509:
+            return new short[] { CertificateType.X509 };
+        default:
+            return null;
+        }
+    }
+
+    @SuppressWarnings("java:S1168")
+    @Override
+    protected short[] getAllowedServerCertificateTypes() {
+        switch (serverInfo.secureMode) {
+        case RPK:
+            return new short[] { CertificateType.RawPublicKey };
+        case X509:
+            return new short[] { CertificateType.X509 };
+        default:
+            return null;
+        }
+    }
+
+    @Override
+    public TlsAuthentication getAuthentication() throws IOException {
+        if (serverInfo.secureMode == SecurityMode.RPK) {
+            return new RpkAuthentication((BcTlsCrypto) getCrypto(), context) {
+
+                @Override
+                public PrivateKey getClientPrivateKey() {
+                    return serverInfo.privateKey;
+                }
+
+                @Override
+                public PublicKey getClientPublicKey() {
+                    return serverInfo.publicKey;
+                }
+
+                @Override
+                public PublicKey getServerPublicKey() {
+                    return serverInfo.serverPublicKey;
+                }
+
+            };
+        } else if (serverInfo.secureMode == SecurityMode.X509) {
+            final X509CertificateVerifier x509CertificateVerifier = certificateVerifierFactory.create(serverInfo,
+                    trustStore);
+            return new X509Authentication((BcTlsCrypto) getCrypto(), context) {
+
+                @Override
+                public PrivateKey getClientPrivateKey() {
+                    return serverInfo.privateKey;
+                }
+
+                @Override
+                public X509Certificate getClientCertificate() {
+                    return serverInfo.clientCertificates == null ? null
+                            : (X509Certificate) serverInfo.clientCertificates[0];
+                }
+
+                @Override
+                public InetSocketAddress getRemotePeerAddress() {
+                    return serverInfo.getAddress();
+                }
+
+                @Override
+                public X509CertificateVerifier getCertificateVerifier() {
+                    return x509CertificateVerifier;
+                }
+
+            };
+        }
+        throw new TlsFatalAlert(AlertDescription.internal_error);
+
+    }
+
+    @Override
+    public int[] getSupportedCipherSuites() {
+        switch (serverInfo.secureMode) {
+        case PSK:
+            return TlsUtils.getSupportedCipherSuites(getCrypto(), getPskCipherSuites());
+        case RPK:
+        case X509:
+            return TlsUtils.getSupportedCipherSuites(getCrypto(), getEcdheCipherSuites());
+        default:
+            throw new IllegalStateException(String.format("Unexpected security mode used %s", serverInfo.secureMode));
+        }
+    }
+
+    public int[] getPskCipherSuites() {
+        // maybe more could be added by default ?
+        return new int[] { //
+                CipherSuite.TLS_PSK_WITH_AES_128_CCM, //
+                CipherSuite.TLS_PSK_WITH_AES_256_CCM, //
+                CipherSuite.TLS_DHE_PSK_WITH_AES_128_CCM, //
+                CipherSuite.TLS_DHE_PSK_WITH_AES_256_CCM, //
+                CipherSuite.TLS_PSK_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_PSK_WITH_AES_256_CCM_8, //
+                CipherSuite.TLS_PSK_DHE_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_PSK_DHE_WITH_AES_256_CCM_8 };
+
+    }
+
+    public int[] getEcdheCipherSuites() {
+        // maybe more could be added by default ?
+        return new int[] { //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 };
+    }
+
+    @Override
+    public TlsPSKIdentity getPSKIdentity() throws IOException {
+        if (serverInfo.secureMode == SecurityMode.PSK)
+            return new BasicTlsPSKIdentity(serverInfo.pskId, serverInfo.pskKey);
+        return null;
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/AbstractTlsAuthentication.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/AbstractTlsAuthentication.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import org.bouncycastle.tls.TlsAuthentication;
+import org.bouncycastle.tls.TlsContext;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+
+public abstract class AbstractTlsAuthentication implements TlsAuthentication {
+
+    private final BcTlsCrypto crypto;
+    private final TlsContext context;
+
+    protected AbstractTlsAuthentication(BcTlsCrypto crypto, TlsContext context) {
+        this.crypto = crypto;
+        this.context = context;
+    }
+
+    public BcTlsCrypto getCrypto() {
+        return crypto;
+    }
+
+    public TlsContext getContext() {
+        return context;
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/RpkAuthentication.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/RpkAuthentication.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateRequest;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsContext;
+import org.bouncycastle.tls.TlsCredentials;
+import org.bouncycastle.tls.TlsServerCertificate;
+import org.bouncycastle.tls.crypto.TlsCryptoParameters;
+import org.bouncycastle.tls.crypto.impl.bc.BcDefaultTlsCredentialedSigner;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+
+public abstract class RpkAuthentication extends AbstractTlsAuthentication {
+
+    protected RpkAuthentication(BcTlsCrypto crypto, TlsContext context) {
+        super(crypto, context);
+    }
+
+    public abstract PrivateKey getClientPrivateKey();
+
+    public abstract PublicKey getClientPublicKey();
+
+    public abstract PublicKey getServerPublicKey();
+
+    @Override
+    public void notifyServerCertificate(TlsServerCertificate serverCertificate) throws IOException {
+
+        if (serverCertificate.getCertificate() == null || serverCertificate.getCertificate().isEmpty()) {
+            throw new IOException("Server certificate/publicKey expected !");
+        }
+
+        byte[] receivedKey = serverCertificate.getCertificate().getCertificateAt(0).getEncoded();
+        if (!Arrays.equals(receivedKey, getServerPublicKey().getEncoded())) {
+            throw new IOException("Server public key mismatch !");
+        }
+    }
+
+    @Override
+    public TlsCredentials getClientCredentials(CertificateRequest certificateRequest) throws IOException {
+
+        Certificate rpkCert = TlsAuthenticationUtil.createRawPublicKeyCertificate(getCrypto(), getClientPublicKey());
+        AsymmetricKeyParameter privateKey = TlsAuthenticationUtil.createAsymmetricPrivateKey(getClientPrivateKey());
+
+        SignatureAndHashAlgorithm selectedSignatureAndHashAlgorithm = TlsAuthenticationUtil
+                .selectSignatureAndHashAlgorithm(getCrypto(), getClientPublicKey(),
+                        certificateRequest.getSupportedSignatureAlgorithms());
+
+        return new BcDefaultTlsCredentialedSigner(new TlsCryptoParameters(getContext()), getCrypto(), privateKey,
+                rpkCert, selectedSignatureAndHashAlgorithm);
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/TlsAuthenticationUtil.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/TlsAuthenticationUtil.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.PrivateKeyFactory;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateEntry;
+import org.bouncycastle.tls.CertificateType;
+import org.bouncycastle.tls.SignatureAlgorithm;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsServerCertificate;
+import org.bouncycastle.tls.crypto.TlsCertificate;
+import org.bouncycastle.tls.crypto.TlsCrypto;
+
+public class TlsAuthenticationUtil {
+
+    private TlsAuthenticationUtil() {
+    }
+
+    public static Certificate createRawPublicKeyCertificate(TlsCrypto crypto, PublicKey publicKey) throws IOException {
+        TlsCertificate clientPubKeyCert = crypto.createCertificate(CertificateType.RawPublicKey,
+                publicKey.getEncoded());
+        return new Certificate(CertificateType.RawPublicKey, null,
+                new CertificateEntry[] { new CertificateEntry(clientPubKeyCert, null) });
+    }
+
+    public static Certificate createX509Certificate(TlsCrypto crypto, X509Certificate certificate) throws IOException {
+        TlsCertificate clientPubKeyCert;
+        try {
+            clientPubKeyCert = crypto.createCertificate(CertificateType.X509, certificate.getEncoded());
+            return new Certificate(CertificateType.X509, null,
+                    new CertificateEntry[] { new CertificateEntry(clientPubKeyCert, null) });
+        } catch (CertificateEncodingException e) {
+            throw new IOException("Unable to convert certificate", e);
+        }
+
+    }
+
+    public static AsymmetricKeyParameter createAsymmetricPrivateKey(PrivateKey privateKey) throws IOException {
+        return PrivateKeyFactory.createKey(privateKey.getEncoded());
+    }
+
+    public static CertPath convertToCertPath(TlsServerCertificate tlsCert) throws CertificateException, IOException {
+        CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+        List<X509Certificate> certs = new ArrayList<>();
+        for (TlsCertificate bcCert : tlsCert.getCertificate().getCertificateList()) {
+            certs.add((X509Certificate) certFactory.generateCertificate(new ByteArrayInputStream(bcCert.getEncoded())));
+        }
+        return certFactory.generateCertPath(certs);
+    }
+
+    public static SignatureAndHashAlgorithm selectSignatureAndHashAlgorithm(TlsCrypto crypto, PublicKey publicKey,
+            @SuppressWarnings({ "rawtypes", "java:S1149" }) //
+            Vector /* <SignatureAndHashAlgorithm> */ signatureAndHashAlgorithms) {
+
+        short signature = getPublicKeySignatureAlgorithm(publicKey);
+        if (signature == -1) {
+            throw new IllegalStateException(
+                    String.format("Client public key use unsupported signature algorithm : %s", publicKey.toString()));
+        }
+
+        for (Object object : signatureAndHashAlgorithms) {
+            SignatureAndHashAlgorithm signatureAndHashAlgorithm = (SignatureAndHashAlgorithm) object;
+            if ( // match key algorithm
+            signatureAndHashAlgorithm.getSignature() == signature
+                    // signature and hash algorithm is supported
+                    && crypto.hasSignatureAndHashAlgorithm(signatureAndHashAlgorithm)) {
+                return signatureAndHashAlgorithm;
+            }
+        }
+        return null;
+    }
+
+    private static short getPublicKeySignatureAlgorithm(PublicKey pubKey) {
+        String algorithm = pubKey.getAlgorithm();
+        if ("RSA".equals(algorithm)) {
+            return SignatureAlgorithm.rsa;
+        } else if ("EC".equals(algorithm)) {
+            return SignatureAlgorithm.ecdsa;
+        } else if ("DSA".equals(algorithm)) {
+            return SignatureAlgorithm.dsa;
+        } else {
+            return -1; // Unknown/unsupported
+        }
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/X509Authentication.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/X509Authentication.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.PrivateKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateRequest;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsContext;
+import org.bouncycastle.tls.TlsCredentials;
+import org.bouncycastle.tls.TlsServerCertificate;
+import org.bouncycastle.tls.crypto.TlsCryptoParameters;
+import org.bouncycastle.tls.crypto.impl.bc.BcDefaultTlsCredentialedSigner;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+import org.eclipse.leshan.core.security.certificate.verifier.X509CertificateVerifier;
+import org.eclipse.leshan.core.security.certificate.verifier.X509CertificateVerifier.Role;
+
+public abstract class X509Authentication extends AbstractTlsAuthentication {
+
+    protected X509Authentication(BcTlsCrypto crypto, TlsContext context) {
+        super(crypto, context);
+    }
+
+    public abstract PrivateKey getClientPrivateKey();
+
+    public abstract X509Certificate getClientCertificate();
+
+    public abstract X509CertificateVerifier getCertificateVerifier();
+
+    public abstract InetSocketAddress getRemotePeerAddress();
+
+    @Override
+    public void notifyServerCertificate(TlsServerCertificate serverCertificate) throws IOException {
+        try {
+            CertPath certPath = TlsAuthenticationUtil.convertToCertPath(serverCertificate);
+            getCertificateVerifier().verifyCertificate(certPath, getRemotePeerAddress(), Role.CLIENT);
+        } catch (CertificateException e) {
+            throw new IOException("Certificate doesn't pass validation !", e);
+        }
+    }
+
+    @Override
+    public TlsCredentials getClientCredentials(CertificateRequest certificateRequest) throws IOException {
+        Certificate cert = TlsAuthenticationUtil.createX509Certificate(getCrypto(), getClientCertificate());
+        AsymmetricKeyParameter privateKey = TlsAuthenticationUtil.createAsymmetricPrivateKey(getClientPrivateKey());
+
+        SignatureAndHashAlgorithm selectedSignatureAndHashAlgorithm = TlsAuthenticationUtil
+                .selectSignatureAndHashAlgorithm(getCrypto(), getClientCertificate().getPublicKey(),
+                        certificateRequest.getSupportedSignatureAlgorithms());
+
+        return new BcDefaultTlsCredentialedSigner(new TlsCryptoParameters(getContext()), getCrypto(), privateKey, cert,
+                selectedSignatureAndHashAlgorithm);
+    }
+
+}

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultTlsIdentityHandler.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultTlsIdentityHandler.java
@@ -22,6 +22,8 @@ import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.leshan.core.peer.IpPeer;
 import org.eclipse.leshan.core.peer.LwM2mPeer;
+import org.eclipse.leshan.core.peer.PskIdentity;
+import org.eclipse.leshan.core.peer.RpkIdentity;
 import org.eclipse.leshan.core.peer.X509Identity;
 import org.eclipse.leshan.core.security.certificate.util.X509CertUtil;
 
@@ -52,6 +54,12 @@ public class DefaultTlsIdentityHandler extends DefaultCoapIdentityHandler {
         if (client.getIdentity() instanceof X509Identity) {
             /* simplify distinguished name to CN= part */
             peerIdentity = new X500Principal("CN=" + ((X509Identity) client.getIdentity()).getX509CommonName());
+            return TransportContext.of(TlsTransportContextKeys.PRINCIPAL, peerIdentity);
+        } else if (client.getIdentity() instanceof PskIdentity) {
+            peerIdentity = new PreSharedKeyPrincipal(((PskIdentity) client.getIdentity()).getPskIdentity());
+            return TransportContext.of(TlsTransportContextKeys.PRINCIPAL, peerIdentity);
+        } else if (client.getIdentity() instanceof RpkIdentity) {
+            peerIdentity = new RawPublicKeyPrincipal(((RpkIdentity) client.getIdentity()).getPublicKey());
             return TransportContext.of(TlsTransportContextKeys.PRINCIPAL, peerIdentity);
         } else {
             throw new IllegalStateException(String.format("Unsupported Identity : %s", client.getIdentity()));

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/PreSharedKeyPrincipal.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/PreSharedKeyPrincipal.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import java.security.Principal;
+import java.util.Objects;
+
+public class PreSharedKeyPrincipal implements Principal {
+
+    private final String identity;
+
+    public PreSharedKeyPrincipal(String identity) {
+        this.identity = identity;
+    }
+
+    public String getIdentity() {
+        return identity;
+    }
+
+    @Override
+    public String getName() {
+        return getIdentity();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(identity);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof PreSharedKeyPrincipal))
+            return false;
+        PreSharedKeyPrincipal other = (PreSharedKeyPrincipal) obj;
+        return Objects.equals(identity, other.identity);
+    }
+}

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/RawPublicKeyPrincipal.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/RawPublicKeyPrincipal.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import java.security.Principal;
+import java.security.PublicKey;
+import java.util.Objects;
+
+public class RawPublicKeyPrincipal implements Principal {
+
+    private final PublicKey pubkey;
+
+    public RawPublicKeyPrincipal(PublicKey pubkey) {
+        this.pubkey = pubkey;
+    }
+
+    public PublicKey getPublicKey() {
+        return pubkey;
+    }
+
+    @Override
+    public String getName() {
+        return getPublicKey().toString();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(pubkey);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof RawPublicKeyPrincipal))
+            return false;
+        RawPublicKeyPrincipal other = (RawPublicKeyPrincipal) obj;
+        return Objects.equals(pubkey, other.pubkey);
+    }
+}

--- a/leshan-tl-jc-shared/src/test/java/org/eclipse/leshan/transport/javacoap/identity/PrincipalTest.java
+++ b/leshan-tl-jc-shared/src/test/java/org/eclipse/leshan/transport/javacoap/identity/PrincipalTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class PrincipalTest {
+
+    @Test
+    void assertEqualsHashcodeForPreSharedKeyPrincipal() {
+        EqualsVerifier.forClass(PreSharedKeyPrincipal.class).verify();
+    }
+
+    @Test
+    void assertEqualsHashcodeForRawPublicKeyPrincipal() {
+        EqualsVerifier.forClass(RawPublicKeyPrincipal.class).verify();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@ Contributors:
     <module>leshan-tl-jc-shared</module>
     <module>leshan-tl-jc-server-coap</module>
     <module>leshan-tl-jc-client-coap</module>
+    <module>leshan-tl-jc-client-coaps</module>
     <module>leshan-tl-jc-server-coaptcp</module>
     <module>leshan-tl-jc-client-coaptcp</module>
 
@@ -244,6 +245,11 @@ Contributors:
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>leshan-tl-jc-client-coaps</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>leshan-tl-jc-server-coaptcp</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -324,6 +330,11 @@ Contributors:
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
         <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bctls-debug-jdk18on</artifactId>
+        <version>1.81</version>
       </dependency>
 
       <!-- Demos, examples and tests dependencies -->


### PR DESCRIPTION
This PR aims to add support of CoAP over DTLS based on java-coap and Bouncy Castle at client side.

Here some limitations from bouncy castle : 
1. [There is no async API](https://github.com/bcgit/bc-java/discussions/2075#discussioncomment-13411380).
2. Client API seem to not support [DTLS Role Exchange](https://github.com/sbernard31/dtls-server?tab=readme-ov-file#dtls-role-exchange). (but it should be implemented using client and server api)
3. API is very low level some and doesn't reuse JSSE class (like PublicKey, PrivateKey, Certificate ...) from openJDK
 

Some missing task : 
 - :heavy_check_mark:   ~~add some unit test about equals/hashcode~~
 - :calendar:  check if we need to implement getTransportContext() (post pone)
 - :heavy_check_mark:  ~~clean sonard issues~~
 
 I also modify LeshanClientDemo so when `--use-java-coap` is used, this will now use java-coap for coaps too. (before it was only for coap)