### PR TITLE
Add coaps support based on java-coap and bouncy castle at server side

### DIFF
--- a/leshan-demo-client/pom.xml
+++ b/leshan-demo-client/pom.xml
@@ -43,6 +43,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-client-coaps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-client-coaptcp</artifactId>
     </dependency>
     <dependency>

--- a/leshan-demo-server/pom.xml
+++ b/leshan-demo-server/pom.xml
@@ -59,6 +59,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-server-coaps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-server-coaptcp</artifactId>
     </dependency>
     <dependency>

--- a/leshan-demo-server/src/main/java/org/eclipse/leshan/demo/server/LeshanServerDemo.java
+++ b/leshan-demo-server/src/main/java/org/eclipse/leshan/demo/server/LeshanServerDemo.java
@@ -63,6 +63,7 @@ import org.eclipse.leshan.transport.californium.server.endpoint.CaliforniumServe
 import org.eclipse.leshan.transport.californium.server.endpoint.coap.CoapOscoreServerEndpointFactory;
 import org.eclipse.leshan.transport.californium.server.endpoint.coap.CoapServerProtocolProvider;
 import org.eclipse.leshan.transport.californium.server.endpoint.coaps.CoapsServerProtocolProvider;
+import org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint.JavaCoapsServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.coaptcp.endpoint.JavaCoapTcpServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.coaptcp.endpoint.JavaCoapsTcpServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.endpoint.JavaCoapServerEndpointsProvider;
@@ -261,6 +262,12 @@ public class LeshanServerDemo {
                 : new InetSocketAddress(cli.main.jlocalAddress, jcoapPort);
         JavaCoapServerEndpointsProvider javacoapEndpointsProvider = new JavaCoapServerEndpointsProvider(jcoapAddr);
 
+        // Create CoAP over endpoint based on java-coap
+        int jcoapsPort = cli.main.jCoapsLocalPort;
+        InetSocketAddress jcoapsAddr = cli.main.jCoapsLocalAddess == null ? new InetSocketAddress(jcoapsPort)
+                : new InetSocketAddress(cli.main.jlocalAddress, jcoapPort);
+        JavaCoapsServerEndpointsProvider javacoapsEndpointsProvider = new JavaCoapsServerEndpointsProvider(jcoapsAddr);
+
         // Create CoAP over TCP endpoint based on java-coap
         int coapTcpPort = cli.main.jTcpLocalPort;
         InetSocketAddress coapTcpAddr = cli.main.jTcpLocalAddress == null ? new InetSocketAddress(coapTcpPort)
@@ -276,8 +283,8 @@ public class LeshanServerDemo {
                 coapsTcpAddr);
 
         // Create LWM2M server
-        builder.setEndpointsProviders(endpointsBuilder.build(), javacoapEndpointsProvider, javacoapTcpEndpointsProvider,
-                javacoapsTcpEndpointsProvider);
+        builder.setEndpointsProviders(endpointsBuilder.build(), javacoapEndpointsProvider, javacoapsEndpointsProvider,
+                javacoapTcpEndpointsProvider, javacoapsTcpEndpointsProvider);
         return builder.build();
     }
 

--- a/leshan-demo-server/src/main/java/org/eclipse/leshan/demo/server/cli/LeshanServerDemoCLI.java
+++ b/leshan-demo-server/src/main/java/org/eclipse/leshan/demo/server/cli/LeshanServerDemoCLI.java
@@ -69,6 +69,19 @@ public class LeshanServerDemoCLI implements Runnable {
                 converter = PortConverter.class)
         public Integer jlocalPort = 5685;
 
