### PR TITLE
Improve Certificate DNS matching

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
@@ -296,11 +296,11 @@ public class LeshanTestClient extends LeshanClient {
             InetSocketAddress endpointAddr = uriHandler.getSocketAddr(endpointURI);
             if (proxy != null && endpointAddr.equals(proxy.getServerAddress())) {
                 EndpointUri proxyUri = uriHandler.replaceAddress(endpointURI, proxy.getClientSideProxyAddress());
-                if (proxyUri.toString().equals(expectedUri)) {
+                if (uriHandler.isUriTargetSameSocket(proxyUri, uriHandler.getParser().parse(expectedUri))) {
                     return true;
                 }
             } else {
-                if (endpointURI.toString().equals(expectedUri)) {
+                if (uriHandler.isUriTargetSameSocket(endpointURI, uriHandler.getParser().parse(expectedUri))) {
                     return true;
                 }
             }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/DefaultEndPointUriHandler.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/DefaultEndPointUriHandler.java
@@ -91,10 +91,16 @@ public class DefaultEndPointUriHandler implements EndPointUriHandler {
     protected static String toUriHostName(InetSocketAddress socketAddr) {
         Validate.notNull(socketAddr);
 
+        String host = socketAddr.getHostString();
+
+        // special case for Ipv6 socket address
         InetAddress addr = socketAddr.getAddress();
-        String host = addr.getHostAddress();
-        if (addr instanceof Inet6Address) {
+        if (addr instanceof Inet6Address
+                // check if getHostString return IP literal and not domain name.
+                && host.equals(addr.getHostAddress())) {
             Inet6Address address6 = (Inet6Address) addr;
+
+            // If this is IP literal about Ipv6 then format it correctly for URI format.
             if (address6.getScopedInterface() != null || address6.getScopeId() > 0) {
                 int pos = host.indexOf('%');
                 if (pos > 0 && pos + 1 < host.length()) {
@@ -107,5 +113,20 @@ public class DefaultEndPointUriHandler implements EndPointUriHandler {
             host = '[' + host + ']';
         }
         return host;
+    }
+
+    @Override
+    public boolean isUriTargetSameSocket(EndpointUri uri1, EndpointUri uri2) {
+        if (!(uri1.getScheme().equals(uri2.getScheme())) || !(uri1.getPort().equals(uri2.getPort()))) {
+            // scheme OR port mismatch
+            return false;
+        }
+        InetSocketAddress socketAddr1 = getSocketAddr(uri1);
+        InetSocketAddress socketAddr2 = getSocketAddr(uri2);
+        if (socketAddr1 == null || socketAddr2 == null) {
+            // at least one uri seems to not target a real socket address.
+            return false;
+        }
+        return socketAddr1.equals(socketAddr2);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/EndPointUriHandler.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/EndPointUriHandler.java
@@ -35,5 +35,12 @@ public interface EndPointUriHandler {
 
     InetSocketAddress getSocketAddr(EndpointUri uri);
 
+    /**
+     * Compare 2 URI by addresses.
+     * <p>
+     * This can be needed when one URI could be based on domain name and the other based on IP.
+     */
+    boolean isUriTargetSameSocket(EndpointUri uri1, EndpointUri uri2);
+
     void validateURI(EndpointUri uri) throws InvalidEndpointUriException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
@@ -395,14 +395,15 @@ public class X509CertUtil {
      *
      * @param matcher Matcher pattern
      * @param target Target DNS name to check
+     * @param noWildcard set to true to skip wildcard matching
      * @return true if matches, false otherwise
      */
-    public static boolean dnsNameMatch(String matcher, String target) {
+    public static boolean dnsNameMatch(String matcher, String target, boolean noWildcard) {
         // DNS matching is case-insensitive : https://www.rfc-editor.org/info/rfc6125/#section-6.4.1
         matcher = matcher.toLowerCase(Locale.ROOT);
         target = target.toLowerCase(Locale.ROOT);
 
-        if (matcher.startsWith("*.")) {
+        if (!noWildcard && matcher.startsWith("*.")) {
             // See wildcard matching constraint :
             // https://www.rfc-editor.org/info/rfc6125/#section-6.4.3
             // https://www.rfc-editor.org/info/rfc6125/#section-7.2
@@ -443,7 +444,7 @@ public class X509CertUtil {
                     int generalName = (Integer) san.get(0);
                     if (generalName == GeneralName.DNS_NAME.value) {
                         String value = (String) san.get(1);
-                        if (dnsNameMatch(value, dnsName)) {
+                        if (dnsNameMatch(value, dnsName, false /* wildcard allowed */)) {
                             return true;
                         }
                     }
@@ -457,7 +458,8 @@ public class X509CertUtil {
             // If subject alternative names are not present fallback to old ways at looking in Subject DN
             String cn = getPrincipalField(certificate.getSubjectX500Principal(), "CN");
 
-            if (dnsNameMatch(cn, dnsName)) {
+            if (dnsNameMatch(cn, dnsName, true/* no wildcard matching */)) {
+                // no wildcard matching, see : https://www.rfc-editor.org/info/rfc7252/#section-9.1.3.3
                 return true;
             }
         } catch (CertificateParsingException e) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
@@ -403,13 +403,25 @@ public class X509CertUtil {
         target = target.toLowerCase(Locale.ROOT);
 
         if (matcher.startsWith("*.")) {
+            // See wildcard matching constraint :
+            // https://www.rfc-editor.org/info/rfc6125/#section-6.4.3
+            // https://www.rfc-editor.org/info/rfc6125/#section-7.2
+            // https://errata.rfc-editor.org/search/?rfc_number=6125&presentation=records
+
+            // Wildcard pattern must have at least 3 labels (*.foo.tld)
+            // to prevent over-broad wildcards like *.com
+            if (matcher.indexOf('.', 2) == -1)
+                return false;
+
             // Simple filtering out
             if (!target.endsWith(matcher.substring(1)))
                 return false;
 
-            // Wildcards only work in one sub level so no extra dots
+            // Wildcards only work in one sub level so no extra dots,
+            // and the leftmost label must be non-empty (RFC 6125: wildcard
+            // must match at least one character)
             String host = target.substring(0, target.length() - (matcher.length() - 1));
-            return host.indexOf('.') == -1;
+            return !host.isEmpty() && host.indexOf('.') == -1;
         }
         return matcher.equals(target);
     }
@@ -424,7 +436,6 @@ public class X509CertUtil {
     public static boolean matchSubjectDnsName(X509Certificate certificate, String dnsName) {
         try {
             // First one need to check SANs if they are present
-
             Collection<List<?>> sans = certificate.getSubjectAlternativeNames();
 
             if (sans != null) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class X509CertUtil {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CertPathUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(X509CertUtil.class);
 
     /**
      * OID for server authentication in extended key.
@@ -303,7 +303,7 @@ public class X509CertUtil {
      * @return Map with field keys and their values
      */
     public static Map<String, String> parseRfc2253Name(String name) {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
 
         // Parse RFC 2253 string
         boolean inValue = false;
@@ -372,7 +372,7 @@ public class X509CertUtil {
             // list in RFC is only example OIDs list (see JDK class AVAKeyword). These extra OID's are
             // actually defined in Sun packages but we should not access them as they are not standard
             // Java classes.
-            HashMap<String, String> extraOids = new HashMap<String, String>();
+            HashMap<String, String> extraOids = new HashMap<>();
             extraOids.put("2.5.4.5", "SERIALNUMBER");
 
             String dn = x500Principal.getName(X500Principal.RFC2253, extraOids);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/util/X509CertUtil.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -396,7 +397,11 @@ public class X509CertUtil {
      * @param target Target DNS name to check
      * @return true if matches, false otherwise
      */
-    private static boolean dnsNameMatch(String matcher, String target) {
+    public static boolean dnsNameMatch(String matcher, String target) {
+        // DNS matching is case-insensitive : https://www.rfc-editor.org/info/rfc6125/#section-6.4.1
+        matcher = matcher.toLowerCase(Locale.ROOT);
+        target = target.toLowerCase(Locale.ROOT);
+
         if (matcher.startsWith("*.")) {
             // Simple filtering out
             if (!target.endsWith(matcher.substring(1)))

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/verifier/BaseCertificateVerifier.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/security/certificate/verifier/BaseCertificateVerifier.java
@@ -56,15 +56,26 @@ public abstract class BaseCertificateVerifier implements X509CertificateVerifier
 
     protected void validateSubject(InetSocketAddress peerSocket, X509Certificate receivedServerCertificate)
             throws CertificateException {
+        if (!isSocketTargetHostname(peerSocket)) {
+            // https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/HTML-Version/OMA-TS-LightweightM2M_Transport-V1_1_1-20190617-A.html#5-2-8-4-0-5284-Deployments-without-DNS
+            throw new CertificateException("When trying to connect with an IP address SNI MUST be used");
+        }
 
-        if (X509CertUtil.matchSubjectDnsName(receivedServerCertificate, peerSocket.getHostName()))
-            return;
-
-        if (X509CertUtil.matchSubjectInetAddress(receivedServerCertificate, peerSocket.getAddress()))
+        if (X509CertUtil.matchSubjectDnsName(receivedServerCertificate, peerSocket.getHostString()))
             return;
 
         throw new CertificateException(
                 "Certificate chain could not be validated - server identity does not match certificate");
+    }
+
+    private static boolean isSocketTargetHostname(InetSocketAddress target) {
+        if (target.isUnresolved()) {
+            // If we need to support unresolved InetSocketAddress, then you need to create a kind of parser maybe from
+            // DefaultEndPointUriParser ?
+            throw new IllegalStateException("InetSocketAddress should be resolved...");
+        }
+        // Tricks : if hoststring equals hostaddress than hoststring return an IP litteral not a host name.
+        return !target.getHostString().equals(target.getAddress().getHostAddress());
     }
 
     protected void validateCertificateCanBeUsedForAuthentication(X509Certificate certificate,

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
@@ -36,7 +36,7 @@ import javax.security.auth.x500.X500Principal;
 import org.eclipse.leshan.core.security.certificate.util.X509CertUtil;
 import org.junit.jupiter.api.Test;
 
-public class X509CertUtilTest {
+class X509CertUtilTest {
 
     private final KeyStore keyStore;
 
@@ -75,13 +75,13 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void principal_simple_cn() {
+    void principal_simple_cn() {
         X500Principal simple = new X500Principal("CN=simple");
         assertEquals("simple", X509CertUtil.getPrincipalField(simple, "CN"));
     }
 
     @Test
-    public void principal_devurn_cn() {
+    void principal_devurn_cn() {
         X500Principal dn = new X500Principal("CN=urn:dev:ops:32473-Refrigerator-5002,O=Organization,C=US");
         assertEquals("urn:dev:ops:32473-Refrigerator-5002", X509CertUtil.getPrincipalField(dn, "CN"));
         assertEquals("Organization", X509CertUtil.getPrincipalField(dn, "O"));
@@ -89,7 +89,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void principal_ieee802_1ar() {
+    void principal_ieee802_1ar() {
         X500Principal dn = new X500Principal("SERIALNUMBER=P123456,CN=MyDevice,O=Company,C=US");
         assertEquals("P123456", X509CertUtil.getPrincipalField(dn, "SERIALNUMBER"));
         assertEquals("MyDevice", X509CertUtil.getPrincipalField(dn, "CN"));
@@ -98,7 +98,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void principal_rfc2253_examples() {
+    void principal_rfc2253_examples() {
         X500Principal example1 = new X500Principal("CN=Steve Kille,O=Isode Limited,C=GB");
         assertEquals("Steve Kille", X509CertUtil.getPrincipalField(example1, "CN"));
         assertEquals("Isode Limited", X509CertUtil.getPrincipalField(example1, "O"));
@@ -134,7 +134,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void x509_simple_dns_name_test() throws KeyStoreException {
+    void x509_simple_dns_name_test() throws KeyStoreException {
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate("server");
 
         assertTrue(X509CertUtil.matchSubjectDnsName(certificate, "server.mydomain.com"));
@@ -143,7 +143,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void x509_san_dns_name_test() throws KeyStoreException {
+    void x509_san_dns_name_test() throws KeyStoreException {
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate("server_with_san");
 
         assertTrue(X509CertUtil.matchSubjectDnsName(certificate, "server.mydomain.com"));
@@ -152,7 +152,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void x509_san_ipv4_test() throws KeyStoreException, UnknownHostException {
+    void x509_san_ipv4_test() throws KeyStoreException, UnknownHostException {
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate("server_with_san");
 
         assertTrue(X509CertUtil.matchSubjectInetAddress(certificate, InetAddress.getByName("192.168.1.42")));
@@ -164,7 +164,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void x509_san_ipv6_test() throws KeyStoreException, UnknownHostException {
+    void x509_san_ipv6_test() throws KeyStoreException, UnknownHostException {
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate("server_with_ipv6");
 
         assertFalse(X509CertUtil.matchSubjectInetAddress(certificate, InetAddress.getByName("192.168.1.42")));
@@ -176,7 +176,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void x509_san_combo_test() throws KeyStoreException, UnknownHostException {
+    void x509_san_combo_test() throws KeyStoreException, UnknownHostException {
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate("localhost");
 
         assertFalse(X509CertUtil.matchSubjectDnsName(certificate, "server.mydomain.com"));
@@ -192,7 +192,7 @@ public class X509CertUtilTest {
     }
 
     @Test
-    public void x509_san_wildcard_test() throws KeyStoreException, UnknownHostException {
+    void x509_san_wildcard_test() {
         X509Certificate certificate = loadX509PemCertificate("./certificates/eclipse.org.pem");
 
         assertTrue(X509CertUtil.matchSubjectDnsName(certificate, "eclipse.org"));

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
@@ -201,4 +201,25 @@ class X509CertUtilTest {
         assertFalse(X509CertUtil.matchSubjectDnsName(certificate, "server.subdomain.eclipse.org"));
         assertFalse(X509CertUtil.matchSubjectDnsName(certificate, "sub.server.eclipse.org"));
     }
+
+    @Test
+    void dns_wildcard_matching_test() {
+        // match
+        assertTrue(X509CertUtil.dnsNameMatch("*.eclipse.org", "server.eclipse.org"));
+
+        // doesn't match
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "server.subdomain.eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "sub.server.eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", ".eclipse.org"));
+
+        // invalid matcher
+        assertFalse(X509CertUtil.dnsNameMatch("*", "eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*.", "eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("s*r.eclipse.org", "server.eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*ver.eclipse.org", "server.eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("server.*.org", "server.eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*.org", "eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*.*.eclipse.org", "sub.server.eclipse.org"));
+    }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
@@ -147,6 +147,7 @@ class X509CertUtilTest {
         X509Certificate certificate = (X509Certificate) keyStore.getCertificate("server_with_san");
 
         assertTrue(X509CertUtil.matchSubjectDnsName(certificate, "server.mydomain.com"));
+        assertTrue(X509CertUtil.matchSubjectDnsName(certificate, "SERVER.MyDomain.com"));
         assertFalse(X509CertUtil.matchSubjectDnsName(certificate, "another.domain.com"));
         assertFalse(X509CertUtil.matchSubjectDnsName(certificate, "localhost"));
     }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/security/util/X509CertUtilTest.java
@@ -205,21 +205,22 @@ class X509CertUtilTest {
     @Test
     void dns_wildcard_matching_test() {
         // match
-        assertTrue(X509CertUtil.dnsNameMatch("*.eclipse.org", "server.eclipse.org"));
+        assertTrue(X509CertUtil.dnsNameMatch("*.eclipse.org", "server.eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "server.eclipse.org", true));
 
         // doesn't match
-        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "server.subdomain.eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "sub.server.eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", ".eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "server.subdomain.eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", "sub.server.eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*.eclipse.org", ".eclipse.org", false));
 
         // invalid matcher
-        assertFalse(X509CertUtil.dnsNameMatch("*", "eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("*.", "eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("s*r.eclipse.org", "server.eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("*ver.eclipse.org", "server.eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("server.*.org", "server.eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("*.org", "eclipse.org"));
-        assertFalse(X509CertUtil.dnsNameMatch("*.*.eclipse.org", "sub.server.eclipse.org"));
+        assertFalse(X509CertUtil.dnsNameMatch("*", "eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*.", "eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("s*r.eclipse.org", "server.eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*ver.eclipse.org", "server.eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("server.*.org", "server.eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*.org", "eclipse.org", false));
+        assertFalse(X509CertUtil.dnsNameMatch("*.*.eclipse.org", "sub.server.eclipse.org", false));
     }
 }


### PR DESCRIPTION
Some improvement/fix/hardening in our certificate DNS matching.

- certificate DNS matching should be case insensitive
- certificate DNS matching should be case insensitive
- DNS matching fallback based on CN should not check wildcard
- Deployments without DNS should be based on SNI only.