+        @Option(names = { "-jsh", "--java-coaps-host" },
+                description = { //
+                        "Set the local CoAP over DTLS address of endpoint based on java-coap library.", //
+                        "Default: any local address." })
+        public String jCoapsLocalAddess;
+
+        @Option(names = { "-jsp", "--java-coaps-port" },
+                description = { //
+                        "Set the local CoAP over DTLS port of endpoint based on java-coap library.", //
+                        "Default: ${DEFAULT-VALUE}" },
+                converter = PortConverter.class)
+        public Integer jCoapsLocalPort = 5686;
+
         @Option(names = { "-th", "--java-coap-tcp-host" },
                 description = { //
                         "Set the local CoAP over TCP address of endpoint based on java-coap library.", //

--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -72,6 +72,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-client-coaps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-client-coaptcp</artifactId>
     </dependency>
     <dependency>

--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -64,6 +64,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-server-coaps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-server-coaptcp</artifactId>
     </dependency>
     <dependency>

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
@@ -62,7 +62,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class PskTest {
+class PskTest {
 
     private static final long SHORT_LIFETIME = 2; // seconds
 
@@ -91,13 +91,13 @@ public class PskTest {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -307,7 +307,7 @@ public class PskTest {
 
     @TestAllTransportLayer
     public void server_initiates_dtls_handshake_timeout(Protocol givenProtocol, String givenClientEndpointProvider,
-            String givenServerEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
+            String givenServerEndpointProvider) throws NonUniqueSecurityInfoException {
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
         server.start();
@@ -355,7 +355,7 @@ public class PskTest {
     @TestAllTransportLayer
     public void server_does_not_initiate_dtls_handshake_with_queue_mode(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
 
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
@@ -471,7 +471,7 @@ public class PskTest {
     @TestAllTransportLayer
     public void registered_device_with_psk_identity_to_server_with_psk_then_remove_security_info(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
         server.start();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
@@ -25,6 +25,7 @@ import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertArg;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -77,7 +78,8 @@ public class PskTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAPS, "Californium", "Californium"));
+                arguments(Protocol.COAPS, "Californium", "Californium"),
+                arguments(Protocol.COAPS, "java-coap", "Californium"));
     }
 
     /*---------------------------------/
@@ -268,6 +270,10 @@ public class PskTest {
     @TestAllTransportLayer
     public void server_initiates_dtls_handshake(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
+
+        // java-coap use bouncy castle which doesn't support server initiated (for now?)
+        assumeTrue(!givenClientEndpointProvider.equals("java-coap"));
+
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
         server.start();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/PskTest.java
@@ -78,8 +78,10 @@ class PskTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAPS, "Californium", "Californium"),
-                arguments(Protocol.COAPS, "java-coap", "Californium"));
+                arguments(Protocol.COAPS, "Californium", "Californium"), //
+                arguments(Protocol.COAPS, "java-coap", "Californium"), //
+                arguments(Protocol.COAPS, "Californium", "java-coap"), //
+                arguments(Protocol.COAPS, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/
@@ -272,7 +274,8 @@ class PskTest {
             String givenServerEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
 
         // java-coap use bouncy castle which doesn't support server initiated (for now?)
-        assumeTrue(!givenClientEndpointProvider.equals("java-coap"));
+        assumeTrue(!givenClientEndpointProvider.equals("java-coap") //
+                && !givenServerEndpointProvider.equals("java-coap"));
 
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
@@ -308,6 +311,11 @@ class PskTest {
     @TestAllTransportLayer
     public void server_initiates_dtls_handshake_timeout(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws NonUniqueSecurityInfoException {
+
+        // java-coap use bouncy castle which doesn't support server initiated (for now?)
+        assumeTrue(!givenClientEndpointProvider.equals("java-coap") //
+                && !givenServerEndpointProvider.equals("java-coap"));
+
         // Create PSK server & start it
         server = givenServer.build(); // default server support PSK
         server.start();

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
@@ -66,7 +66,8 @@ public class RpkTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAPS, "Californium", "Californium"));
+                arguments(Protocol.COAPS, "Californium", "Californium"), //
+                arguments(Protocol.COAPS, "java-coap", "Californium"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class RpkTest {
+class RpkTest {
 
     /*---------------------------------/
     *  Parameterized Tests
@@ -79,13 +79,13 @@ public class RpkTest {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -134,7 +134,7 @@ public class RpkTest {
     @TestAllTransportLayer
     public void registered_device_with_rpk_to_server_with_rpk_without_endpointname(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
         // Create RPK server & start it
         server = givenServer.using(serverPublicKey, serverPrivateKey).build();
         server.start();
@@ -175,9 +175,8 @@ public class RpkTest {
                 .trusting(serverPublicKey).build();
 
         // We use the server public key as bad client public key
-        PublicKey bad_client_public_key = serverPublicKey;
-        server.getSecurityStore()
-                .add(SecurityInfo.newRawPublicKeyInfo(client.getEndpointName(), bad_client_public_key));
+        PublicKey badClientPublicKey = serverPublicKey;
+        server.getSecurityStore().add(SecurityInfo.newRawPublicKeyInfo(client.getEndpointName(), badClientPublicKey));
 
         // Check client is not registered
         assertThat(client).isNotRegisteredAt(server);

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkTest.java
@@ -67,7 +67,9 @@ class RpkTest {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
                 arguments(Protocol.COAPS, "Californium", "Californium"), //
-                arguments(Protocol.COAPS, "java-coap", "Californium"));
+                arguments(Protocol.COAPS, "java-coap", "Californium"), //
+                arguments(Protocol.COAPS, "Californium", "java-coap"), //
+                arguments(Protocol.COAPS, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.security.cert.CertificateEncodingException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -52,7 +51,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class RpkX509Test {
+class RpkX509Test {
     /*---------------------------------/
      *  Parameterized Tests
      * -------------------------------*/
@@ -78,13 +77,13 @@ public class RpkX509Test {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -101,7 +100,7 @@ public class RpkX509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_rpk(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer.using(serverX509CertSignedByRoot.getPublicKey(), serverPrivateKeyFromCert).build();
         server.start();
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
@@ -65,7 +65,8 @@ public class RpkX509Test {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAPS, "Californium", "Californium"));
+                arguments(Protocol.COAPS, "Californium", "Californium"), //
+                arguments(Protocol.COAPS, "java-coap", "Californium"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/RpkX509Test.java
@@ -25,6 +25,7 @@ import static org.eclipse.leshan.integration.tests.util.Credentials.serverX509Ce
 import static org.eclipse.leshan.integration.tests.util.Credentials.trustedCertificatesByServer;
 import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.annotation.Retention;
@@ -65,7 +66,9 @@ class RpkX509Test {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
                 arguments(Protocol.COAPS, "Californium", "Californium"), //
-                arguments(Protocol.COAPS, "java-coap", "Californium"));
+                arguments(Protocol.COAPS, "java-coap", "Californium"), //
+                arguments(Protocol.COAPS, "Californium", "java-coap"), //
+                arguments(Protocol.COAPS, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/
@@ -120,6 +123,10 @@ class RpkX509Test {
     public void registered_device_with_rpk_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws NonUniqueSecurityInfoException, InterruptedException {
+
+        // java-coap use bouncy castle which can not accept both x509+RPK (clearly a bug)
+        assumeTrue(!givenServerEndpointProvider.equals("java-coap"));
+
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverX509CertSignedByRoot, serverPrivateKeyFromCert)//

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/ServerOnlySecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/ServerOnlySecurityTest.java
@@ -100,7 +100,8 @@ public class ServerOnlySecurityTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // Server Endpoint Provider
-                arguments("Californium"));
+                arguments("Californium"), //
+                arguments("java-coap"));
     }
 
     /*---------------------------------/
@@ -221,7 +222,10 @@ public class ServerOnlySecurityTest {
         Exception e = assertThrowsExactly(SendFailedException.class, () -> {
             server.send(registration, new ReadRequest(3, 0, 1), 1000);
         });
-        assertThat(e).cause().isExactlyInstanceOf(EndpointMismatchException.class);
+
+        if (givenServerEndpointProvider.equalsIgnoreCase("Californium")) {
+            assertThat(e).cause().isExactlyInstanceOf(EndpointMismatchException.class);
+        }
 
         connector.stop();
         client.destroy(false);

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.security.cert.CertificateEncodingException;
 import java.util.stream.Stream;
 
 import org.eclipse.leshan.core.CertificateUsage;
@@ -60,7 +59,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class SniTest {
+class SniTest {
 
     /*---------------------------------/
      *  Parameterized Tests
@@ -86,7 +85,7 @@ public class SniTest {
     LeshanTestClient client;
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -112,7 +111,7 @@ public class SniTest {
      * -------------------------------*/
     @TestAllTransportLayer
     public void registered_device_with_rpk(Protocol givenProtocol, String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -151,8 +150,7 @@ public class SniTest {
 
     @TestAllTransportLayer
     public void registered_device_with_x509_using_domain_issuer_certificate_usage(Protocol givenProtocol,
-            String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            String givenClientEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -192,8 +190,7 @@ public class SniTest {
 
     @TestAllTransportLayer
     public void registered_device_with_x509_using_trust_anchor_assertion_certificate_usage(Protocol givenProtocol,
-            String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            String givenClientEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -233,7 +230,7 @@ public class SniTest {
     @TestAllTransportLayer
     public void registered_device_with_x509_using_service_certificate_constraint_certificate_usage(
             Protocol givenProtocol, String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //
@@ -272,8 +269,7 @@ public class SniTest {
 
     @TestAllTransportLayer
     public void registered_device_with_x509_using_ca_constraint_certificate_usage(Protocol givenProtocol,
-            String givenClientEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            String givenClientEndpointProvider) throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create server & start it
         server = givenServerUsing(givenProtocol).with("Californium") //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/SniTest.java
@@ -74,7 +74,8 @@ public class SniTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider
-                arguments(Protocol.COAPS, "Californium"));
+                arguments(Protocol.COAPS, "Californium"), //
+                arguments(Protocol.COAPS, "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
@@ -40,7 +40,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.security.PrivateKey;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -65,7 +64,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(BeforeEachParameterizedResolver.class)
-public class X509Test {
+class X509Test {
 
     /*---------------------------------/
     *  Parameterized Tests
@@ -93,13 +92,13 @@ public class X509Test {
     LeshanTestClient client;
 
     @BeforeEach
-    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+    void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
         givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
         givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
     }
 
     @AfterEach
-    public void stop() throws InterruptedException {
+    void stop() {
         if (client != null)
             client.destroy(false);
         if (server != null)
@@ -113,10 +112,11 @@ public class X509Test {
     /*---------------------------------/
      *  Tests
      * -------------------------------*/
+    @SuppressWarnings("java:S2925")
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_x509cert_then_remove_security_info(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -163,7 +163,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -199,7 +199,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_x509cert_without_endpointname(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -236,7 +236,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_to_server_with_self_signed_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         // Create X509 server & start it
         server = givenServer //
                 .actingAsServerOnly()//
@@ -271,7 +271,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_and_bad_endpoint_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -299,7 +299,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_and_bad_cn_certificate_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         // Create X509 server & start it
         server = givenServer //
                 .actingAsServerOnly()//
@@ -327,7 +327,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_and_bad_private_key_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -357,7 +357,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_untrusted_x509cert_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
 
         // Create X509 server & start it
         server = givenServer //
@@ -385,7 +385,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_selfsigned_x509cert_to_server_with_x509cert(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         // Create X509 server & start it
         server = givenServer //
                 .actingAsServerOnly()//
@@ -427,7 +427,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_ca_constraint_with_direct_trust(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -461,7 +461,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_intermediate_ca_as_ca_contraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
 
         server = givenServer //
                 .actingAsServerOnly()//
@@ -501,7 +501,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_ca_constraint_like_trust_anchor(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -541,7 +541,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_root_as_ca_contraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -580,7 +580,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_self_signed_certificate_as_ca_contraint_which_is_not_in_certhchain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -614,7 +614,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_self_signed_certificate_as_ca_contraint(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -650,7 +650,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_service_certificate_constraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -690,7 +690,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_root_ca_as_service_certificate_constraint(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -724,7 +724,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_another_certificate_as_service_certificate_constraint(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -758,7 +758,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_server_self_signed_cert_as_service_certificate_constraint_which_is_not_in_certhchain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -792,7 +792,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_server_self_signed_cert_as_service_certificate_constraint(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -826,7 +826,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_service_certificate_constraint_with_missing_intermediate_certificate_in_chain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa[0])//
@@ -864,7 +864,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_trust_anchor_assertion_with_direct_trust(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -898,7 +898,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_intermediate_cert_as_trust_anchor_assertion(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -937,7 +937,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_root_ca_cert_as_trust_anchor_assertion(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -976,7 +976,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_trust_anchor_assertion_which_is_not_in_certchain(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1010,7 +1010,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_self_signed__cert_as_trust_anchor_assertion(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1044,7 +1044,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_direct_trust_with_self_signed_certificate_as_trust_anchor_assertion(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -1078,7 +1078,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_direct_trust_with_certificate_signed_by_ca_as_trust_anchor_assertion(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa[0])//
@@ -1114,7 +1114,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_with_server_certificate_signed_by_ca_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1153,7 +1153,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_no_end_entity_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1187,7 +1187,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_another_end_entity_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1221,7 +1221,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_unexpected_self_signed_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException {
+            throws NonUniqueSecurityInfoException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa)//
@@ -1255,7 +1255,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_expected_self_signed_certificate_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertSelfSigned)//
@@ -1294,7 +1294,7 @@ public class X509Test {
     @TestAllTransportLayer
     public void registered_device_with_x509cert_using_server_certificate_signed_by_ca_as_domain_issuer_certificate(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws NonUniqueSecurityInfoException, CertificateEncodingException, InterruptedException {
+            throws NonUniqueSecurityInfoException, InterruptedException {
         server = givenServer //
                 .actingAsServerOnly()//
                 .using(serverPrivateKeyFromCert, serverX509CertChainWithIntermediateCa[0])//

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
@@ -80,6 +80,7 @@ public class X509Test {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
                 arguments(Protocol.COAPS, "Californium", "Californium"),
+                arguments(Protocol.COAPS, "java-coap", "Californium"),
                 arguments(Protocol.COAPS_TCP, "java-coap", "java-coap"));
     }
 
@@ -157,7 +158,6 @@ public class X509Test {
         // try to update
         client.triggerRegistrationUpdate();
         client.waitForUpdateFailureTo(server, 2, TimeUnit.SECONDS);
-
     }
 
     @TestAllTransportLayer

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/security/X509Test.java
@@ -80,6 +80,8 @@ class X509Test {
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
                 arguments(Protocol.COAPS, "Californium", "Californium"),
                 arguments(Protocol.COAPS, "java-coap", "Californium"),
+                arguments(Protocol.COAPS, "Californium", "java-coap"),
+                arguments(Protocol.COAPS, "java-coap", "java-coap"),
                 arguments(Protocol.COAPS_TCP, "java-coap", "java-coap"));
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
@@ -86,6 +86,7 @@ import org.eclipse.leshan.transport.californium.client.endpoint.ClientProtocolPr
 import org.eclipse.leshan.transport.californium.client.endpoint.coap.CoapClientProtocolProvider;
 import org.eclipse.leshan.transport.californium.client.endpoint.coap.CoapOscoreProtocolProvider;
 import org.eclipse.leshan.transport.californium.client.endpoint.coaps.CoapsClientProtocolProvider;
+import org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.JavaCoapsClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.coaptcp.endpoint.JavaCoapTcpClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.coaptcp.endpoint.JavaCoapsTcpClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.endpoint.JavaCoapClientEndpointsProvider;
@@ -311,6 +312,8 @@ public class LeshanTestClientBuilder extends LeshanClientBuilder {
     protected LwM2mClientEndpointsProvider getJavaCoapProtocolProvider(Protocol protocol) {
         if (protocolToUse.equals(Protocol.COAP)) {
             return new JavaCoapClientEndpointsProvider();
+        } else if (protocolToUse.equals(Protocol.COAPS)) {
+            return new JavaCoapsClientEndpointsProvider();
         } else if (protocolToUse.equals(Protocol.COAP_TCP)) {
             return new JavaCoapTcpClientEndpointsProvider();
         } else if (protocolToUse.equals(Protocol.COAPS_TCP)) {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServer.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServer.java
@@ -64,6 +64,7 @@ import org.eclipse.leshan.servers.security.EditableSecurityStore;
 import org.eclipse.leshan.servers.security.SecurityStore;
 import org.eclipse.leshan.servers.security.ServerSecurityInfo;
 import org.eclipse.leshan.transport.californium.server.endpoint.CaliforniumServerEndpoint;
+import org.eclipse.leshan.transport.javacoap.server.endpoint.JavaCoapServerEndpoint;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -136,6 +137,9 @@ public class LeshanTestServer extends LeshanServer {
                             String.format("clearSecurityContext not implemented for connector %s",
                                     connector.getClass().getSimpleName()));
                 }
+            } else if (endpoint instanceof JavaCoapServerEndpoint) {
+                ((JavaCoapServerEndpoint) endpoint).getConnectionManager().clearAllConnection();
+                return;
             }
             throw new IllegalStateException(String.format("clearSecurityContext not implemented for endpoint %s",
                     endpoint.getClass().getSimpleName()));

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServerBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServerBuilder.java
@@ -62,6 +62,7 @@ import org.eclipse.leshan.transport.californium.server.endpoint.ServerProtocolPr
 import org.eclipse.leshan.transport.californium.server.endpoint.coap.CoapOscoreServerEndpointFactory;
 import org.eclipse.leshan.transport.californium.server.endpoint.coap.CoapServerProtocolProvider;
 import org.eclipse.leshan.transport.californium.server.endpoint.coaps.CoapsServerProtocolProvider;
+import org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint.JavaCoapsServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.coaptcp.endpoint.JavaCoapTcpServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.coaptcp.endpoint.JavaCoapsTcpServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.endpoint.JavaCoapServerEndpointsProvider;
@@ -271,6 +272,8 @@ public class LeshanTestServerBuilder extends LeshanServerBuilder {
     protected LwM2mServerEndpointsProvider getJavaCoapProtocolProvider(Protocol protocol) {
         if (protocol.equals(Protocol.COAP)) {
             return new JavaCoapServerEndpointsProvider(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        } else if (protocol.equals(Protocol.COAPS)) {
+            return new JavaCoapsServerEndpointsProvider(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         } else if (protocol.equals(Protocol.COAP_TCP)) {
             return new JavaCoapTcpServerEndpointsProvider(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         } else if (protocol.equals(Protocol.COAPS_TCP)) {

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
@@ -26,6 +26,7 @@ import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.CoapResponse;
 import com.mbed.coap.server.CoapServer;
 import com.mbed.coap.server.filter.TokenGeneratorFilter;
+import com.mbed.coap.transport.CoapTransport;
 import com.mbed.coap.transport.udp.DatagramSocketTransport;
 import com.mbed.coap.utils.Service;
 
@@ -36,9 +37,20 @@ public class JavaCoapClientEndpointsProvider extends AbstractJavaCoapClientEndpo
     }
 
     @Override
-    protected CoapServer createCoapServer(ServerInfo serverInfo, Service<CoapRequest, CoapResponse> router,
-            List<Certificate> trustStore) {
-        return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM)
-                .transport(new DatagramSocketTransport(0)).route(router).build();
+    protected CoapTransport createCoapTransport(ServerInfo serverInfo, List<Certificate> trustStore) {
+        return new DatagramSocketTransport(0);
+    }
+
+    @Override
+    protected JavaCoapConnectionController createConnectionController(CoapTransport transport) {
+        return (server, resume) -> {
+            // nothing to do in coap
+        };
+    }
+
+    @Override
+    protected CoapServer createCoapServer(CoapTransport transport, Service<CoapRequest, CoapResponse> router) {
+        return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM).transport(transport).route(router)
+                .build();
     }
 }

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapConnectionController.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapConnectionController.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.endpoint;
+
+import org.eclipse.leshan.client.servers.LwM2mServer;
+
+public interface JavaCoapConnectionController {
+    void forceReconnection(LwM2mServer server, boolean resume);
+}

--- a/leshan-tl-jc-client-coaps/pom.xml
+++ b/leshan-tl-jc-client-coaps/pom.xml
@@ -14,7 +14,6 @@ and the Eclipse Distribution License is available at
 
 Contributors:
     Sierra Wireless - initial API and implementation
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -24,26 +23,23 @@ Contributors:
     <version>2.0.0-SNAPSHOT</version>
     <relativePath>../build-config/lib-build-config/pom.xml</relativePath>
   </parent>
-  <artifactId>leshan-tl-jc-shared</artifactId>
+  <artifactId>leshan-tl-jc-client-coaps</artifactId>
   <packaging>bundle</packaging>
-  <name>Leshan transport javacoap shared</name>
-  <description>Shared classes used for transport based on java-coap</description>
+  <name>Leshan transport javacoap client coaps</name>
+  <description>A transport implementation for leshan client based on java-coap and Bouncy Castle for CoAP over DTLS protocol</description>
 
   <dependencies>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
-      <artifactId>leshan-lwm2m-core</artifactId>
+      <artifactId>leshan-lwm2m-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.github.open-coap</groupId>
-      <artifactId>coap-core</artifactId>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-client-coap</artifactId>
     </dependency>
-
-    <!-- test dependencies -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-debug-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
@@ -51,9 +47,10 @@ Contributors:
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
 </project>

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
@@ -132,15 +132,14 @@ public class BouncyCastleDtlsTransport implements CoapTransport {
     }
 
     private CoapPacket blockingReceive(DTLSTransport transport) {
-        byte[] readBuffer = new byte[2048];
+        byte[] readBuffer = new byte[1500];
         CoapPacket packet = null;
         try {
             // wait to receive new data
             int receive = transport.receive(readBuffer, 0, readBuffer.length, 100);
             if (receive > 0) {
                 packet = CoapSerializer.deserialize(destination, readBuffer, receive);
-                LOGGER.trace("coap packet received {}", packet);
-
+                LOGGER.trace("Coap packet received {}", packet);
             }
         } catch (CoapException e) {
             LOGGER.warn(e.toString(), e);

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+
+import org.bouncycastle.tls.DTLSClientProtocol;
+import org.bouncycastle.tls.DTLSTransport;
+import org.bouncycastle.tls.TlsClient;
+import org.bouncycastle.tls.UDPTransport;
+
+import com.mbed.coap.exception.CoapException;
+import com.mbed.coap.packet.CoapPacket;
+import com.mbed.coap.packet.CoapSerializer;
+import com.mbed.coap.transport.CoapTransport;
+import com.mbed.coap.utils.ExecutorHelpers;
+
+public class BouncyCastleDtlsTransport implements CoapTransport {
+
+    private final InetSocketAddress destination;
+    private final TlsClient client;
+    private final ExecutorService readingWorker;
+    private final boolean internalReadingWorker;
+    private final ExecutorService sendingWorker;
+    private final boolean internalSendingWorker;
+
+    // all this field can be accessed by different thread
+    private volatile boolean isRunning = false;
+    private CompletableFuture<DTLSTransport> whenConnected;
+    private DatagramSocket socket;
+    private DTLSTransport dtlsTransport;
+
+    public BouncyCastleDtlsTransport(TlsClient client, InetSocketAddress destination, ExecutorService readingWorker,
+            ExecutorService sendingWorker) {
+        this.destination = destination;
+        this.client = client;
+        if (readingWorker != null) {
+            this.readingWorker = readingWorker;
+            this.internalReadingWorker = false;
+        } else {
+            this.readingWorker = ExecutorHelpers.newSingleThreadExecutor("dtls-reader");
+            this.internalReadingWorker = true;
+        }
+        if (sendingWorker != null) {
+            this.sendingWorker = sendingWorker;
+            this.internalSendingWorker = false;
+        } else {
+            this.sendingWorker = ExecutorHelpers.newSingleThreadExecutor("dtls-sender");
+            this.internalSendingWorker = false;
+        }
+    }
+
+    @Override
+    public synchronized void start() throws IOException {
+        isRunning = true;
+        // Create local socket
+        socket = new DatagramSocket();
+        socket.connect(destination.getAddress(), destination.getPort());
+    }
+
+    @Override
+    public synchronized InetSocketAddress getLocalSocketAddress() {
+        return (InetSocketAddress) socket.getLocalSocketAddress();
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (isRunning) {
+            if (dtlsTransport != null)
+                try {
+                    dtlsTransport.close();
+                } catch (IOException e) {
+                    throw new IllegalStateException("unable to close dtls transport", e);
+                }
+            socket.close();
+            if (internalReadingWorker)
+                readingWorker.shutdown();
+            if (internalSendingWorker)
+                sendingWorker.shutdown();
+        }
+        isRunning = false;
+    }
+
+    protected synchronized CompletableFuture<DTLSTransport> connectIfNeeded() {
+
+        if (whenConnected == null || whenConnected.isCompletedExceptionally()) {
+
+            // create connecting future
+            whenConnected = CompletableFuture.supplyAsync(() -> {
+
+                // connect to foreign peer
+                DTLSTransport newTransport;
+                try {
+                    newTransport = new DTLSClientProtocol().connect(client, new UDPTransport(socket, 1500));
+                } catch (IOException e) {
+                    throw new CompletionException(String.format("unable to connect to %s", destination), e);
+                }
+
+                // store current transport
+                synchronized (this) {
+                    dtlsTransport = newTransport;
+                }
+                return newTransport;
+            }, readingWorker);
+        }
+        return whenConnected;
+    }
+
+    @Override
+    public CompletableFuture<CoapPacket> receive() {
+        return connectIfNeeded() //
+                .thenApplyAsync(this::blockingReceive, readingWorker) //
+                .thenCompose(it -> (it == null) ? receive() : CompletableFuture.completedFuture(it));
+    }
+
+    private CoapPacket blockingReceive(DTLSTransport transport) {
+        byte[] readBuffer = new byte[2048];
+        CoapPacket packet = null;
+        try {
+            // wait to receive new data
+            int receive = transport.receive(readBuffer, 0, readBuffer.length, 100);
+            if (receive > 0) {
+                packet = CoapSerializer.deserialize(destination, readBuffer, receive);
+                LOGGER.trace("coap packet received {}", packet);
+
+            }
+        } catch (CoapException e) {
+            LOGGER.warn(e.toString(), e);
+        } catch (IOException e) {
+            throw new CompletionException(e);
+        }
+        return packet;
+    }
+
+    @Override
+    public final CompletableFuture<Boolean> sendPacket(CoapPacket coapPacket) {
+        return connectIfNeeded() //
+                .thenApplyAsync(transport -> sendData(transport, coapPacket), sendingWorker);
+    }
+
+    public synchronized boolean sendData(DTLSTransport transport, CoapPacket coapPacket) {
+        try {
+            InetSocketAddress adr = coapPacket.getRemoteAddress();
+            if (!adr.equals(this.destination)) {
+                throw new IllegalStateException("No connection with: " + adr);
+            }
+            byte[] bytes = CoapSerializer.serialize(coapPacket);
+            LOGGER.trace("Try to send coap packet {} ...", coapPacket);
+            transport.send(bytes, 0, bytes.length);
+            LOGGER.trace("... coap packet {} sent ", coapPacket.getMessageId());
+            return true;
+        } catch (IOException e) {
+            throw new CompletionException(String.format("unable to send data to %s", destination), e);
+        }
+    }
+
+    public synchronized void forceReconnection() {
+        whenConnected = null;
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/LwM2mTlsClient.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/LwM2mTlsClient.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Vector;
+
+import org.bouncycastle.tls.AlertDescription;
+import org.bouncycastle.tls.BasicTlsPSKIdentity;
+import org.bouncycastle.tls.CertificateType;
+import org.bouncycastle.tls.CipherSuite;
+import org.bouncycastle.tls.DefaultTlsClient;
+import org.bouncycastle.tls.NameType;
+import org.bouncycastle.tls.ProtocolVersion;
+import org.bouncycastle.tls.ServerName;
+import org.bouncycastle.tls.TlsAuthentication;
+import org.bouncycastle.tls.TlsFatalAlert;
+import org.bouncycastle.tls.TlsPSKIdentity;
+import org.bouncycastle.tls.TlsUtils;
+import org.bouncycastle.tls.crypto.TlsCrypto;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+import org.eclipse.leshan.client.security.CertificateVerifierFactory;
+import org.eclipse.leshan.client.servers.ServerInfo;
+import org.eclipse.leshan.core.SecurityMode;
+import org.eclipse.leshan.core.security.certificate.verifier.X509CertificateVerifier;
+import org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication.RpkAuthentication;
+import org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication.X509Authentication;
+
+public class LwM2mTlsClient extends DefaultTlsClient {
+
+    private final CertificateVerifierFactory certificateVerifierFactory = new CertificateVerifierFactory();
+    private final ServerInfo serverInfo;
+    private final List<Certificate> trustStore;
+
+    public LwM2mTlsClient(TlsCrypto crypto, ServerInfo serverInfo, List<Certificate> trustStore) {
+        super(crypto);
+        this.serverInfo = serverInfo;
+        this.trustStore = trustStore;
+    }
+
+    @Override
+    public ProtocolVersion[] getProtocolVersions() {
+        return ProtocolVersion.DTLSv12.only();
+    }
+
+    @Override
+    public int getHandshakeTimeoutMillis() {
+        // limit global handshake time to 15s
+        return 15000;
+    }
+
+    @SuppressWarnings({ "rawtypes", "java:S1168" })
+    @Override
+    protected Vector getSNIServerNames() {
+        if (serverInfo.sni != null) {
+            Vector<ServerName> serverNames = new Vector<>();
+            serverNames.add(new ServerName(NameType.host_name, serverInfo.sni.getBytes()));
+            return serverNames;
+        }
+        return null;
+    }
+
+    @SuppressWarnings("java:S1168")
+    @Override
+    protected short[] getAllowedClientCertificateTypes() {
+        switch (serverInfo.secureMode) {
+        case RPK:
+            return new short[] { CertificateType.RawPublicKey };
+        case X509:
+            return new short[] { CertificateType.X509 };
+        default:
+            return null;
+        }
+    }
+
+    @SuppressWarnings("java:S1168")
+    @Override
+    protected short[] getAllowedServerCertificateTypes() {
+        switch (serverInfo.secureMode) {
+        case RPK:
+            return new short[] { CertificateType.RawPublicKey };
+        case X509:
+            return new short[] { CertificateType.X509 };
+        default:
+            return null;
+        }
+    }
+
+    @Override
+    public TlsAuthentication getAuthentication() throws IOException {
+        if (serverInfo.secureMode == SecurityMode.RPK) {
+            return new RpkAuthentication((BcTlsCrypto) getCrypto(), context) {
+
+                @Override
+                public PrivateKey getClientPrivateKey() {
+                    return serverInfo.privateKey;
+                }
+
+                @Override
+                public PublicKey getClientPublicKey() {
+                    return serverInfo.publicKey;
+                }
+
+                @Override
+                public PublicKey getServerPublicKey() {
+                    return serverInfo.serverPublicKey;
+                }
+
+            };
+        } else if (serverInfo.secureMode == SecurityMode.X509) {
+            final X509CertificateVerifier x509CertificateVerifier = certificateVerifierFactory.create(serverInfo,
+                    trustStore);
+            return new X509Authentication((BcTlsCrypto) getCrypto(), context) {
+
+                @Override
+                public PrivateKey getClientPrivateKey() {
+                    return serverInfo.privateKey;
+                }
+
+                @Override
+                public X509Certificate getClientCertificate() {
+                    return serverInfo.clientCertificates == null ? null
+                            : (X509Certificate) serverInfo.clientCertificates[0];
+                }
+
+                @Override
+                public InetSocketAddress getRemotePeerAddress() {
+                    return serverInfo.getAddress();
+                }
+
+                @Override
+                public X509CertificateVerifier getCertificateVerifier() {
+                    return x509CertificateVerifier;
+                }
+
+            };
+        }
+        throw new TlsFatalAlert(AlertDescription.internal_error);
+
+    }
+
+    @Override
+    public int[] getSupportedCipherSuites() {
+        switch (serverInfo.secureMode) {
+        case PSK:
+            return TlsUtils.getSupportedCipherSuites(getCrypto(), getPskCipherSuites());
+        case RPK:
+        case X509:
+            return TlsUtils.getSupportedCipherSuites(getCrypto(), getEcdheCipherSuites());
+        default:
+            throw new IllegalStateException(String.format("Unexpected security mode used %s", serverInfo.secureMode));
+        }
+    }
+
+    public int[] getPskCipherSuites() {
+        // maybe more could be added by default ?
+        return new int[] { //
+                CipherSuite.TLS_PSK_WITH_AES_128_CCM, //
+                CipherSuite.TLS_PSK_WITH_AES_256_CCM, //
+                CipherSuite.TLS_DHE_PSK_WITH_AES_128_CCM, //
+                CipherSuite.TLS_DHE_PSK_WITH_AES_256_CCM, //
+                CipherSuite.TLS_PSK_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_PSK_WITH_AES_256_CCM_8, //
+                CipherSuite.TLS_PSK_DHE_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_PSK_DHE_WITH_AES_256_CCM_8 };
+
+    }
+
+    public int[] getEcdheCipherSuites() {
+        // maybe more could be added by default ?
+        return new int[] { //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 };
+    }
+
+    @Override
+    public TlsPSKIdentity getPSKIdentity() throws IOException {
+        if (serverInfo.secureMode == SecurityMode.PSK)
+            return new BasicTlsPSKIdentity(serverInfo.pskId, serverInfo.pskKey);
+        return null;
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/AbstractTlsAuthentication.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/AbstractTlsAuthentication.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import org.bouncycastle.tls.TlsAuthentication;
+import org.bouncycastle.tls.TlsContext;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+
+public abstract class AbstractTlsAuthentication implements TlsAuthentication {
+
+    private final BcTlsCrypto crypto;
+    private final TlsContext context;
+
+    protected AbstractTlsAuthentication(BcTlsCrypto crypto, TlsContext context) {
+        this.crypto = crypto;
+        this.context = context;
+    }
+
+    public BcTlsCrypto getCrypto() {
+        return crypto;
+    }
+
+    public TlsContext getContext() {
+        return context;
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/RpkAuthentication.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/RpkAuthentication.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateRequest;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsContext;
+import org.bouncycastle.tls.TlsCredentials;
+import org.bouncycastle.tls.TlsServerCertificate;
+import org.bouncycastle.tls.crypto.TlsCryptoParameters;
+import org.bouncycastle.tls.crypto.impl.bc.BcDefaultTlsCredentialedSigner;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+
+public abstract class RpkAuthentication extends AbstractTlsAuthentication {
+
+    protected RpkAuthentication(BcTlsCrypto crypto, TlsContext context) {
+        super(crypto, context);
+    }
+
+    public abstract PrivateKey getClientPrivateKey();
+
+    public abstract PublicKey getClientPublicKey();
+
+    public abstract PublicKey getServerPublicKey();
+
+    @Override
+    public void notifyServerCertificate(TlsServerCertificate serverCertificate) throws IOException {
+
+        if (serverCertificate.getCertificate() == null || serverCertificate.getCertificate().isEmpty()) {
+            throw new IOException("Server certificate/publicKey expected !");
+        }
+
+        byte[] receivedKey = serverCertificate.getCertificate().getCertificateAt(0).getEncoded();
+        if (!Arrays.equals(receivedKey, getServerPublicKey().getEncoded())) {
+            throw new IOException("Server public key mismatch !");
+        }
+    }
+
+    @Override
+    public TlsCredentials getClientCredentials(CertificateRequest certificateRequest) throws IOException {
+
+        Certificate rpkCert = TlsAuthenticationUtil.createRawPublicKeyCertificate(getCrypto(), getClientPublicKey());
+        AsymmetricKeyParameter privateKey = TlsAuthenticationUtil.createAsymmetricPrivateKey(getClientPrivateKey());
+
+        SignatureAndHashAlgorithm selectedSignatureAndHashAlgorithm = TlsAuthenticationUtil
+                .selectSignatureAndHashAlgorithm(getCrypto(), getClientPublicKey(),
+                        certificateRequest.getSupportedSignatureAlgorithms());
+
+        return new BcDefaultTlsCredentialedSigner(new TlsCryptoParameters(getContext()), getCrypto(), privateKey,
+                rpkCert, selectedSignatureAndHashAlgorithm);
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/TlsAuthenticationUtil.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/TlsAuthenticationUtil.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.PrivateKeyFactory;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateEntry;
+import org.bouncycastle.tls.CertificateType;
+import org.bouncycastle.tls.SignatureAlgorithm;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsServerCertificate;
+import org.bouncycastle.tls.crypto.TlsCertificate;
+import org.bouncycastle.tls.crypto.TlsCrypto;
+
+public class TlsAuthenticationUtil {
+
+    private TlsAuthenticationUtil() {
+    }
+
+    public static Certificate createRawPublicKeyCertificate(TlsCrypto crypto, PublicKey publicKey) throws IOException {
+        TlsCertificate clientPubKeyCert = crypto.createCertificate(CertificateType.RawPublicKey,
+                publicKey.getEncoded());
+        return new Certificate(CertificateType.RawPublicKey, null,
+                new CertificateEntry[] { new CertificateEntry(clientPubKeyCert, null) });
+    }
+
+    public static Certificate createX509Certificate(TlsCrypto crypto, X509Certificate certificate) throws IOException {
+        TlsCertificate clientPubKeyCert;
+        try {
+            clientPubKeyCert = crypto.createCertificate(CertificateType.X509, certificate.getEncoded());
+            return new Certificate(CertificateType.X509, null,
+                    new CertificateEntry[] { new CertificateEntry(clientPubKeyCert, null) });
+        } catch (CertificateEncodingException e) {
+            throw new IOException("Unable to convert certificate", e);
+        }
+
+    }
+
+    public static AsymmetricKeyParameter createAsymmetricPrivateKey(PrivateKey privateKey) throws IOException {
+        return PrivateKeyFactory.createKey(privateKey.getEncoded());
+    }
+
+    public static CertPath convertToCertPath(TlsServerCertificate tlsCert) throws CertificateException, IOException {
+        CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+        List<X509Certificate> certs = new ArrayList<>();
+        for (TlsCertificate bcCert : tlsCert.getCertificate().getCertificateList()) {
+            certs.add((X509Certificate) certFactory.generateCertificate(new ByteArrayInputStream(bcCert.getEncoded())));
+        }
+        return certFactory.generateCertPath(certs);
+    }
+
+    public static SignatureAndHashAlgorithm selectSignatureAndHashAlgorithm(TlsCrypto crypto, PublicKey publicKey,
+            @SuppressWarnings({ "rawtypes", "java:S1149" }) //
+            Vector /* <SignatureAndHashAlgorithm> */ signatureAndHashAlgorithms) {
+
+        short signature = getPublicKeySignatureAlgorithm(publicKey);
+        if (signature == -1) {
+            throw new IllegalStateException(
+                    String.format("Client public key use unsupported signature algorithm : %s", publicKey.toString()));
+        }
+
+        for (Object object : signatureAndHashAlgorithms) {
+            SignatureAndHashAlgorithm signatureAndHashAlgorithm = (SignatureAndHashAlgorithm) object;
+            if ( // match key algorithm
+            signatureAndHashAlgorithm.getSignature() == signature
+                    // signature and hash algorithm is supported
+                    && crypto.hasSignatureAndHashAlgorithm(signatureAndHashAlgorithm)) {
+                return signatureAndHashAlgorithm;
+            }
+        }
+        return null;
+    }
+
+    private static short getPublicKeySignatureAlgorithm(PublicKey pubKey) {
+        String algorithm = pubKey.getAlgorithm();
+        if ("RSA".equals(algorithm)) {
+            return SignatureAlgorithm.rsa;
+        } else if ("EC".equals(algorithm)) {
+            return SignatureAlgorithm.ecdsa;
+        } else if ("DSA".equals(algorithm)) {
+            return SignatureAlgorithm.dsa;
+        } else {
+            return -1; // Unknown/unsupported
+        }
+    }
+}

--- a/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/X509Authentication.java
+++ b/leshan-tl-jc-client-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaps/bc/endpoint/authentication/X509Authentication.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaps.bc.endpoint.authentication;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.PrivateKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateRequest;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsContext;
+import org.bouncycastle.tls.TlsCredentials;
+import org.bouncycastle.tls.TlsServerCertificate;
+import org.bouncycastle.tls.crypto.TlsCryptoParameters;
+import org.bouncycastle.tls.crypto.impl.bc.BcDefaultTlsCredentialedSigner;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+import org.eclipse.leshan.core.security.certificate.verifier.X509CertificateVerifier;
+import org.eclipse.leshan.core.security.certificate.verifier.X509CertificateVerifier.Role;
+
+public abstract class X509Authentication extends AbstractTlsAuthentication {
+
+    protected X509Authentication(BcTlsCrypto crypto, TlsContext context) {
+        super(crypto, context);
+    }
+
+    public abstract PrivateKey getClientPrivateKey();
+
+    public abstract X509Certificate getClientCertificate();
+
+    public abstract X509CertificateVerifier getCertificateVerifier();
+
+    public abstract InetSocketAddress getRemotePeerAddress();
+
+    @Override
+    public void notifyServerCertificate(TlsServerCertificate serverCertificate) throws IOException {
+        try {
+            CertPath certPath = TlsAuthenticationUtil.convertToCertPath(serverCertificate);
+            getCertificateVerifier().verifyCertificate(certPath, getRemotePeerAddress(), Role.CLIENT);
+        } catch (CertificateException e) {
+            throw new IOException("Certificate doesn't pass validation !", e);
+        }
+    }
+
+    @Override
+    public TlsCredentials getClientCredentials(CertificateRequest certificateRequest) throws IOException {
+        Certificate cert = TlsAuthenticationUtil.createX509Certificate(getCrypto(), getClientCertificate());
+        AsymmetricKeyParameter privateKey = TlsAuthenticationUtil.createAsymmetricPrivateKey(getClientPrivateKey());
+
+        SignatureAndHashAlgorithm selectedSignatureAndHashAlgorithm = TlsAuthenticationUtil
+                .selectSignatureAndHashAlgorithm(getCrypto(), getClientCertificate().getPublicKey(),
+                        certificateRequest.getSupportedSignatureAlgorithms());
+
+        return new BcDefaultTlsCredentialedSigner(new TlsCryptoParameters(getContext()), getCrypto(), privateKey, cert,
+                selectedSignatureAndHashAlgorithm);
+    }
+
+}

--- a/leshan-tl-jc-client-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaptcp/endpoint/JavaCoapsTcpClientEndpointsProvider.java
+++ b/leshan-tl-jc-client-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaptcp/endpoint/JavaCoapsTcpClientEndpointsProvider.java
@@ -39,7 +39,7 @@ import org.eclipse.leshan.transport.javacoap.SingleX509KeyManager;
 import org.eclipse.leshan.transport.javacoap.client.endpoint.AbstractJavaCoapClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.endpoint.JavaCoapConnectionController;
 import org.eclipse.leshan.transport.javacoap.identity.DefaultTlsIdentityHandler;
-import org.eclipse.leshan.transport.javacoap.identity.TlsTransportContextKeys;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransportContextKeys;
 
 import com.mbed.coap.packet.BlockSize;
 import com.mbed.coap.packet.CoapPacket;

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/AbstractJavaCoapServerEndpointsProvider.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/AbstractJavaCoapServerEndpointsProvider.java
@@ -56,7 +56,7 @@ public abstract class AbstractJavaCoapServerEndpointsProvider implements LwM2mSe
     private JavaCoapServerEndpoint lwm2mEndpoint;
     private final IdentityHandler identityHandler;
 
-    public AbstractJavaCoapServerEndpointsProvider(Protocol protocol, String endpointDescription,
+    protected AbstractJavaCoapServerEndpointsProvider(Protocol protocol, String endpointDescription,
             InetSocketAddress localAddress, IdentityHandler identityHandler) {
         this.supportedProtocol = protocol;
         this.endpointDescription = endpointDescription;
@@ -98,7 +98,7 @@ public abstract class AbstractJavaCoapServerEndpointsProvider implements LwM2mSe
     }
 
     protected abstract CoapTransport createCoapTransport(InetSocketAddress localAddress,
-            ServerSecurityInfo serverSecurityInfo, SecurityStore SecurityStore);
+            ServerSecurityInfo serverSecurityInfo, SecurityStore securityStore);
 
     protected abstract CoapServer createCoapServer(CoapTransport transport,
             Service<CoapRequest, CoapResponse> resources, NotificationsReceiver notificationReceiver,

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/ConnectionsManager.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/ConnectionsManager.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.endpoint;
+
+public interface ConnectionsManager {
+    void clearAllConnection();
+}

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/JavaCoapServerEndpointsProvider.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/JavaCoapServerEndpointsProvider.java
@@ -29,6 +29,7 @@ import com.mbed.coap.server.CoapServerBuilder;
 import com.mbed.coap.server.filter.TokenGeneratorFilter;
 import com.mbed.coap.server.observe.NotificationsReceiver;
 import com.mbed.coap.server.observe.ObservationsStore;
+import com.mbed.coap.transport.CoapTransport;
 import com.mbed.coap.transport.udp.DatagramSocketTransport;
 import com.mbed.coap.utils.Service;
 
@@ -40,11 +41,10 @@ public class JavaCoapServerEndpointsProvider extends AbstractJavaCoapServerEndpo
     }
 
     @Override
-    protected CoapServer createCoapServer(InetSocketAddress localAddress, ServerSecurityInfo serverSecurityInfo,
-            SecurityStore securityStore, Service<CoapRequest, CoapResponse> resources,
+    protected CoapServer createCoapServer(CoapTransport transport, Service<CoapRequest, CoapResponse> resources,
             NotificationsReceiver notificationReceiver, ObservationsStore observationsStore) {
         return createCoapServer() //
-                .transport(new DatagramSocketTransport(localAddress)) //
+                .transport(transport) //
                 .route(resources) //
                 .notificationsReceiver(notificationReceiver) //
                 .observationsStore(observationsStore) //
@@ -53,5 +53,18 @@ public class JavaCoapServerEndpointsProvider extends AbstractJavaCoapServerEndpo
 
     protected CoapServerBuilder createCoapServer() {
         return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM);
+    }
+
+    @Override
+    protected CoapTransport createCoapTransport(InetSocketAddress localAddress, ServerSecurityInfo serverSecurityInfo,
+            SecurityStore securityStore) {
+        return new DatagramSocketTransport(localAddress);
+    }
+
+    @Override
+    protected ConnectionsManager createConnectionManager(CoapTransport transport) {
+        return () -> {
+            // no connection to manage with CoAP
+        };
     }
 }

--- a/leshan-tl-jc-server-coaps/pom.xml
+++ b/leshan-tl-jc-server-coaps/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright (c) 2023 Sierra Wireless and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   http://www.eclipse.org/legal/epl-v20.html
+and the Eclipse Distribution License is available at
+   http://www.eclipse.org/org/documents/edl-v10.html.
+
+Contributors:
+    Sierra Wireless - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.leshan</groupId>
+    <artifactId>lib-build-config</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../build-config/lib-build-config/pom.xml</relativePath>
+  </parent>
+  <artifactId>leshan-tl-jc-server-coaps</artifactId>
+  <packaging>bundle</packaging>
+  <name>Leshan transport javacoap server coaps</name>
+  <description>A transport implementation for leshan server based on java-coap and Bouncy Castle for CoAP over DTLS protocol</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-lwm2m-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-jc-server-coap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-debug-jdk18on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/ApplicationData.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/ApplicationData.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.net.InetSocketAddress;
+
+import com.mbed.coap.transport.TransportContext;
+
+public class ApplicationData {
+
+    private final byte[] data;
+    private final InetSocketAddress addr;
+    private final TransportContext context;
+
+    public ApplicationData(byte[] data, InetSocketAddress addr, TransportContext context) {
+        super();
+        this.data = data;
+        this.addr = addr;
+        this.context = context;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public InetSocketAddress getAddr() {
+        return addr;
+    }
+
+    public TransportContext getContext() {
+        return context;
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/ApplicationDataReceiver.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/ApplicationDataReceiver.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+public interface ApplicationDataReceiver {
+    void packetReceived(ApplicationData packet);
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/BouncyCastleDtlsTransport.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Predicate;
+
+import org.bouncycastle.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mbed.coap.exception.CoapException;
+import com.mbed.coap.packet.CoapPacket;
+import com.mbed.coap.packet.CoapSerializer;
+import com.mbed.coap.transport.CoapTransport;
+import com.mbed.coap.utils.ExecutorHelpers;
+
+public class BouncyCastleDtlsTransport implements CoapTransport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BouncyCastleDtlsTransport.class);
+
+    private final InetSocketAddress localAddress;
+    private final LwM2mTlsServerFactory tlsServerFactory;
+
+    private final ExecutorService readingWorker;
+    private final boolean internalReadingWorker;
+    private final ExecutorService packetHandlerWorker;
+    private final boolean internalPacketHandlerWorker;
+
+    // all this field can be accessed by different thread
+    private volatile boolean isRunning = false;
+    private DatagramSocket socket;
+    private DtlsConnectionsHandler connectionsManager;
+
+    public BouncyCastleDtlsTransport(LwM2mTlsServerFactory tlsServerFactory, InetSocketAddress localAddress,
+            ExecutorService readingWorker, ExecutorService packetHandlerWorker) {
+        this.localAddress = localAddress;
+        this.tlsServerFactory = tlsServerFactory;
+        if (readingWorker != null) {
+            this.readingWorker = readingWorker;
+            this.internalReadingWorker = false;
+        } else {
+            this.readingWorker = ExecutorHelpers.newSingleThreadExecutor("dtls-reader");
+            this.internalReadingWorker = true;
+        }
+        if (packetHandlerWorker != null) {
+            this.packetHandlerWorker = packetHandlerWorker;
+            this.internalPacketHandlerWorker = false;
+        } else {
+            this.packetHandlerWorker = ExecutorHelpers.newSingleThreadExecutor("packet-handler");
+            this.internalPacketHandlerWorker = false;
+        }
+
+    }
+
+    @Override
+    public synchronized void start() throws IOException {
+        isRunning = true;
+        // Create local socket
+        socket = new DatagramSocket(localAddress);
+        connectionsManager = new DtlsConnectionsHandler(tlsServerFactory, packetHandlerWorker, socket);
+        DatagramReadTask readerTask = new DatagramReadTask(socket);
+        readingWorker.execute(readerTask);
+    }
+
+    public class DatagramReadTask implements Runnable {
+        private static final int BUFFER_SIZE = 1500;
+
+        private final DatagramSocket socket;
+
+        public DatagramReadTask(DatagramSocket socket) {
+            this.socket = socket;
+        }
+
+        @Override
+        public void run() {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            DatagramPacket datagramPacket = new DatagramPacket(buffer, buffer.length);
+
+            while (isRunning) {
+                try {
+                    LOG.trace("Wait for datagram on socket ...");
+                    socket.receive(datagramPacket);
+                    LOG.trace("Datagram ({} bytes) received from {}", datagramPacket.getLength(),
+                            datagramPacket.getSocketAddress());
+                    connectionsManager.datagramPacketReceived(
+                            new InetSocketAddress(datagramPacket.getAddress(), datagramPacket.getPort()),
+                            Arrays.copyOf(datagramPacket.getData(), datagramPacket.getLength()));
+                } catch (IOException e) {
+                    isRunning = false;
+                    LOG.warn("DTLS Socket Reader Task interrupted by unexpected IO exception", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public synchronized InetSocketAddress getLocalSocketAddress() {
+        return (InetSocketAddress) socket.getLocalSocketAddress();
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (isRunning) {
+            socket.close();
+            if (internalReadingWorker)
+                readingWorker.shutdown();
+            if (internalPacketHandlerWorker)
+                packetHandlerWorker.shutdown();
+        }
+        isRunning = false;
+    }
+
+    @Override
+    public CompletableFuture<CoapPacket> receive() {
+        CompletableFuture<ApplicationData> applicationDataReceived = new CompletableFuture<>();
+        CompletableFuture<CoapPacket> coapPacketReceived = applicationDataReceived.thenApply(p -> {
+            try {
+                CoapPacket packet = CoapSerializer.deserialize(p.getAddr(), p.getData(), p.getData().length);
+                if (packet != null && p.getContext() != null) {
+                    packet.setTransportContext(p.getContext());
+                }
+                return packet;
+            } catch (CoapException e) {
+                throw new IllegalStateException(
+                        String.format("unable to deserialize coap packet from %s", p.getAddr()));
+            }
+        });
+        connectionsManager.queuePacketConsumer(applicationDataReceived);
+        return coapPacketReceived;
+    }
+
+    @Override
+    public final CompletableFuture<Boolean> sendPacket(CoapPacket coapPacket) {
+        return connectionsManager.queueApplicationDataToSend(new ApplicationData(CoapSerializer.serialize(coapPacket),
+                coapPacket.getRemoteAddress(), coapPacket.getTransportContext()));
+    }
+
+    public void removeConnection(Predicate<? super Entry<InetSocketAddress, DtlsConnectionHandler>> filter) {
+        connectionsManager.removeConnection(filter);
+    }
+
+    public void removeAllConnections() {
+        connectionsManager.removeAllConnection();
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/CoapsBouncyCastleTransportResolver.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/CoapsBouncyCastleTransportResolver.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateType;
+import org.bouncycastle.tls.SecurityParameters;
+import org.eclipse.leshan.core.security.util.SecurityUtil;
+import org.eclipse.leshan.transport.javacoap.identity.PreSharedKeyPrincipal;
+import org.eclipse.leshan.transport.javacoap.identity.RawPublicKeyPrincipal;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.IpTransportContextKeys;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransportContextKeys;
+
+import com.mbed.coap.transport.TransportContext;
+
+public class CoapsBouncyCastleTransportResolver {
+
+    public TransportContext getContext(SecurityParameters parameters, InetSocketAddress foreignPeerAddr) {
+
+        TransportContext transport = TransportContext.of(IpTransportContextKeys.REMOTE_ADDRESS, foreignPeerAddr);
+        Principal principal = getPrincipal(parameters);
+        if (principal != null) {
+            transport = transport.with(TlsTransportContextKeys.PRINCIPAL, principal); //
+        }
+        // TODO add more transport context ?
+        // .with(TlsTransportContextKeys.TLS_SESSION_ID, new Opaque(parameters.getSessionID()).toHex()) //
+        // .with(TlsTransportContextKeys.CIPHER_SUITE_ID, parameters.getCipherSuite()) //
+        return transport;
+    }
+
+    private Principal getPrincipal(SecurityParameters parameters) {
+
+        if (parameters.getPSKIdentity() != null) {
+            return new PreSharedKeyPrincipal(new String(parameters.getPSKIdentity()));
+        } else if (parameters.getClientCertificateType() == CertificateType.RawPublicKey
+                && parameters.getPeerCertificate() != null && !parameters.getPeerCertificate().isEmpty()) {
+            Certificate clientCertificate = parameters.getPeerCertificate();
+            PublicKey publicKey;
+            try {
+                publicKey = SecurityUtil.publicKey.decode(clientCertificate.getCertificateAt(0).getEncoded());
+            } catch (IOException | GeneralSecurityException e) {
+                throw new IllegalStateException("unable to decode public key");
+            }
+            return new RawPublicKeyPrincipal(publicKey);
+        } else if (parameters.getClientCertificateType() == CertificateType.X509
+                && parameters.getPeerCertificate() != null && !parameters.getPeerCertificate().isEmpty()) {
+            Certificate clientCertificate = parameters.getPeerCertificate();
+            X509Certificate certificate;
+            try {
+                certificate = SecurityUtil.certificate.decode(clientCertificate.getCertificateAt(0).getEncoded());
+            } catch (IOException | GeneralSecurityException e) {
+                throw new IllegalStateException("unable to decode public key");
+            }
+            return certificate.getSubjectX500Principal();
+        }
+
+        return null;
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/DtlsConnectionHandler.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/DtlsConnectionHandler.java
@@ -200,7 +200,7 @@ public class DtlsConnectionHandler {
             return;
         }
 
-        if (!Boolean.TRUE.equals(transportContextMather.apply(appData.getContext(), transportContext))) {
+        if (!Boolean.TRUE.equals(transportContextMather.test(appData.getContext(), transportContext))) {
             LOG.warn("Drop AppData because expected transport context doesn't match current one for peer {}", remote);
             packetSent.completeExceptionally(new IllegalStateException(
                     String.format("connection at %s is not handle by peer with given transport context %s", remote,

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/DtlsConnectionHandler.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/DtlsConnectionHandler.java
@@ -1,0 +1,264 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.bouncycastle.tls.ContentType;
+import org.bouncycastle.tls.DTLSRequest;
+import org.bouncycastle.tls.DTLSServerProtocol;
+import org.bouncycastle.tls.DTLSTransport;
+import org.bouncycastle.tls.DTLSVerifier;
+import org.bouncycastle.tls.DatagramSender;
+import org.bouncycastle.tls.HandshakeType;
+import org.bouncycastle.tls.ProtocolVersion;
+import org.bouncycastle.tls.TlsUtils;
+import org.eclipse.leshan.transport.javacoap.transport.context.DefaultTransportContextMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mbed.coap.transport.TransportContext;
+
+public class DtlsConnectionHandler {
+    private static final int MTU = 1500;
+
+    private static final Logger LOG = LoggerFactory.getLogger(DtlsConnectionHandler.class);
+
+    private final InetSocketAddress remote;
+    private final ExecutorService executor;
+    private final ApplicationDataReceiver packetReceiver;
+    private final DefaultTransportContextMatcher transportContextMather;
+    private final CoapsBouncyCastleTransportResolver transportContextResolver;
+    private final LwM2mTlsServerFactory tlsServerFactory;
+    private final DatagramSocket socket;
+
+    private final BlockingQueue<byte[]> incommingDatagramPacket = new LinkedBlockingQueue<>();
+
+    private final AtomicBoolean processing = new AtomicBoolean(false);
+
+    private boolean handshakeComplete = false;
+    private boolean handshakeInProgress = false;
+    private TransportContext transportContext;
+    private DTLSTransport dtlsTransport;
+    private final DTLSVerifier verifier;
+
+    public DtlsConnectionHandler(InetSocketAddress remote, ExecutorService executor,
+            ApplicationDataReceiver packetReceiver, DefaultTransportContextMatcher transportContextMather,
+            CoapsBouncyCastleTransportResolver transportContextResolver, LwM2mTlsServerFactory tlsServerFactory,
+            DatagramSocket socket) {
+        this.remote = remote;
+        this.executor = executor;
+        this.packetReceiver = packetReceiver;
+        this.transportContextMather = transportContextMather;
+        this.transportContextResolver = transportContextResolver;
+        this.tlsServerFactory = tlsServerFactory;
+        this.socket = socket;
+        this.verifier = new DTLSVerifier(tlsServerFactory.getCrypto());
+    }
+
+    public void datagramPacketReceived(byte[] datagramPacket) {
+        incommingDatagramPacket.add(datagramPacket);
+        tryProcess();
+    }
+
+    private void tryProcess() {
+        if (processing.compareAndSet(false, true)) {
+            LOG.trace("processing submitted for {} ...", remote);
+            executor.submit(this::processLoop);
+        } else {
+            LOG.trace("prosssing already ongoing for {} ...", remote);
+        }
+    }
+
+    private void processLoop() {
+        LOG.trace("Start processing task for {} ...", remote);
+        try {
+            int packetLen = 0;
+            do {
+                try {
+                    packetLen = handlePacket();
+                } catch (Exception e) {
+                    LOG.warn("unexpected issue raised during DTLS Connection job handling", e);
+                }
+            } while (packetLen != -1);
+        } finally {
+            processing.set(false);
+            LOG.trace("... stopped task for {}", remote);
+            if (!incommingDatagramPacket.isEmpty()) {
+                tryProcess();
+            }
+        }
+    }
+
+    private int handlePacket() {
+        // Look at next packet to handle
+        byte[] nextPacket = incommingDatagramPacket.peek();
+        if (nextPacket == null) {
+            return -1;
+        }
+
+        // if this is client hello
+        if (isClientHello(nextPacket)) {
+            LOG.trace("CLIENT_HELLO received from {}", remote);
+            // use HELLO_VERIFY_REQUEST to avoid IP spoofing
+            incommingDatagramPacket.poll(); // unqueue client hello
+            DTLSRequest verifiedRequest = verifier.verifyRequest(remote.getHostString().getBytes(), nextPacket, 0,
+                    nextPacket.length, new DatagramSender() {
+                        @Override
+                        public void send(byte[] buf, int off, int len) throws IOException {
+                            socket.send(new DatagramPacket(buf, off, len, remote));
+                        }
+
+                        @Override
+                        public int getSendLimit() throws IOException {
+                            return MTU;
+                        }
+                    });
+            if (verifiedRequest == null) {
+                LOG.trace("CLIENT_HELLO not verified from {}", remote);
+                return -1;
+            }
+            LOG.trace("CLIENT_HELLO verified from {}", remote);
+
+            // If CLIENT HELLO is verified start handshake
+            if (!handshakeInProgress) {
+                handshakeComplete = false;
+                handshakeInProgress = true;
+                try {
+                    startHandshake(verifiedRequest);
+                } finally {
+                    handshakeInProgress = false;
+                }
+            }
+        }
+        // read encrypted APPLICATION_DATA
+        try {
+            if (dtlsTransport != null) {
+                byte[] buffer = new byte[1500];
+                int len = dtlsTransport.receive(buffer, 0, buffer.length, 100);
+                if (len > 0) {
+                    LOG.trace("Packet ({} bytes) received from {}", len, remote);
+                    packetReceiver
+                            .packetReceived(new ApplicationData(Arrays.copyOf(buffer, len), remote, transportContext));
+                }
+                LOG.trace("transport received len {}", len);
+                return len;
+            }
+        } catch (IOException e) {
+            LOG.warn("Unexpected IO exception when handling datagram from {}", remote, e);
+        }
+        LOG.trace("Ignore packet no dtlsTransport for {}", remote);
+        incommingDatagramPacket.poll(); // remove ignore packet
+        return -1;
+    }
+
+    public void startHandshake(DTLSRequest verifiedClientHello) {
+        LwM2mTlsServer server = tlsServerFactory.createTlsServer(remote);
+        DTLSServerProtocol protocol = new DTLSServerProtocol();
+        try {
+            LOG.trace("Handshake started for {}", remote);
+            dtlsTransport = protocol.accept(server,
+                    new QueuedDatagramTransport(MTU, socket, remote, incommingDatagramPacket), verifiedClientHello);
+            LOG.trace("data decrypted from {}", remote);
+            transportContext = transportContextResolver.getContext(server.getSecurityParametersConnection(), remote);
+            LOG.trace("resolve transport context for {}", remote);
+            handshakeComplete = true;
+            LOG.trace("Handshake complete for {}", remote);
+        } catch (IOException e) {
+            LOG.warn("Unexpected IO exception when handshaking with {}", remote, e);
+        }
+
+    }
+
+    public void queuePacketToSend(ApplicationData appData, CompletableFuture<Boolean> packetSent) {
+        // TODO packet should be queued to be send when handshake is complete
+        if (!handshakeComplete) {
+            LOG.warn("Drop AppData because hanshake is not complete with {}", remote);
+            packetSent.complete(false);
+            return;
+        }
+
+        if (!Boolean.TRUE.equals(transportContextMather.apply(appData.getContext(), transportContext))) {
+            LOG.warn("Drop AppData because expected transport context doesn't match current one for peer {}", remote);
+            packetSent.completeExceptionally(new IllegalStateException(
+                    String.format("connection at %s is not handle by peer with given transport context %s", remote,
+                            appData.getContext())));
+            return;
+        }
+
+        try {
+            dtlsTransport.send(appData.getData(), 0, appData.getData().length);
+            packetSent.complete(true);
+        } catch (IOException e) {
+            LOG.warn("Unexpected IO exception when sending to {}", remote, e);
+            packetSent.completeExceptionally(e);
+        }
+    }
+
+    public TransportContext getTransportContext() {
+        return transportContext;
+    }
+
+    // =================================================== //
+    // This code should be available in BouncyCastle
+    private static final int RECORD_HEADER_LENGTH = 13;
+    private static final int MAX_FRAGMENT_LENGTH = 1 << 14;
+
+    protected boolean isClientHello(byte[] data) {
+        if (data.length < RECORD_HEADER_LENGTH) {
+            return false;
+        }
+
+        short contentType = TlsUtils.readUint8(data, 0);
+        if (ContentType.handshake != contentType) {
+            return false;
+        }
+
+        ProtocolVersion version = TlsUtils.readVersion(data, 1);
+        if (!ProtocolVersion.DTLSv10.isEqualOrEarlierVersionOf(version)) {
+            return false;
+        }
+
+        int epoch = TlsUtils.readUint16(data, 3);
+        if (0 != epoch) {
+            return false;
+        }
+
+        // long sequenceNumber = TlsUtils.readUint48(data, dataOff + 5)
+
+        int length = TlsUtils.readUint16(data, 11);
+        if (length < 1 || length > MAX_FRAGMENT_LENGTH) {
+            return false;
+        }
+
+        if (data.length < RECORD_HEADER_LENGTH + length) {
+            return false;
+        }
+
+        short msgType = TlsUtils.readUint8(data, RECORD_HEADER_LENGTH);
+        return HandshakeType.client_hello == msgType;
+    }
+    // =================================================== //
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/DtlsConnectionsHandler.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/DtlsConnectionsHandler.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Predicate;
+
+import org.eclipse.leshan.core.request.exception.UnconnectedPeerException;
+import org.eclipse.leshan.transport.javacoap.transport.context.DefaultTransportContextMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DtlsConnectionsHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DtlsConnectionsHandler.class);
+
+    private final LwM2mTlsServerFactory tlsServerFactory;
+    private final ExecutorService dtlsConnectionsHandlerWorkers;
+    private final DatagramSocket socket;
+
+    private final ApplicationDataReceiver applicationDataReceiver;
+    private final DefaultTransportContextMatcher transportContextMather = new DefaultTransportContextMatcher();
+    private final CoapsBouncyCastleTransportResolver transportContextResolver = new CoapsBouncyCastleTransportResolver();
+
+    private final ConcurrentMap<InetSocketAddress, DtlsConnectionHandler> peers = new ConcurrentHashMap<>();
+    private final ConcurrentLinkedQueue<CompletableFuture<ApplicationData>> consummers = new ConcurrentLinkedQueue<>();
+
+    public DtlsConnectionsHandler(LwM2mTlsServerFactory tlsServerFactory, ExecutorService dtlsConnectionsHandlerWorkers,
+            DatagramSocket socket) {
+        this.tlsServerFactory = tlsServerFactory;
+        this.dtlsConnectionsHandlerWorkers = dtlsConnectionsHandlerWorkers;
+        this.socket = socket;
+        this.applicationDataReceiver = appData -> {
+            CompletableFuture<ApplicationData> consumer = consummers.poll();
+            if (consumer != null) {
+                consumer.complete(appData);
+            } else {
+                LOG.warn("Packet recevied from {} dropped because there is no consumer for it", appData.getAddr());
+            }
+        };
+    }
+
+    public void datagramPacketReceived(InetSocketAddress peer, byte[] data) {
+        DtlsConnectionHandler connectionHandler = peers.computeIfAbsent(peer, c -> {
+            LOG.trace("New Connection Handler for {}", peer);
+            return new DtlsConnectionHandler(peer, dtlsConnectionsHandlerWorkers, applicationDataReceiver,
+                    transportContextMather, transportContextResolver, tlsServerFactory, socket);
+        });
+
+        connectionHandler.datagramPacketReceived(data);
+    }
+
+    public void queuePacketConsumer(CompletableFuture<ApplicationData> consummer) {
+        consummers.add(consummer);
+    }
+
+    public CompletableFuture<Boolean> queueApplicationDataToSend(ApplicationData appData) {
+        CompletableFuture<Boolean> packetSent = new CompletableFuture<>();
+        DtlsConnectionHandler connectionHandler = peers.get(appData.getAddr());
+        if (connectionHandler == null) {
+            LOG.warn("No connection for peer {} : unable to send packet ", appData.getAddr());
+            packetSent.completeExceptionally(new UnconnectedPeerException("no connection for %s", appData.getAddr()));
+            return packetSent;
+        } else {
+            connectionHandler.queuePacketToSend(appData, packetSent);
+            return packetSent;
+        }
+    }
+
+    public void removeConnection(Predicate<? super Entry<InetSocketAddress, DtlsConnectionHandler>> filter) {
+        for (Map.Entry<InetSocketAddress, DtlsConnectionHandler> entry : peers.entrySet()) {
+            InetSocketAddress key = entry.getKey();
+            DtlsConnectionHandler value = entry.getValue();
+            if (filter.test(entry) && peers.remove(key, value)) {
+                return;
+            }
+        }
+    }
+
+    public void removeAllConnection() {
+        peers.clear();
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/JavaCoapsServerEndpointsProvider.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/JavaCoapsServerEndpointsProvider.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.net.InetSocketAddress;
+import java.security.Principal;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.security.certificate.util.X509CertUtil;
+import org.eclipse.leshan.servers.security.EditableSecurityStore;
+import org.eclipse.leshan.servers.security.SecurityInfo;
+import org.eclipse.leshan.servers.security.SecurityStore;
+import org.eclipse.leshan.servers.security.ServerSecurityInfo;
+import org.eclipse.leshan.transport.javacoap.identity.DefaultTlsIdentityHandler;
+import org.eclipse.leshan.transport.javacoap.identity.PreSharedKeyPrincipal;
+import org.eclipse.leshan.transport.javacoap.identity.RawPublicKeyPrincipal;
+import org.eclipse.leshan.transport.javacoap.server.endpoint.AbstractJavaCoapServerEndpointsProvider;
+import org.eclipse.leshan.transport.javacoap.server.endpoint.ConnectionsManager;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransportContextKeys;
+
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.server.CoapServer;
+import com.mbed.coap.server.CoapServerBuilder;
+import com.mbed.coap.server.filter.TokenGeneratorFilter;
+import com.mbed.coap.server.observe.NotificationsReceiver;
+import com.mbed.coap.server.observe.ObservationsStore;
+import com.mbed.coap.transport.CoapTransport;
+import com.mbed.coap.transport.TransportContext;
+import com.mbed.coap.utils.Service;
+
+public class JavaCoapsServerEndpointsProvider extends AbstractJavaCoapServerEndpointsProvider {
+
+    private final BcTlsCrypto crypto = new BcTlsCrypto();
+
+    public JavaCoapsServerEndpointsProvider(InetSocketAddress localAddress) {
+        super(Protocol.COAPS, "CoAP over DTLS experimental endpoint based on java-coap and Bouncy Castle librar",
+                localAddress, new DefaultTlsIdentityHandler());
+    }
+
+    @Override
+    protected CoapServer createCoapServer(CoapTransport transport, Service<CoapRequest, CoapResponse> resources,
+            NotificationsReceiver notificationReceiver, ObservationsStore observationsStore) {
+        return createCoapServer() //
+                .transport(transport) //
+                .route(resources) //
+                .notificationsReceiver(notificationReceiver) //
+                .observationsStore(observationsStore) //
+                .build();
+    }
+
+    protected CoapServerBuilder createCoapServer() {
+        return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM);
+    }
+
+    @Override
+    protected CoapTransport createCoapTransport(InetSocketAddress localAddress, ServerSecurityInfo serverSecurityInfo,
+            SecurityStore securityStore) {
+        BouncyCastleDtlsTransport dtlsTransport = new BouncyCastleDtlsTransport(
+                createTlsServerFactory(serverSecurityInfo, securityStore), localAddress, null, null);
+        if (securityStore instanceof EditableSecurityStore) {
+            ((EditableSecurityStore) securityStore).addListener((infosAreCompromised, infos) -> {
+                if (infosAreCompromised) {
+                    for (SecurityInfo info : infos) {
+                        cleanConnection(dtlsTransport, info);
+                    }
+                }
+            });
+        }
+
+        return dtlsTransport;
+    }
+
+    protected LwM2mTlsServerFactory createTlsServerFactory(ServerSecurityInfo serverSecurityInfo,
+            SecurityStore securityStore) {
+        return new LwM2mTlsServerFactory(crypto, serverSecurityInfo, securityStore);
+    }
+
+    private void cleanConnection(BouncyCastleDtlsTransport dtlsTransport, SecurityInfo info) {
+        dtlsTransport.removeConnection(con -> {
+            TransportContext transportContext = con.getValue().getTransportContext();
+            Principal principal = transportContext != null ? transportContext.get(TlsTransportContextKeys.PRINCIPAL)
+                    : null;
+            if (info.usePSK() && principal instanceof PreSharedKeyPrincipal) {
+                return info.getPskIdentity().equals(((PreSharedKeyPrincipal) principal).getIdentity());
+            } else if (info.useRPK() && principal instanceof RawPublicKeyPrincipal) {
+                return info.getRawPublicKey().equals(((RawPublicKeyPrincipal) principal).getPublicKey());
+            } else if (info.useX509Cert() && principal instanceof X500Principal) {
+                // Extract common name
+                String x509CommonName = X509CertUtil.extractCN(principal.getName());
+                if (x509CommonName.equals(info.getEndpoint())) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+
+    @Override
+    protected ConnectionsManager createConnectionManager(CoapTransport transport) {
+        return ((BouncyCastleDtlsTransport) transport)::removeAllConnections;
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/LwM2mTlsServer.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/LwM2mTlsServer.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.PublicKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Vector;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.tls.AlertDescription;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateRequest;
+import org.bouncycastle.tls.CertificateType;
+import org.bouncycastle.tls.CipherSuite;
+import org.bouncycastle.tls.ClientCertificateType;
+import org.bouncycastle.tls.KeyExchangeAlgorithm;
+import org.bouncycastle.tls.PSKTlsServer;
+import org.bouncycastle.tls.ProtocolVersion;
+import org.bouncycastle.tls.SecurityParameters;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsCredentials;
+import org.bouncycastle.tls.TlsFatalAlert;
+import org.bouncycastle.tls.TlsPSKIdentityManager;
+import org.bouncycastle.tls.TlsUtils;
+import org.bouncycastle.tls.crypto.TlsCryptoParameters;
+import org.bouncycastle.tls.crypto.impl.bc.BcDefaultTlsCredentialedSigner;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+import org.eclipse.leshan.core.security.certificate.util.X509CertUtil;
+import org.eclipse.leshan.core.security.certificate.verifier.DefaultCertificateVerifier;
+import org.eclipse.leshan.core.security.certificate.verifier.X509CertificateVerifier.Role;
+import org.eclipse.leshan.servers.security.ServerSecurityInfo;
+import org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint.authentication.TlsAuthenticationUtil;
+
+public class LwM2mTlsServer extends PSKTlsServer {
+
+    private final ServerSecurityInfo serverSecurityInfo;
+    private final BcTlsCrypto crypto;
+    private final DefaultCertificateVerifier certificateVerifier;
+    private final InetSocketAddress clientAddr;
+
+    public LwM2mTlsServer(BcTlsCrypto crypto, TlsPSKIdentityManager pskIdentityManager,
+            ServerSecurityInfo serverSecurityInfo, InetSocketAddress clientAddr) {
+        super(crypto, pskIdentityManager);
+        this.serverSecurityInfo = serverSecurityInfo;
+        this.crypto = crypto;
+        if (serverSecurityInfo.getTrustedCertificates() != null) {
+            this.certificateVerifier = new DefaultCertificateVerifier(
+                    X509CertUtil.toX509CertificatesList(Arrays.asList(serverSecurityInfo.getTrustedCertificates()))) {
+                @Override
+                protected void validateSubject(InetSocketAddress peerSocket, X509Certificate receivedServerCertificate)
+                        throws CertificateException {
+                    // Do not validate subject at server side.
+                }
+            };
+        } else {
+            this.certificateVerifier = null;
+        }
+        this.clientAddr = clientAddr;
+    }
+
+    @Override
+    protected ProtocolVersion[] getSupportedVersions() {
+        return ProtocolVersion.DTLSv12.only();
+    }
+
+    @Override
+    public int getHandshakeTimeoutMillis() {
+        // limit global handshake time to 15s
+        return 15000;
+    }
+
+    /**
+     * @return {@link SecurityParameters} of established connection or <code>null</code> if peer not connected.
+     */
+    public SecurityParameters getSecurityParametersConnection() {
+        if (context == null) {
+            return null;
+        }
+        return context.getSecurityParametersConnection();
+    }
+
+    @SuppressWarnings("java:S1168")
+    @Override
+    protected short[] getAllowedClientCertificateTypes() {
+        if (serverSecurityInfo.getCertificateChain() != null) {
+            return new short[] { CertificateType.X509, CertificateType.RawPublicKey };
+        } else if (serverSecurityInfo.getPublicKey() != null) {
+            return new short[] { CertificateType.RawPublicKey };
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public TlsCredentials getCredentials() throws IOException {
+        // we should not return credentials when PSK is used : I didn't find better way to check that...
+        int keyExchangeAlgorithm = context.getSecurityParametersHandshake().getKeyExchangeAlgorithm();
+        switch (keyExchangeAlgorithm) {
+        case KeyExchangeAlgorithm.DHE_PSK:
+        case KeyExchangeAlgorithm.ECDHE_PSK:
+        case KeyExchangeAlgorithm.PSK:
+        case KeyExchangeAlgorithm.RSA_PSK:
+            return null;
+        default:
+            break;
+        }
+
+        Certificate cert = null;
+        PublicKey publicKey = null;
+        if (serverSecurityInfo.getPublicKey() != null) {
+            publicKey = serverSecurityInfo.getPublicKey();
+            cert = TlsAuthenticationUtil.createRawPublicKeyCertificate(getCrypto(), publicKey);
+        } else if (serverSecurityInfo.getCertificateChain() != null
+                && serverSecurityInfo.getCertificateChain().length > 0) {
+            publicKey = serverSecurityInfo.getCertificateChain()[0].getPublicKey();
+            cert = TlsAuthenticationUtil.createCertChain(getCrypto(), serverSecurityInfo.getCertificateChain());
+        }
+
+        if (publicKey != null && cert != null) {
+
+            AsymmetricKeyParameter privateKey = TlsAuthenticationUtil
+                    .createAsymmetricPrivateKey(serverSecurityInfo.getPrivateKey());
+
+            @SuppressWarnings("java:S1149")
+            Vector<?> clientSigAlgsSupported = context.getSecurityParametersHandshake().getClientSigAlgs();
+
+            SignatureAndHashAlgorithm signatureAndHashAlgorithm = TlsAuthenticationUtil
+                    .selectSignatureAndHashAlgorithm(crypto, publicKey, clientSigAlgsSupported);
+
+            return new BcDefaultTlsCredentialedSigner(new TlsCryptoParameters(context), crypto, privateKey, cert,
+                    signatureAndHashAlgorithm);
+        }
+        return null;
+
+    }
+
+    @Override
+    public CertificateRequest getCertificateRequest() throws IOException {
+        short[] certificateTypes = new short[] { ClientCertificateType.ecdsa_sign };
+        @SuppressWarnings("java:S1149")
+        Vector<?> supportedSigAlgs = TlsUtils.getDefaultSupportedSignatureAlgorithms(context);
+        return new CertificateRequest(certificateTypes, supportedSigAlgs, null);
+    }
+
+    @Override
+    public void notifyClientCertificate(Certificate clientCertificate) throws IOException {
+        if (clientCertificate == null || clientCertificate.isEmpty()) {
+            throw new TlsFatalAlert(AlertDescription.bad_certificate);
+        }
+        if (clientCertificate.getCertificateType() == CertificateType.RawPublicKey) {
+            return;
+        }
+        // validate certificate chain
+        if (certificateVerifier == null) {
+            throw new TlsFatalAlert(AlertDescription.bad_certificate);
+        }
+        try {
+            CertPath certPath = TlsAuthenticationUtil.convertToCertPath(clientCertificate);
+            certificateVerifier.verifyCertificate(certPath, clientAddr, Role.CLIENT);
+        } catch (CertificateException | IOException e) {
+            throw new TlsFatalAlert(AlertDescription.bad_certificate, e);
+        }
+    }
+
+    @Override
+    public int[] getSupportedCipherSuites() {
+        int[] supportedCiphers = TlsUtils.getSupportedCipherSuites(getCrypto(), getPskCipherSuites());
+        if (serverSecurityInfo.getCertificateChain() != null || serverSecurityInfo.getPublicKey() != null) {
+            supportedCiphers = merge(supportedCiphers,
+                    TlsUtils.getSupportedCipherSuites(getCrypto(), getEcdheCipherSuites()));
+        }
+        return supportedCiphers;
+    }
+
+    protected int[] merge(int[] a, int[] b) {
+        int[] merged = new int[a.length + b.length];
+
+        System.arraycopy(a, 0, merged, 0, a.length);
+        System.arraycopy(b, 0, merged, a.length, b.length);
+        return merged;
+    }
+
+    public int[] getPskCipherSuites() {
+        // maybe more could be added by default ?
+        return new int[] { //
+                CipherSuite.TLS_PSK_WITH_AES_128_CCM, //
+                CipherSuite.TLS_PSK_WITH_AES_256_CCM, //
+                CipherSuite.TLS_DHE_PSK_WITH_AES_128_CCM, //
+                CipherSuite.TLS_DHE_PSK_WITH_AES_256_CCM, //
+                CipherSuite.TLS_PSK_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_PSK_WITH_AES_256_CCM_8, //
+                CipherSuite.TLS_PSK_DHE_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_PSK_DHE_WITH_AES_256_CCM_8 };
+
+    }
+
+    public int[] getEcdheCipherSuites() {
+        // maybe more could be added by default ?
+        return new int[] { //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, //
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 };
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/LwM2mTlsServerFactory.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/LwM2mTlsServerFactory.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.net.InetSocketAddress;
+
+import org.bouncycastle.tls.TlsPSKIdentityManager;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+import org.eclipse.leshan.servers.security.SecurityInfo;
+import org.eclipse.leshan.servers.security.SecurityStore;
+import org.eclipse.leshan.servers.security.ServerSecurityInfo;
+
+public class LwM2mTlsServerFactory {
+
+    private final ServerSecurityInfo serverSecurityInfo;
+    private final SecurityStore securityStore;
+    private final BcTlsCrypto crypto;
+
+    public LwM2mTlsServerFactory(BcTlsCrypto crypto, ServerSecurityInfo securityInfo, SecurityStore securityStore) {
+        this.crypto = crypto;
+        this.serverSecurityInfo = securityInfo;
+        this.securityStore = securityStore;
+    }
+
+    @SuppressWarnings("java:S1168")
+    public LwM2mTlsServer createTlsServer(InetSocketAddress clientAddr) {
+        return new LwM2mTlsServer(crypto, new TlsPSKIdentityManager() {
+
+            @Override
+            public byte[] getPSK(byte[] identity) {
+                SecurityInfo clientSecurityInfo = securityStore.getByIdentity(new String(identity));
+                if (clientSecurityInfo != null && clientSecurityInfo.usePSK())
+                    // bouncy castle will erase the byte array so clone is needed.
+                    return clientSecurityInfo.getPreSharedKey().clone();
+                return null;
+            }
+
+            @Override
+            public byte[] getHint() {
+                return null;
+            }
+        }, serverSecurityInfo, clientAddr);
+    }
+
+    public BcTlsCrypto getCrypto() {
+        return crypto;
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/QueuedDatagramTransport.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/QueuedDatagramTransport.java
@@ -88,5 +88,6 @@ public class QueuedDatagramTransport implements DatagramTransport {
 
     @Override
     public void close() throws IOException {
+        // nothing to close socket is shared.
     }
 }

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/QueuedDatagramTransport.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/QueuedDatagramTransport.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.bouncycastle.tls.DatagramTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is implementation of {@link DatagramTransport} to send/receive data from/to 1 particular peer
+ */
+public class QueuedDatagramTransport implements DatagramTransport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueuedDatagramTransport.class);
+
+    private final DatagramSocket socket;
+    private final int bufferSize;
+    private final InetSocketAddress peer;
+    private final BlockingQueue<byte[]> queue;
+
+    QueuedDatagramTransport(int bufferSize, DatagramSocket socket, InetSocketAddress peer,
+            BlockingQueue<byte[]> queue) {
+        this.bufferSize = bufferSize;
+        this.socket = socket;
+        this.peer = peer;
+        this.queue = queue;
+    }
+
+    @Override
+    public int getReceiveLimit() {
+        return bufferSize;
+    }
+
+    @Override
+    public int getSendLimit() {
+        return getReceiveLimit();
+    }
+
+    @Override
+    public int receive(byte[] buf, int off, int len, int waitMillis) throws IOException {
+        try {
+            LOG.trace("Waiting dequeue data for {} ({} offset, {} length)", peer, off, len);
+            byte[] data = queue.poll(waitMillis, TimeUnit.MILLISECONDS);
+            if (data == null) {
+                LOG.trace("No data to dequeue for {} : timeout", peer);
+                throw new SocketTimeoutException();
+            }
+            if (data.length > len) {
+                throw new IllegalStateException(String
+                        .format("data received (%d bytes) is too big for given buffer (%d bytes)", data.length, len));
+            }
+            System.arraycopy(data, 0, buf, off, data.length);
+            LOG.trace("Data ({} bytes) dequeue for {}", data.length, peer);
+            return data.length;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.trace("Received method interrupted", e);
+            return -1;
+        }
+    }
+
+    @Override
+    public void send(byte[] buf, int off, int len) throws IOException {
+        LOG.trace("Send data to {} ({} offset {} length)", peer, off, len);
+        socket.send(new DatagramPacket(buf, off, len, peer));
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/authentication/AbstractTlsAuthentication.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/authentication/AbstractTlsAuthentication.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint.authentication;
+
+import org.bouncycastle.tls.TlsAuthentication;
+import org.bouncycastle.tls.TlsContext;
+import org.bouncycastle.tls.crypto.impl.bc.BcTlsCrypto;
+
+public abstract class AbstractTlsAuthentication implements TlsAuthentication {
+
+    private final BcTlsCrypto crypto;
+    private final TlsContext context;
+
+    protected AbstractTlsAuthentication(BcTlsCrypto crypto, TlsContext context) {
+        this.crypto = crypto;
+        this.context = context;
+    }
+
+    public BcTlsCrypto getCrypto() {
+        return crypto;
+    }
+
+    public TlsContext getContext() {
+        return context;
+    }
+}

--- a/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/authentication/TlsAuthenticationUtil.java
+++ b/leshan-tl-jc-server-coaps/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaps/bc/endpoint/authentication/TlsAuthenticationUtil.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaps.bc.endpoint.authentication;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.util.PrivateKeyFactory;
+import org.bouncycastle.tls.Certificate;
+import org.bouncycastle.tls.CertificateEntry;
+import org.bouncycastle.tls.CertificateType;
+import org.bouncycastle.tls.SignatureAlgorithm;
+import org.bouncycastle.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.tls.TlsServerCertificate;
+import org.bouncycastle.tls.crypto.TlsCertificate;
+import org.bouncycastle.tls.crypto.TlsCrypto;
+
+public class TlsAuthenticationUtil {
+
+    private TlsAuthenticationUtil() {
+    }
+
+    public static Certificate createRawPublicKeyCertificate(TlsCrypto crypto, PublicKey publicKey) throws IOException {
+        TlsCertificate clientPubKeyCert = crypto.createCertificate(CertificateType.RawPublicKey,
+                publicKey.getEncoded());
+        return new Certificate(CertificateType.RawPublicKey, null,
+                new CertificateEntry[] { new CertificateEntry(clientPubKeyCert, null) });
+    }
+
+    public static Certificate createCertChain(TlsCrypto crypto, X509Certificate[] chain) throws IOException {
+        TlsCertificate[] certs = new TlsCertificate[chain.length];
+        for (int i = 0; i < chain.length; i++) {
+            try {
+                certs[i] = crypto.createCertificate(chain[i].getEncoded());
+            } catch (CertificateEncodingException e) {
+                throw new IOException("Unable to convert certificate", e);
+            }
+        }
+        return new Certificate(certs);
+    }
+
+    public static AsymmetricKeyParameter createAsymmetricPrivateKey(PrivateKey privateKey) throws IOException {
+        return PrivateKeyFactory.createKey(privateKey.getEncoded());
+    }
+
+    public static CertPath convertToCertPath(TlsServerCertificate tlsCert) throws CertificateException, IOException {
+        return convertToCertPath(tlsCert.getCertificate());
+    }
+
+    public static CertPath convertToCertPath(Certificate cert) throws CertificateException, IOException {
+        CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+        List<X509Certificate> certs = new ArrayList<>();
+        for (TlsCertificate bcCert : cert.getCertificateList()) {
+            certs.add((X509Certificate) certFactory.generateCertificate(new ByteArrayInputStream(bcCert.getEncoded())));
+        }
+        return certFactory.generateCertPath(certs);
+    }
+
+    public static SignatureAndHashAlgorithm selectSignatureAndHashAlgorithm(TlsCrypto crypto, PublicKey publicKey,
+            @SuppressWarnings({ "rawtypes", "java:S1149" }) //
+            Collection /* <SignatureAndHashAlgorithm> */ signatureAndHashAlgorithms) {
+
+        short signature = getPublicKeySignatureAlgorithm(publicKey);
+        if (signature == -1) {
+            throw new IllegalStateException(
+                    String.format("Client public key use unsupported signature algorithm : %s", publicKey.toString()));
+        }
+
+        for (Object object : signatureAndHashAlgorithms) {
+            SignatureAndHashAlgorithm signatureAndHashAlgorithm = (SignatureAndHashAlgorithm) object;
+            if ( // match key algorithm
+            signatureAndHashAlgorithm.getSignature() == signature
+                    // signature and hash algorithm is supported
+                    && crypto.hasSignatureAndHashAlgorithm(signatureAndHashAlgorithm)) {
+                return signatureAndHashAlgorithm;
+            }
+        }
+        return null;
+    }
+
+    public static short getPublicKeySignatureAlgorithm(PublicKey pubKey) {
+        String algorithm = pubKey.getAlgorithm();
+        if ("RSA".equals(algorithm)) {
+            return SignatureAlgorithm.rsa;
+        } else if ("EC".equals(algorithm)) {
+            return SignatureAlgorithm.ecdsa;
+        } else if ("DSA".equals(algorithm)) {
+            return SignatureAlgorithm.dsa;
+        } else {
+            return -1; // Unknown/unsupported
+        }
+    }
+}

--- a/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/endpoint/LwM2mTransportContextMatcher.java
+++ b/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/endpoint/LwM2mTransportContextMatcher.java
@@ -20,8 +20,8 @@ import java.util.regex.Pattern;
 
 import javax.security.auth.x500.X500Principal;
 
-import org.eclipse.leshan.transport.javacoap.identity.TlsTransportContextKeys;
-import org.eclipse.leshan.transport.javacoap.server.coaptcp.transport.DefaultTransportContextMatcher;
+import org.eclipse.leshan.transport.javacoap.transport.context.DefaultTransportContextMatcher;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransportContextKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpTransportResolver.java
+++ b/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpTransportResolver.java
@@ -19,20 +19,19 @@ import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.function.Function;
 
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.IpTransportContextKeys;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TcpTransportContextKeys;
+
 import com.mbed.coap.transport.TransportContext;
 
 import io.netty.channel.Channel;
 
 public class CoapTcpTransportResolver implements Function<Channel, TransportContext> {
 
-    public static final TransportContext.Key<InetSocketAddress> REMOTE_ADDRESS = new TransportContext.Key<>(null);
-    public static final TransportContext.Key<String> CONNECTION_ID = new TransportContext.Key<>(null);
-    public static final TransportContext.Key<Instant> CONNECTION_START_TIMESTAMP = new TransportContext.Key<>(null);
-
     @Override
     public TransportContext apply(Channel channel) {
-        return TransportContext.of(REMOTE_ADDRESS, (InetSocketAddress) channel.remoteAddress()) //
-                .with(CONNECTION_ID, channel.id().asShortText()) //
-                .with(CONNECTION_START_TIMESTAMP, Instant.now());
+        return TransportContext.of(IpTransportContextKeys.REMOTE_ADDRESS, (InetSocketAddress) channel.remoteAddress()) //
+                .with(TcpTransportContextKeys.CONNECTION_ID, channel.id().asShortText()) //
+                .with(TcpTransportContextKeys.CONNECTION_START_TIMESTAMP, Instant.now());
     }
 }

--- a/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapsTcpTransportResolver.java
+++ b/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapsTcpTransportResolver.java
@@ -21,7 +21,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 
-import org.eclipse.leshan.transport.javacoap.identity.TlsTransportContextKeys;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransportContextKeys;
 
 import com.mbed.coap.packet.Opaque;
 import com.mbed.coap.transport.TransportContext;

--- a/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/NettyCoapTcpTransport.java
+++ b/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/NettyCoapTcpTransport.java
@@ -23,7 +23,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -65,11 +65,11 @@ public class NettyCoapTcpTransport implements CoapTcpTransport {
     private CompletableFuture<CoapPacket> receivePromise = new CompletableFuture<>();
     private final SslContext sslContext;
     private final Function<Channel, TransportContext> contextResolver;
-    private final BiFunction<TransportContext, TransportContext, Boolean> contextMatcher;
+    private final BiPredicate<TransportContext, TransportContext> contextMatcher;
 
     public NettyCoapTcpTransport(InetSocketAddress localadddress, //
             Function<Channel, TransportContext> contextResolver, //
-            BiFunction<TransportContext, TransportContext, Boolean> contextMatcher, //
+            BiPredicate<TransportContext, TransportContext> contextMatcher, //
             SslContext sslContext) {
         this.localAddress = localadddress;
         this.sslContext = sslContext;
@@ -246,7 +246,7 @@ public class NettyCoapTcpTransport implements CoapTcpTransport {
         ChannelPromise channelPromise = channel.newPromise();
         channel.writeAndFlush(packet, channelPromise);
 
-        return toCompletableFuture(channelPromise).thenApply(__ -> true);
+        return toCompletableFuture(channelPromise).thenApply(__v -> true);
     }
 
     public void closeConnections(Predicate<Channel> filter) {

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultTlsIdentityHandler.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultTlsIdentityHandler.java
@@ -22,6 +22,8 @@ import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.leshan.core.peer.IpPeer;
 import org.eclipse.leshan.core.peer.LwM2mPeer;
+import org.eclipse.leshan.core.peer.PskIdentity;
+import org.eclipse.leshan.core.peer.RpkIdentity;
 import org.eclipse.leshan.core.peer.X509Identity;
 import org.eclipse.leshan.core.security.certificate.util.X509CertUtil;
 
@@ -52,6 +54,12 @@ public class DefaultTlsIdentityHandler extends DefaultCoapIdentityHandler {
         if (client.getIdentity() instanceof X509Identity) {
             /* simplify distinguished name to CN= part */
             peerIdentity = new X500Principal("CN=" + ((X509Identity) client.getIdentity()).getX509CommonName());
+            return TransportContext.of(TlsTransportContextKeys.PRINCIPAL, peerIdentity);
+        } else if (client.getIdentity() instanceof PskIdentity) {
+            peerIdentity = new PreSharedKeyPrincipal(((PskIdentity) client.getIdentity()).getPskIdentity());
+            return TransportContext.of(TlsTransportContextKeys.PRINCIPAL, peerIdentity);
+        } else if (client.getIdentity() instanceof RpkIdentity) {
+            peerIdentity = new RawPublicKeyPrincipal(((RpkIdentity) client.getIdentity()).getPublicKey());
             return TransportContext.of(TlsTransportContextKeys.PRINCIPAL, peerIdentity);
         } else {
             throw new IllegalStateException(String.format("Unsupported Identity : %s", client.getIdentity()));

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultTlsIdentityHandler.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultTlsIdentityHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.leshan.core.peer.PskIdentity;
 import org.eclipse.leshan.core.peer.RpkIdentity;
 import org.eclipse.leshan.core.peer.X509Identity;
 import org.eclipse.leshan.core.security.certificate.util.X509CertUtil;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransportContextKeys;
 
 import com.mbed.coap.transport.TransportContext;
 
@@ -39,6 +40,12 @@ public class DefaultTlsIdentityHandler extends DefaultCoapIdentityHandler {
                 // Extract common name
                 String x509CommonName = X509CertUtil.extractCN(principal.getName());
                 return new IpPeer(address, new X509Identity(x509CommonName));
+            }
+            if (principal instanceof PreSharedKeyPrincipal) {
+                return new IpPeer(address, new PskIdentity(((PreSharedKeyPrincipal) principal).getIdentity()));
+            }
+            if (principal instanceof RawPublicKeyPrincipal) {
+                return new IpPeer(address, new RpkIdentity(((RawPublicKeyPrincipal) principal).getPublicKey()));
             }
             throw new IllegalStateException(
                     String.format("Unable to extract sender identity : unexpected type of Principal %s [%s]",

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/PreSharedKeyPrincipal.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/PreSharedKeyPrincipal.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import java.security.Principal;
+import java.util.Objects;
+
+public class PreSharedKeyPrincipal implements Principal {
+
+    private final String identity;
+
+    public PreSharedKeyPrincipal(String identity) {
+        this.identity = identity;
+    }
+
+    public String getIdentity() {
+        return identity;
+    }
+
+    @Override
+    public String getName() {
+        return getIdentity();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(identity);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof PreSharedKeyPrincipal))
+            return false;
+        PreSharedKeyPrincipal other = (PreSharedKeyPrincipal) obj;
+        return Objects.equals(identity, other.identity);
+    }
+}

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/RawPublicKeyPrincipal.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/identity/RawPublicKeyPrincipal.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import java.security.Principal;
+import java.security.PublicKey;
+import java.util.Objects;
+
+public class RawPublicKeyPrincipal implements Principal {
+
+    private final PublicKey pubkey;
+
+    public RawPublicKeyPrincipal(PublicKey pubkey) {
+        this.pubkey = pubkey;
+    }
+
+    public PublicKey getPublicKey() {
+        return pubkey;
+    }
+
+    @Override
+    public String getName() {
+        return getPublicKey().toString();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(pubkey);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof RawPublicKeyPrincipal))
+            return false;
+        RawPublicKeyPrincipal other = (RawPublicKeyPrincipal) obj;
+        return Objects.equals(pubkey, other.pubkey);
+    }
+}

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/DefaultTransportContextMatcher.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/DefaultTransportContextMatcher.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.transport.javacoap.transport.context;
 
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 
 import org.eclipse.leshan.transport.javacoap.transport.context.keys.IpTransportContextKeys;
 import org.eclipse.leshan.transport.javacoap.transport.context.keys.TcpTransportContextKeys;
@@ -24,7 +24,7 @@ import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransport
 import com.mbed.coap.transport.TransportContext;
 import com.mbed.coap.transport.TransportContext.Key;
 
-public class DefaultTransportContextMatcher implements BiFunction<TransportContext, TransportContext, Boolean> {
+public class DefaultTransportContextMatcher implements BiPredicate<TransportContext, TransportContext> {
 
     private final Key<?>[] knownKeys;
 
@@ -42,7 +42,7 @@ public class DefaultTransportContextMatcher implements BiFunction<TransportConte
     }
 
     @Override
-    public Boolean apply(TransportContext packetTransport, TransportContext channelTransport) {
+    public boolean test(TransportContext packetTransport, TransportContext channelTransport) {
         // TODO we should be able to iterate on all keys ...
         // As we can not workaround is to test all known key
         for (Key<?> key : knownKeys) {
@@ -58,6 +58,7 @@ public class DefaultTransportContextMatcher implements BiFunction<TransportConte
         return true;
     }
 
+    @SuppressWarnings("java:S1172")
     protected boolean matches(Key<?> key, Object packetValue, Object channelValue) {
         return packetValue.equals(channelValue);
     }

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/DefaultTransportContextMatcher.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/DefaultTransportContextMatcher.java
@@ -13,11 +13,13 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
-package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+package org.eclipse.leshan.transport.javacoap.transport.context;
 
 import java.util.function.BiFunction;
 
-import org.eclipse.leshan.transport.javacoap.identity.TlsTransportContextKeys;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.IpTransportContextKeys;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TcpTransportContextKeys;
+import org.eclipse.leshan.transport.javacoap.transport.context.keys.TlsTransportContextKeys;
 
 import com.mbed.coap.transport.TransportContext;
 import com.mbed.coap.transport.TransportContext.Key;
@@ -27,9 +29,9 @@ public class DefaultTransportContextMatcher implements BiFunction<TransportConte
     private final Key<?>[] knownKeys;
 
     public DefaultTransportContextMatcher() {
-        this(CoapTcpTransportResolver.REMOTE_ADDRESS, //
-                CoapTcpTransportResolver.CONNECTION_ID, //
-                CoapTcpTransportResolver.CONNECTION_START_TIMESTAMP, //
+        this(IpTransportContextKeys.REMOTE_ADDRESS, //
+                TcpTransportContextKeys.CONNECTION_ID, //
+                TcpTransportContextKeys.CONNECTION_START_TIMESTAMP, //
                 TlsTransportContextKeys.TLS_SESSION_ID, //
                 TlsTransportContextKeys.PRINCIPAL, //
                 TlsTransportContextKeys.CIPHER_SUITE);

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/IpTransportContextKeys.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/IpTransportContextKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Sierra Wireless and others.
+ * Copyright (c) 2025 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -13,14 +13,14 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
-package org.eclipse.leshan.transport.javacoap.identity;
+package org.eclipse.leshan.transport.javacoap.transport.context.keys;
 
-import java.security.Principal;
+import java.net.InetSocketAddress;
 
 import com.mbed.coap.transport.TransportContext;
 
-public class TlsTransportContextKeys {
-    public static final TransportContext.Key<String> TLS_SESSION_ID = new TransportContext.Key<>(null);
-    public static final TransportContext.Key<String> CIPHER_SUITE = new TransportContext.Key<>(null);
-    public static final TransportContext.Key<Principal> PRINCIPAL = new TransportContext.Key<>(null);
+public class IpTransportContextKeys {
+
+    public static final TransportContext.Key<InetSocketAddress> REMOTE_ADDRESS = new TransportContext.Key<>(null);
+
 }

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/IpTransportContextKeys.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/IpTransportContextKeys.java
@@ -21,6 +21,9 @@ import com.mbed.coap.transport.TransportContext;
 
 public class IpTransportContextKeys {
 
+    private IpTransportContextKeys() {
+    }
+
     public static final TransportContext.Key<InetSocketAddress> REMOTE_ADDRESS = new TransportContext.Key<>(null);
 
 }

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TcpTransportContextKeys.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TcpTransportContextKeys.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.transport.context.keys;
+
+import java.time.Instant;
+
+import com.mbed.coap.transport.TransportContext;
+
+public class TcpTransportContextKeys {
+
+    public static final TransportContext.Key<String> CONNECTION_ID = new TransportContext.Key<>(null);
+    public static final TransportContext.Key<Instant> CONNECTION_START_TIMESTAMP = new TransportContext.Key<>(null);
+
+}

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TcpTransportContextKeys.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TcpTransportContextKeys.java
@@ -21,6 +21,9 @@ import com.mbed.coap.transport.TransportContext;
 
 public class TcpTransportContextKeys {
 
+    private TcpTransportContextKeys() {
+    }
+
     public static final TransportContext.Key<String> CONNECTION_ID = new TransportContext.Key<>(null);
     public static final TransportContext.Key<Instant> CONNECTION_START_TIMESTAMP = new TransportContext.Key<>(null);
 

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TlsTransportContextKeys.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TlsTransportContextKeys.java
@@ -20,6 +20,10 @@ import java.security.Principal;
 import com.mbed.coap.transport.TransportContext;
 
 public class TlsTransportContextKeys {
+
+    private TlsTransportContextKeys() {
+    }
+
     public static final TransportContext.Key<String> TLS_SESSION_ID = new TransportContext.Key<>(null);
     public static final TransportContext.Key<String> CIPHER_SUITE = new TransportContext.Key<>(null);
     public static final TransportContext.Key<Integer> CIPHER_SUITE_ID = new TransportContext.Key<>(null);

--- a/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TlsTransportContextKeys.java
+++ b/leshan-tl-jc-shared/src/main/java/org/eclipse/leshan/transport/javacoap/transport/context/keys/TlsTransportContextKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Sierra Wireless and others.
+ * Copyright (c) 2024 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -13,21 +13,15 @@
  * Contributors:
  *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
-package org.eclipse.leshan.transport.javacoap.identity;
+package org.eclipse.leshan.transport.javacoap.transport.context.keys;
 
-public class IdentityHandlerProvider {
+import java.security.Principal;
 
-//    private final HashMap<Endpoint, IdentityHandler> identityHandlers = new HashMap<>();
-//
-//    public void addIdentityHandler(Endpoint endpoint, IdentityHandler identityHandler) {
-//        identityHandlers.put(endpoint, identityHandler);
-//    }
-//
-//    public void clear() {
-//        identityHandlers.clear();
-//    }
-//
-//    public IdentityHandler getIdentityHandler(Endpoint endpoint) {
-//        return identityHandlers.get(endpoint);
-//    }
+import com.mbed.coap.transport.TransportContext;
+
+public class TlsTransportContextKeys {
+    public static final TransportContext.Key<String> TLS_SESSION_ID = new TransportContext.Key<>(null);
+    public static final TransportContext.Key<String> CIPHER_SUITE = new TransportContext.Key<>(null);
+    public static final TransportContext.Key<Integer> CIPHER_SUITE_ID = new TransportContext.Key<>(null);
+    public static final TransportContext.Key<Principal> PRINCIPAL = new TransportContext.Key<>(null);
 }

--- a/leshan-tl-jc-shared/src/test/java/org/eclipse/leshan/transport/javacoap/identity/PrincipalTest.java
+++ b/leshan-tl-jc-shared/src/test/java/org/eclipse/leshan/transport/javacoap/identity/PrincipalTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class PrincipalTest {
+
+    @Test
+    void assertEqualsHashcodeForPreSharedKeyPrincipal() {
+        EqualsVerifier.forClass(PreSharedKeyPrincipal.class).verify();
+    }
+
+    @Test
+    void assertEqualsHashcodeForRawPublicKeyPrincipal() {
+        EqualsVerifier.forClass(RawPublicKeyPrincipal.class).verify();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@ Contributors:
     <!-- transport layer based on java-coap -->
     <module>leshan-tl-jc-shared</module>
     <module>leshan-tl-jc-server-coap</module>
+    <module>leshan-tl-jc-server-coaps</module>
     <module>leshan-tl-jc-client-coap</module>
     <module>leshan-tl-jc-client-coaps</module>
     <module>leshan-tl-jc-server-coaptcp</module>
@@ -236,6 +237,11 @@ Contributors:
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>leshan-tl-jc-server-coap</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>leshan-tl-jc-server-coaps</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@ Contributors:
     <module>leshan-tl-jc-shared</module>
     <module>leshan-tl-jc-server-coap</module>
     <module>leshan-tl-jc-client-coap</module>
+    <module>leshan-tl-jc-client-coaps</module>
     <module>leshan-tl-jc-server-coaptcp</module>
     <module>leshan-tl-jc-client-coaptcp</module>
 
@@ -244,6 +245,11 @@ Contributors:
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>leshan-tl-jc-client-coaps</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>leshan-tl-jc-server-coaptcp</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -324,6 +330,11 @@ Contributors:
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
         <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bctls-debug-jdk18on</artifactId>
+        <version>1.81</version>
       </dependency>
 
       <!-- Demos, examples and tests dependencies -->


### PR DESCRIPTION
This PR aims to add support of CoAP over DTLS based on java-coap and Bouncy Castle at server side.

Here some limitations from bouncy castle : 
1. [There is no async API](https://github.com/bcgit/bc-java/discussions/2075#discussioncomment-13411380) which is a bigger issue at server side than client one.
2. Client API seem to not support [DTLS Role Exchange](https://github.com/sbernard31/dtls-server?tab=readme-ov-file#dtls-role-exchange). (but it should be implemented using client and server api)
3. API is very low level some and doesn't reuse JSSE class (like PublicKey, PrivateKey, Certificate ...) from openJDK
4. API is only about handle 1 DTLS connection between 2 peers. If you want to handle several on same socket you need to demux packet, handle and store connection on yourself. So lot of work to do ...  In this PR there is a very basic implementation of that.
5. Server [does not  support RPK and X509 at the same time.](https://github.com/bcgit/bc-java/blob/0e100a58af34d0cf91ea5cfd1f0a6d36681c3653/tls/src/main/java/org/bouncycastle/tls/AbstractTlsServer.java#L605-L606)
6. still not clear to me if connectionID is supported
 
Some missing task : 
 - :heavy_check_mark:   ~~clean sonard issues~~
 - :heavy_check_mark:  ~~add an endpoint using that in server-demo~~
